### PR TITLE
Handle regular and player error objects

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,13 +1,11 @@
 //! Client to Spotify API endpoint
 // 3rd-part library
 use chrono::prelude::*;
-use failure;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Method;
 use reqwest::StatusCode;
 use serde::de::Deserialize;
-use serde_json;
 use serde_json::map::Map;
 use serde_json::Value;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,9 +96,10 @@ impl ApiError {
                 }
             }
             status @ StatusCode::FORBIDDEN | status @ StatusCode::NOT_FOUND => {
-                match response.json::<ApiError>().await {
-                    Ok(reason) => reason,
-                    Err(_) => ApiError::Other(status.as_u16()),
+                if let Ok(reason) = response.json::<ApiError>().await {
+                    reason
+                } else {
+                    ApiError::Other(status.as_u16())
                 }
             }
             status => ApiError::Other(status.as_u16()),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,13 +1,11 @@
 //! Client to Spotify API endpoint
 // 3rd-part library
 use chrono::prelude::*;
-use failure;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Client;
 use reqwest::Method;
 use reqwest::StatusCode;
 use serde::de::Deserialize;
-use serde_json;
 use serde_json::map::Map;
 use serde_json::Value;
 

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -4,7 +4,6 @@ use chrono::prelude::*;
 use dotenv::dotenv;
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::Client;
-use serde_json;
 
 // use built-in library
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
Addresses #63.

There is a message given alongside most API errors, but it has been
thrown away until now. This commit presents the full JSON object to the
end consumer of the error (see [error object](https://developer.spotify.com/documentation/web-api/reference/object-model/#error-object), [player error object](https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-object))

The `From<&Response>` impl was removed and replaced with a non-trait `from_response` method so that the async `Response::json` method could be called.