### PR TITLE
Use Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description="Spotify API wrapper"
 homepage="https://github.com/samrayleung/rspotify"
 repository="https://github.com/samrayleung/rspotify"
 keywords=["spotify","api"]
+edition = "2018"
 [dependencies]
 base64 = "0.10.0"
 derive_builder = "0.7"

--- a/src/spotify/model/album.rs
+++ b/src/spotify/model/album.rs
@@ -3,11 +3,11 @@ use chrono::prelude::*;
 
 use std::collections::HashMap;
 
-use spotify::senum::{Type, AlbumType};
-use super::track::SimplifiedTrack;
 use super::artist::SimplifiedArtist;
 use super::image::Image;
 use super::page::Page;
+use super::track::SimplifiedTrack;
+use crate::spotify::senum::{AlbumType, Type};
 
 ///[link to album object simplified](https://developer.spotify.com/web-api/object-model/#album-object-simplified)
 /// Simplified Album Object
@@ -17,29 +17,28 @@ pub struct SimplifiedAlbum {
     pub album_group: Option<String>,
     pub album_type: Option<String>,
     pub artists: Vec<SimplifiedArtist>,
-    #[serde(skip_serializing_if="Vec::is_empty",default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub available_markets: Vec<String>,
     pub external_urls: HashMap<String, String>,
     pub href: Option<String>,
     pub id: Option<String>,
     pub images: Vec<Image>,
     pub name: String,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub release_date: Option<String>,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub release_date_precision: Option<String>,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub restrictions: Option<Restrictions>,
     #[serde(rename = "type")]
     pub _type: Type,
     pub uri: Option<String>,
 }
 
-
 /// Restrictions object
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Restrictions {
-    pub reason: String
+    pub reason: String,
 }
 
 ///[link to album object full](https://developer.spotify.com/web-api/object-model/#album-object-full)

--- a/src/spotify/model/artist.rs
+++ b/src/spotify/model/artist.rs
@@ -1,10 +1,10 @@
 //! All objects related to artist defined by Spotify API
 
-use std::collections::HashMap;
-use serde_json::Value;
-use spotify::senum::Type;
 use super::image::Image;
 use super::page::CursorBasedPage;
+use crate::spotify::senum::Type;
+use serde_json::Value;
+use std::collections::HashMap;
 ///[artist object simplified](https://developer.spotify.com/web-api/object-model/#artist-object-simplified)
 /// Simplified Artist Object
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -20,7 +20,7 @@ pub struct SimplifiedArtist {
 
 ///[artist object full](https://developer.spotify.com/web-api/object-model/#artist-object-full)
 /// Full Artist Object
-#[derive(Clone, Debug,Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FullArtist {
     pub external_urls: HashMap<String, String>,
     pub followers: HashMap<String, Option<Value>>,

--- a/src/spotify/model/context.rs
+++ b/src/spotify/model/context.rs
@@ -1,9 +1,9 @@
 //! All objects related to context
 use std::collections::HashMap;
 
-use spotify::senum::{Type,RepeatState};
 use super::device::Device;
 use super::track::FullTrack;
+use crate::spotify::senum::{RepeatState, Type};
 /// Context object
 ///[get the users currently playing track](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -28,8 +28,6 @@ pub struct FullPlayingContext {
     pub is_playing: bool,
     pub item: Option<FullTrack>,
 }
-
-
 
 ///[get the users currently playing track](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/spotify/model/device.rs
+++ b/src/spotify/model/device.rs
@@ -1,6 +1,6 @@
 /// All objects related to device
 ///[get a users available devices](https://developer.spotify.com/web-api/get-a-users-available-devices/)
-use spotify::senum::DeviceType;
+use crate::spotify::senum::DeviceType;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Device {
     pub id: String,

--- a/src/spotify/model/playlist.rs
+++ b/src/spotify/model/playlist.rs
@@ -1,13 +1,13 @@
 //! All kinds of playlists objects
-use serde_json::Value;
 use chrono::prelude::*;
+use serde_json::Value;
 use std::collections::HashMap;
 
 use super::image::Image;
-use super::user::PublicUser;
-use super::track::FullTrack;
 use super::page::Page;
-use spotify::senum::Type;
+use super::track::FullTrack;
+use super::user::PublicUser;
+use crate::spotify::senum::Type;
 ///[playlist object simplified](https://developer.spotify.com/web-api/object-model/#playlist-object-simplified)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimplifiedPlaylist {

--- a/src/spotify/model/track.rs
+++ b/src/spotify/model/track.rs
@@ -3,16 +3,16 @@ use chrono::prelude::*;
 
 use std::collections::HashMap;
 
-use super::artist::SimplifiedArtist;
-use super::album::SimplifiedAlbum;
 use super::album::Restrictions;
-use spotify::senum::Type;
+use super::album::SimplifiedAlbum;
+use super::artist::SimplifiedArtist;
+use crate::spotify::senum::Type;
 ///[track object full](https://developer.spotify.com/web-api/object-model/#track-object-full)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FullTrack {
     pub album: SimplifiedAlbum,
     pub artists: Vec<SimplifiedArtist>,
-    #[serde(skip_serializing_if="Vec::is_empty",default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub available_markets: Vec<String>,
     pub disc_number: i32,
     pub duration_ms: u32,
@@ -41,13 +41,13 @@ pub struct FullTrack {
 /// Track Link
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrackLink{
+pub struct TrackLink {
     pub external_urls: HashMap<String, String>,
     pub href: String,
     pub id: String,
     #[serde(rename = "type")]
     pub _type: Type,
-    pub uri: String
+    pub uri: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/spotify/model/user.rs
+++ b/src/spotify/model/user.rs
@@ -1,11 +1,11 @@
 //! All kinds of user object
-use serde_json::Value;
 use chrono::NaiveDate;
+use serde_json::Value;
 
 use std::collections::HashMap;
 
 use super::image::Image;
-use spotify::senum::Type;
+use crate::spotify::senum::Type;
 ///[public user object](https://developer.spotify.com/web-api/object-model/#user-object-public)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PublicUser {


### PR DESCRIPTION
Async/await requires Rust 2018 edition. This PR therefore prepares
rspotify for implementing async/await.