### PR TITLE
Add missing "Show" and "Episode" types

### DIFF
--- a/src/spotify/model/playlist.rs
+++ b/src/spotify/model/playlist.rs
@@ -51,7 +51,7 @@ pub struct PlaylistTrack {
     pub added_at: DateTime<Utc>,
     pub added_by: Option<PublicUser>,
     pub is_local: bool,
-    pub track: FullTrack,
+    pub track: Option<FullTrack>,
 }
 ///[get list featured playlists](https://developer.spotify.com/web-api/get-list-featured-playlists/)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/spotify/senum.rs
+++ b/src/spotify/senum.rs
@@ -76,7 +76,7 @@ fn test_album_type_convert_from_str() {
     assert_eq!(empty_type.is_err(), true);
 }
 
-///  Type: ‘artist’, ‘album’,‘track’ or ‘playlist’
+///  Type: ‘artist’, ‘album’,‘track’, ‘playlist’, 'show' or 'episode'
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Type {
@@ -85,6 +85,8 @@ pub enum Type {
     Track,
     Playlist,
     User,
+    Show,
+    Episode,
 }
 impl Type {
     pub fn as_str(&self) -> &str {
@@ -94,6 +96,8 @@ impl Type {
             Type::Track => "track",
             Type::Playlist => "playlist",
             Type::User => "user",
+            Type::Show => "show",
+            Type::Episode => "episode",
         }
     }
 }
@@ -106,6 +110,8 @@ impl FromStr for Type {
             "track" => Ok(Type::Track),
             "playlist" => Ok(Type::Playlist),
             "user" => Ok(Type::User),
+            "show" => Ok(Type::Show),
+            "episode" => Ok(Type::Episode),
             _ => Err(Error::new(ErrorKind::NoEnum(s.to_owned()))),
         }
     }


### PR DESCRIPTION
I ran into these types when using the spotify api, this would throw an error:

```convert result failed, reason: Error("unknown variant `show`, expected one of `artist`, `album`, `track`, `playlist`, `user`", line: 57, column: 27); content```

The same happened for `episode`.

The problem is for these types, "track" is null on FullPlaylist, so this changes the public api a bit...