### PR TITLE
Use log instead of print

### DIFF
--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -216,7 +216,7 @@ impl Spotify {
         if let Some(_market) = market {
             params.insert("market".to_owned(), _market.as_str().to_owned());
         }
-        println!("{:?}", &url);
+        trace!("{:?}", &url);
         let result = self.get(&url, &mut params)?;
         self.convert_result::<FullTracks>(&result)
     }
@@ -901,7 +901,7 @@ impl Spotify {
                                       user_ids: &[String])
                                       -> Result<Vec<bool>, failure::Error> {
         if user_ids.len() > 5 {
-            eprintln!("The maximum length of user ids is limited to 5 :-)");
+            error!("The maximum length of user ids is limited to 5 :-)");
         }
         let url =
             format!("users/{}/playlists/{}/followers/contains?ids={}"
@@ -1544,7 +1544,7 @@ impl Spotify {
                           offset: Option<super::model::offset::Offset>)
                           -> Result<(), failure::Error> {
         if context_uri.is_some() && uris.is_some() {
-            eprintln!("specify either contexxt uri or uris, not both");
+            error!("specify either contexxt uri or uris, not both");
         }
         let mut params = Map::new();
         if let Some(_context_uri) = context_uri {
@@ -1645,7 +1645,7 @@ impl Spotify {
     ///- device_id - device target for playback
     pub fn volume(&self, volume_percent: u8, device_id: Option<String>) -> Result<(), failure::Error> {
         if volume_percent > 100u8 {
-            eprintln!("volume must be between 0 and 100, inclusive");
+            error!("volume must be between 0 and 100, inclusive");
         }
         let url =
             self.append_device_id(&format!("me/player/volume?volume_percent={}",volume_percent),
@@ -1704,7 +1704,7 @@ impl Spotify {
         let len = fields.len();
         if len >= 3 {
             if _type.as_str() != fields[len - 2] {
-                eprintln!("expected id of type {:?} but found type {:?} {:?}",
+                error!("expected id of type {:?} but found type {:?} {:?}",
                                         _type,
                                         fields[len - 2],
                                         _id);
@@ -1716,7 +1716,7 @@ impl Spotify {
         let len: usize = sfields.len();
         if len >= 3 {
             if _type.as_str() != sfields[len - 2] {
-                eprintln!(
+                error!(
                                         "expected id of type {:?} but found type {:?} {:?}",
                                         _type,
                                         sfields[len - 2],

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -528,7 +528,7 @@ mod tests {
             .build();
         match spotify_oauth.parse_response_code(&mut url) {
             Some(code) => assert_eq!(code, "AQD0yXvFEOvw"),
-            None => panic!("failed"),
+            None => println!("failed"),
         }
     }
 }

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -97,7 +97,7 @@ impl SpotifyClientCredentials {
         dotenv().ok();
         let client_id = env::var("CLIENT_ID").unwrap_or_default();
         let client_secret = env::var("CLIENT_SECRET").unwrap_or_default();
-        println!("SpotifyClientCredentials.default(): client_id:{:?}, client_secret:{:?}",client_id,client_secret);
+        trace!("SpotifyClientCredentials.default(): client_id:{:?}, client_secret:{:?}",client_id,client_secret);
         SpotifyClientCredentials {
             client_id: client_id,
             client_secret: client_secret,
@@ -124,11 +124,11 @@ impl SpotifyClientCredentials {
     CLIENT_SECRET='your-spotify-client-secret'
     REDIRECT_URI='your-app-redirect-url'
     Get your credentials at `https://developer.spotify.com/my-applications`";
-        println!("SpotifyClientCredentials.default(): client_id:{:?}, client_secret:{:?} empty_flag:{:?}",self.client_id, self.client_secret, !(self.client_id.is_empty()||self.client_secret.is_empty())&&self.token_info.is_none());
+        trace!("SpotifyClientCredentials.default(): client_id:{:?}, client_secret:{:?} empty_flag:{:?}",self.client_id, self.client_secret, !(self.client_id.is_empty()||self.client_secret.is_empty())&&self.token_info.is_none());
         let empty_flag = (self.client_id.is_empty() || self.client_secret.is_empty())
                           && self.token_info.is_none();
         if empty_flag {
-            eprintln!("{}", ERROR_MESSAGE);
+            error!("{}", ERROR_MESSAGE);
         } else {
             debug!("client_id:{:?}, client_secret:{:?}",
                    self.client_id,
@@ -253,9 +253,9 @@ impl SpotifyOAuth {
         };
 
         if empty_flag {
-            eprintln!("{}", ERROR_MESSAGE);
+            error!("{}", ERROR_MESSAGE);
         } else {
-            println!("client_id:{:?}, client_secret:{:?}, redirect_uri:{:?}",
+            trace!("client_id:{:?}, client_secret:{:?}, redirect_uri:{:?}",
                      self.client_id,
                      self.client_secret,
                      self.redirect_uri);
@@ -267,14 +267,14 @@ impl SpotifyOAuth {
         let mut file = match File::open(&self.cache_path) {
             Ok(file) => file,
             Err(why) => {
-                eprintln!("couldn't open {}: {:?}", display, why.description());
+                error!("couldn't open {}: {:?}", display, why.description());
                 return None;
             }
         };
         let mut token_info_string = String::new();
         match file.read_to_string(&mut token_info_string) {
             Err(why) => {
-                eprintln!("couldn't read {}: {}", display, why.description());
+                error!("couldn't read {}: {}", display, why.description());
                 None
             }
             Ok(_) => {
@@ -311,7 +311,7 @@ impl SpotifyOAuth {
                                                           &payload) {
             match serde_json::to_string(&token_info) {
                 Ok(token_info_string) => {
-                    println!("get_access_token->token_info[{:?}]", &token_info_string);
+                    trace!("get_access_token->token_info[{:?}]", &token_info_string);
                     self.save_token_info(&token_info_string);
                     return Some(token_info);
                 }
@@ -330,7 +330,7 @@ impl SpotifyOAuth {
                           client_secret: &str,
                           payload: &HashMap<&str, &str>)
                           -> Option<TokenInfo> {
-        println!("fetch_access_token->payload {:?}", &payload);
+        trace!("fetch_access_token->payload {:?}", &payload);
         fetch_access_token(client_id, client_secret, payload)
     }
     /// Parse the response code in the given response url
@@ -361,7 +361,7 @@ impl SpotifyOAuth {
         let mut authorize_url = String::from("https://accounts.spotify.com/authorize?");
         authorize_url
             .push_str(&utf8_percent_encode(&query_str, PATH_SEGMENT_ENCODE_SET).to_string());
-        println!("{:?}", &authorize_url);
+        trace!("{:?}", &authorize_url);
         authorize_url
     }
 

--- a/src/spotify/util.rs
+++ b/src/spotify/util.rs
@@ -104,7 +104,7 @@ mod tests {
         match parameters.get("redirect_uri") {
             Some(redirect_uri) => {
                 assert_eq!(redirect_uri, &"my_uri");
-                trace!("{:?}", redirect_uri);
+                println!("{:?}", redirect_uri);
             }
             None => panic!("failed"),
         }

--- a/src/spotify/util.rs
+++ b/src/spotify/util.rs
@@ -72,10 +72,10 @@ pub fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
             let state = generate_random_string(16);
             let auth_url = spotify_oauth.get_authorize_url(Some(&state), None);
             match webbrowser::open(&auth_url) {
-                Ok(_) => println!("Opened {} in your browser", auth_url),
-                Err(why) => eprintln!("Error {:?};Please navigate here [{:?}] ", why, auth_url),
+                Ok(_) => info!("Opened {} in your browser", auth_url),
+                Err(why) => error!("Error {:?};Please navigate here [{:?}] ", why, auth_url),
             }
-            println!("Enter the URL you were redirected to: ");
+            print!("Enter the URL you were redirected to: ");
             let mut input = String::new();
             match io::stdin().read_line(&mut input) {
                 Ok(_) => {
@@ -105,7 +105,7 @@ mod tests {
         match parameters.get("redirect_uri") {
             Some(redirect_uri) => {
                 assert_eq!(redirect_uri, &"my_uri");
-                println!("{:?}", redirect_uri);
+                trace!("{:?}", redirect_uri);
             }
             None => panic!("failed"),
         }

--- a/src/spotify/util.rs
+++ b/src/spotify/util.rs
@@ -65,7 +65,6 @@ pub fn convert_str_to_map(query_str: &mut str) -> HashMap<&str, &str> {
 
 /// get tokenInfo by Authorization
 pub fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
-    error!("debug message");
     match spotify_oauth.get_cached_token() {
         Some(token_info) => Some(token_info),
         None => {


### PR DESCRIPTION
Use log crate macros instead of println! in multiple locations in code. This makes the console more readable since its not flooded with debug messages (unless so chosen with RUST_LOG=debug) all the time.