### PR TITLE
Add a missing reference to current_user_recently_played

### DIFF
--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -1113,7 +1113,7 @@ impl Spotify {
     ///Parameters:
     ///- limit - the number of entities to return
     pub fn current_user_recently_played<L: Into<Option<u32>>>
-        (self,
+        (&self,
          limit: L)
          -> Result<CursorBasedPage<PlayHistory>, failure::Error> {
         let limit = limit.into().unwrap_or(50);


### PR DESCRIPTION
Hi @ramsayleung 

Thank you for your great project. I really like this library.  I found a missing reference for current_user_recently_played.
`Spotify` will be consumed after I call this function.