### PR TITLE
Remove an unnecessary mut from current_user_saved_tracks_delete

### DIFF
--- a/examples/current_user_saved_tracks_delete.rs
+++ b/examples/current_user_saved_tracks_delete.rs
@@ -38,7 +38,7 @@ fn main() {
             let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
             tracks_ids.push(track_id2);
             tracks_ids.push(track_id1);
-            match spotify.current_user_saved_tracks_delete(tracks_ids) {
+            match spotify.current_user_saved_tracks_delete(&tracks_ids) {
                 Ok(_) => {
                     println!("saved tracks delete successful");
                 }

--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -1010,9 +1010,9 @@ impl Spotify {
     ///"Your Music" library.
     ///Parameters:
     ///- track_ids - a list of track URIs, URLs or IDs
-    pub fn current_user_saved_tracks_delete(&self, mut track_ids: Vec<String>) -> Result<(), failure::Error> {
+    pub fn current_user_saved_tracks_delete(&self, track_ids: &[String]) -> Result<(), failure::Error> {
         let uris: Vec<String> = track_ids
-            .iter_mut()
+            .iter()
             .map(|id| self.get_id(Type::Track, id))
             .collect();
         let url = format!("me/tracks/?ids={}",uris.join(","));

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -275,7 +275,7 @@ fn test_current_user_saved_tracks_delete() {
             let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
             tracks_ids.push(track_id2);
             tracks_ids.push(track_id1);
-            let result = spotify.current_user_saved_tracks_delete(tracks_ids);
+            let result = spotify.current_user_saved_tracks_delete(&tracks_ids);
             assert!(result.is_ok());
         }
         None => assert!(false),


### PR DESCRIPTION
I found an unnecessary `mut` from current_user_saved_tracks_delete.  It is better to change functions like `current_user_saved_tracks_delete` and `current_user_saved_albums_delete` to have similar arguments.
```Rust
pub fn current_user_saved_albums_delete(&self, album_ids: &[String]) -> Result<(), failure::Error>
{
//..
}
pub fn current_user_saved_tracks_delete(&self, track_ids: &[String]) -> Result<(), failure::Error>
{
///..
}
```

I removed it and also modified example and test code.