### PR TITLE
Fixed a typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ console where your application is running. For example:
 ![](./doc/images/rspotify.gif)
 
 ## Examples
-If you have a use case you are intertested in, you could check the
+If you have a use case you are interested in, you could check the
 [examples](./examples), which has all kinds of detailed examples. For example,
 If you want to get recently played history, you could check
 [current_user_recently_played](./examples/current_user_recently_played.rs). This is


### PR DESCRIPTION
In the old version, "Examples" Section had the following first sentence:
- If you have a use case you are **intertested** in...

Fixed it to be:
- If you have a use case you are **interested** in...