### PR TITLE
get_token processing can be done in two parts

### DIFF
--- a/src/spotify/util.rs
+++ b/src/spotify/util.rs
@@ -63,27 +63,33 @@ pub fn convert_str_to_map(query_str: &mut str) -> HashMap<&str, &str> {
     map
 }
 
+pub fn request_token(spotify_oauth: &mut SpotifyOAuth) {
+    let state = generate_random_string(16);
+    let auth_url = spotify_oauth.get_authorize_url(Some(&state), None);
+    match webbrowser::open(&auth_url) {
+        Ok(_) => println!("Opened {} in your browser", auth_url),
+        Err(why) => eprintln!("Error {:?};Please navigate here [{:?}] ", why, auth_url),
+    }
+}
+
+pub fn process_token(spotify_oauth: &mut SpotifyOAuth, input: &mut String) -> Option<TokenInfo> {
+    match spotify_oauth.parse_response_code(input) {
+        Some(code) => spotify_oauth.get_access_token(&code),
+        None => None,
+    }
+}
+
 /// get tokenInfo by Authorization
 pub fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
     error!("debug message");
     match spotify_oauth.get_cached_token() {
         Some(token_info) => Some(token_info),
         None => {
-            let state = generate_random_string(16);
-            let auth_url = spotify_oauth.get_authorize_url(Some(&state), None);
-            match webbrowser::open(&auth_url) {
-                Ok(_) => println!("Opened {} in your browser", auth_url),
-                Err(why) => eprintln!("Error {:?};Please navigate here [{:?}] ", why, auth_url),
-            }
+            request_token(spotify_oauth);
             println!("Enter the URL you were redirected to: ");
             let mut input = String::new();
             match io::stdin().read_line(&mut input) {
-                Ok(_) => {
-                    match spotify_oauth.parse_response_code(&mut input) {
-                        Some(code) => spotify_oauth.get_access_token(&code),
-                        None => None,
-                    }
-                }
+                Ok(_) => process_token(spotify_oauth, &mut input),
                 Err(_) => None,
             }
         }


### PR DESCRIPTION
This patch separates get_token functionality into two different functions while still maintaining legacy compatibility where user is queried on the command line for return URL address.

Separating the behavior allows handling request and verification of received token in code. For example: I am working on a small app that spawns a simple http server to localhost to wait for users browser to return back from Spotify website. Thus user never needs to enter the values themselves to console.