### PR TITLE
Make PrivateUser country optional

### DIFF
--- a/src/spotify/model/user.rs
+++ b/src/spotify/model/user.rs
@@ -24,7 +24,7 @@ pub struct PublicUser {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PrivateUser {
     pub birthdate: Option<NaiveDate>,
-    pub country: String,
+    pub country: Option<String>,
     pub display_name: Option<String>,
     pub email: Option<String>,
     pub external_urls: HashMap<String, String>,


### PR DESCRIPTION
Using the crate got a deserialize error calling `current_user`. The docs say this parameter is optional, so the struct should reflect that. Note this is a sever breaking change and should bump the version to 0.6.