### PR TITLE
Support other tls implementations besides openssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,36 @@ jobs:
         with:
           command: check
 
+  cross-compile:
+    name: Cross Compile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install gcc for armhf
+        run: sudo apt-get update && sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }} --no-default-features --features "rustls-tls"
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ log = "0.4"
 percent-encoding = "1.0.1"
 rand = "0.6.5"
 random = "0.12.2"
-reqwest = { version = "0.10", features = ["json", "socks"] }
+reqwest-default-tls ={ version = "0.10", features=["json","socks"], optional = true, package = "reqwest" }
+reqwest-native-tls ={ version = "0.10", features=["json","socks", "native-tls"], default-features = false, optional = true,  package = "reqwest"}
+reqwest-native-tls-vendored ={ version = "0.10", features=["json","socks", "native-tls-vendored"], default-features = false, optional = true, package = "reqwest" }
+reqwest-rustls-tls ={ version = "0.10", features=["json","socks", "rustls-tls"], default-features = false, optional = true, package = "reqwest" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -37,7 +40,16 @@ tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 
 [features]
-blocking = ["reqwest/blocking"]
+default = ["default-tls"]
+default-tls = ["reqwest-default-tls"]
+default-tls-blocking = ["reqwest-default-tls/blocking"]
+# Enables native-tls specific functionality not available by default.
+native-tls = ["reqwest-native-tls"]
+native-tls-blocking = ["reqwest-native-tls/blocking"]
+native-tls-vendored = ["reqwest-native-tls-vendored"]
+native-tls-vendored-blocking = ["reqwest-native-tls-vendored/blocking"]
+rustls-tls = ["reqwest-rustls-tls"]
+rustls-tls-blocking = ["reqwest-rustls-tls/blocking"]
 
 [[example]]
 name = "device"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,22 @@
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-extern crate reqwest;
+
+#[cfg(any(feature = "default-tls", feature = "default-tls-blocking"))]
+extern crate reqwest_default_tls as reqwest;
+
+#[cfg(any(feature = "native-tls-crate", feature = "native-tls-crate-blocking"))]
+extern crate reqwest_native_tls as reqwest;
+
+#[cfg(any(
+    feature = "native-tls-vendored",
+    feature = "native-tls-vendored-blocking"
+))]
+extern crate reqwest_native_tls_vendored as reqwest;
+
+#[cfg(any(feature = "rustls-tls", feature = "rustls-tls-blocking"))]
+extern crate reqwest_rustls_tls as reqwest;
+
 extern crate serde;
 #[macro_use]
 extern crate serde_json;

--- a/tests/test_device.rs
+++ b/tests/test_device.rs
@@ -1,4 +1,15 @@
-extern crate reqwest;
+#[cfg(feature = "default-tls")]
+extern crate reqwest_default_tls as reqwest;
+
+#[cfg(feature = "native-tls-crate")]
+extern crate reqwest_native_tls as reqwest;
+
+#[cfg(feature = "native-tls-vendored")]
+extern crate reqwest_native_tls_vendored as reqwest;
+
+#[cfg(feature = "rustls-tls")]
+extern crate reqwest_rustls_tls as reqwest;
+
 extern crate rspotify;
 
 //TODO waitting for mutable mockito test framework


### PR DESCRIPTION
Goal is to make it easier to cross compile when using this crate.
Basically I feel a big pain point in cross compilation are always libraries such as libopenssl which have to be available for your target architecture. Rust native implementations make cross compilation a lot easier because you can pretty much just rely on cargo without having to worry about missing some particular library.

Before: 
```
cargo build --release --target arm-unknown-linux-gnueabihf                                            
   Compiling openssl-sys v0.9.54
   Compiling futures-util v0.3.3
error: failed to run custom build command for `openssl-sys v0.9.54`

Caused by:
  process didn't exit successfully: `/home/abc/github-thirdparty/rspotify/target/release/build/openssl-sys-47ed6ba4b4c9b64b/build-script-main` (exit code: 101)
--- stdout
cargo:rustc-cfg=const_fn
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR
ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR unset
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
OPENSSL_LIB_DIR unset
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR
ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR unset
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
OPENSSL_INCLUDE_DIR unset
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR
ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR unset
cargo:rerun-if-env-changed=OPENSSL_DIR
OPENSSL_DIR unset
run pkg_config fail: "Cross compilation detected. Use PKG_CONFIG_ALLOW_CROSS=1 to override"

--- stderr
thread 'main' panicked at '

Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

Make sure you also have the development packages of openssl installed.
For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

$HOST = x86_64-unknown-linux-gnu
$TARGET = arm-unknown-linux-gnueabihf
openssl-sys = 0.9.54

', /home/abc/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.54/build/find_normal.rs:150:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```

After using  [rustls](https://github.com/ctz/rustls):
```
 cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features rustls-tls
   Compiling rspotify v0.8.0 (/home/abc/github-thirdparty/rspotify)
    Finished release [optimized] target(s) in 13.69s
```

After using openssl vendored (build from source):
```
cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features native-tls-vendored         
   Compiling rspotify v0.8.0 (/home/abc/github-thirdparty/rspotify)
    Finished release [optimized] target(s) in 13.85s
```