### PR TITLE
add functions to get access token and refresh token without cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target/
 **/*.rs.bk
 .idea/
-*cache*
+.spotify_token_cache.json
 .tern-port
 cmake-build-debug
 */.test_token

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3"
 [features]
 default = ["default-tls"]
 default-tls = ["reqwest-default-tls"]
-default-tls-blocking = ["reqwest-default-tls/blocking"]
+blocking = ["reqwest-default-tls/blocking"]
 # Enables native-tls specific functionality not available by default.
 native-tls = ["reqwest-native-tls"]
 native-tls-blocking = ["reqwest-native-tls/blocking"]
@@ -376,3 +376,8 @@ path = "examples/blocking/user_unfollow_users.rs"
 name = "volume"
 required-features = ["blocking"]
 path = "examples/blocking/volume.rs"
+
+[[example]]
+name = "blocking_get_access_token_without_cache"
+required-features = ["blocking"]
+path = "examples/blocking/get_access_token_without_cache.rs"

--- a/examples/blocking/get_access_token_without_cache.rs
+++ b/examples/blocking/get_access_token_without_cache.rs
@@ -36,7 +36,9 @@ fn main() {
             let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
             let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None, None);
             println!("{:?}", playlists);
-            match spotify_oauth.refresh_access_token_without_cache(&token_info.refresh_token.unwrap()) {
+            match spotify_oauth
+                .refresh_access_token_without_cache(&token_info.refresh_token.unwrap())
+            {
                 Some(refresh_token) => {
                     println!("refresh token: {:?}", refresh_token);
                 }

--- a/examples/blocking/get_access_token_without_cache.rs
+++ b/examples/blocking/get_access_token_without_cache.rs
@@ -1,0 +1,48 @@
+extern crate rspotify;
+
+use rspotify::blocking::client::Spotify;
+use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
+use rspotify::blocking::util::get_token_without_cache;
+
+fn main() {
+    // Set client_id and client_secret in .env file or
+    // export CLIENT_ID="your client_id"
+    // export CLIENT_SECRET="secret"
+    // export REDIRECT_URI=your-direct-uri
+
+    // Or set client_id, client_secret,redirect_uri explictly
+    // let oauth = SpotifyOAuth::default()
+    //     .client_id("this-is-my-client-id")
+    //     .client_secret("this-is-my-client-secret")
+    //     .redirect_uri("http://localhost:8888/callback")
+    //     .build();
+
+    let mut spotify_oauth = SpotifyOAuth::default().build();
+    match get_token_without_cache(&mut spotify_oauth) {
+        Some(token_info) => {
+            let client_credential = SpotifyClientCredentials::default()
+                .token_info(token_info.to_owned())
+                .build();
+
+            // Or set client_id and client_secret explictly
+            // let client_credential = SpotifyClientCredentials::default()
+            //     .client_id("this-is-my-client-id")
+            //     .client_secret("this-is-my-client-secret")
+            //     .build();
+            let spotify = Spotify::default()
+                .client_credentials_manager(client_credential)
+                .build();
+            let user_id = "spotify";
+            let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
+            let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None, None);
+            println!("{:?}", playlists);
+            match spotify_oauth.refresh_access_token_without_cache(&token_info.refresh_token.unwrap()) {
+                Some(refresh_token) => {
+                    println!("refresh token: {:?}", refresh_token);
+                }
+                None => println!("refresh token failed"),
+            }
+        }
+        None => println!("auth failed"),
+    };
+}

--- a/examples/get_access_token_without_cache.rs
+++ b/examples/get_access_token_without_cache.rs
@@ -40,8 +40,11 @@ async fn main() {
             let result = spotify.user_artist_check_follow(&artist_ids).await;
             println!("result:{:?}", result);
             // refresh token without cache
-            match oauth.refresh_access_token_without_cache(&token_info.refresh_token.unwrap()).await{
-                Some(refresh_token) =>{
+            match oauth
+                .refresh_access_token_without_cache(&token_info.refresh_token.unwrap())
+                .await
+            {
+                Some(refresh_token) => {
                     println!("refresh token: {:?}", refresh_token);
                 }
                 None => println!("refresh token failed"),

--- a/examples/get_access_token_without_cache.rs
+++ b/examples/get_access_token_without_cache.rs
@@ -1,0 +1,52 @@
+extern crate rspotify;
+
+use rspotify::client::Spotify;
+use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
+use rspotify::util::get_token_without_cache;
+
+#[tokio::main]
+async fn main() {
+    // Set client_id and client_secret in .env file or
+    // export CLIENT_ID="your client_id"
+    // export CLIENT_SECRET="secret"
+    // export REDIRECT_URI=your-direct-uri
+
+    // Or set client_id, client_secret,redirect_uri explictly
+    // let oauth = SpotifyOAuth::default()
+    //     .client_id("this-is-my-client-id")
+    //     .client_secret("this-is-my-client-secret")
+    //     .redirect_uri("http://localhost:8888/callback")
+    //     .build();
+
+    let mut oauth = SpotifyOAuth::default().scope("user-follow-read").build();
+    match get_token_without_cache(&mut oauth).await {
+        Some(token_info) => {
+            let client_credential = SpotifyClientCredentials::default()
+                .token_info(token_info.to_owned())
+                .build();
+            // Or set client_id and client_secret explictly
+            // let client_credential = SpotifyClientCredentials::default()
+            //     .client_id("this-is-my-client-id")
+            //     .client_secret("this-is-my-client-secret")
+            //     .build();
+            let spotify = Spotify::default()
+                .client_credentials_manager(client_credential)
+                .build();
+            let mut artist_ids = vec![];
+            let artist_id1 = String::from("74ASZWbe4lXaubB36ztrGX");
+            let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
+            artist_ids.push(artist_id1);
+            artist_ids.push(artist_id2);
+            let result = spotify.user_artist_check_follow(&artist_ids).await;
+            println!("result:{:?}", result);
+            // refresh token without cache
+            match oauth.refresh_access_token_without_cache(&token_info.refresh_token.unwrap()).await{
+                Some(refresh_token) =>{
+                    println!("refresh token: {:?}", refresh_token);
+                }
+                None => println!("refresh token failed"),
+            }
+        }
+        None => println!("auth failed"),
+    };
+}

--- a/src/blocking/oauth2.rs
+++ b/src/blocking/oauth2.rs
@@ -302,17 +302,20 @@ impl SpotifyOAuth {
             }
         }
     }
-    /// gets the access_token for the app given the code
-    pub fn get_access_token(&self, code: &str) -> Option<TokenInfo> {
+    /// gets the access_token for the app with given the code without caching token.
+
+    pub fn get_access_token_without_cache(&self, code: &str) -> Option<TokenInfo> {
         let mut payload: HashMap<&str, &str> = HashMap::new();
         payload.insert("redirect_uri", &self.redirect_uri);
         payload.insert("code", code);
         payload.insert("grant_type", "authorization_code");
         payload.insert("scope", &self.scope);
         payload.insert("state", &self.state);
-        if let Some(token_info) =
-            self.fetch_access_token(&self.client_id, &self.client_secret, &payload)
-        {
+        return self.fetch_access_token(&self.client_id, &self.client_secret, &payload);
+    }
+    /// gets the access_token for the app with given the code
+    pub fn get_access_token(&self, code: &str) -> Option<TokenInfo> {
+        if let Some(token_info) = self.get_access_token_without_cache(code) {
             match serde_json::to_string(&token_info) {
                 Ok(token_info_string) => {
                     trace!("get_access_token->token_info[{:?}]", &token_info_string);
@@ -373,15 +376,18 @@ impl SpotifyOAuth {
         authorize_url
     }
 
-    /// after refresh access_token, the response may be empty
-    /// when refresh_token again
-    pub fn refresh_access_token(&self, refresh_token: &str) -> Option<TokenInfo> {
+    /// refresh token without caching token.
+    pub fn refresh_access_token_without_cache(&self, refresh_token: &str) -> Option<TokenInfo> {
         let mut payload = HashMap::new();
         payload.insert("refresh_token", refresh_token);
         payload.insert("grant_type", "refresh_token");
-        if let Some(token_info) =
-            self.fetch_access_token(&self.client_id, &self.client_secret, &payload)
-        {
+        return self.fetch_access_token(&self.client_id, &self.client_secret, &payload);
+    }
+
+    /// after refresh access_token, the response may be empty
+    /// when refresh_token again
+    pub fn refresh_access_token(&self, refresh_token: &str) -> Option<TokenInfo> {
+        if let Some(token_info) = self.refresh_access_token_without_cache(refresh_token) {
             match serde_json::to_string(&token_info) {
                 Ok(token_info_string) => {
                     self.save_token_info(&token_info_string);

--- a/src/blocking/util.rs
+++ b/src/blocking/util.rs
@@ -87,6 +87,16 @@ pub fn process_token(spotify_oauth: &mut SpotifyOAuth, input: &mut String) -> Op
     }
 }
 
+pub fn process_token_without_cache(
+    spotify_oauth: &mut SpotifyOAuth,
+    input: &mut String,
+) -> Option<TokenInfo> {
+    match spotify_oauth.parse_response_code(input) {
+        Some(code) => spotify_oauth.get_access_token_without_cache(&code),
+        None => None,
+    }
+}
+
 /// get tokenInfo by Authorization
 pub fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
     match spotify_oauth.get_cached_token() {
@@ -100,6 +110,17 @@ pub fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
                 Err(_) => None,
             }
         }
+    }
+}
+
+/// get tokenInfo by Authorization without cache.
+pub fn get_token_without_cache(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
+    request_token(spotify_oauth);
+    println!("Enter the URL you were redirected to: ");
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(_) => process_token_without_cache(spotify_oauth, &mut input),
+        Err(_) => None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 extern crate log;
 extern crate env_logger;
 
-#[cfg(any(feature = "default-tls", feature = "default-tls-blocking"))]
+#[cfg(any(feature = "default-tls", feature = "blocking"))]
 extern crate reqwest_default_tls as reqwest;
 
 #[cfg(any(feature = "native-tls-crate", feature = "native-tls-crate-blocking"))]

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -310,9 +310,8 @@ impl SpotifyOAuth {
         payload.insert("grant_type", "authorization_code");
         payload.insert("scope", &self.scope);
         payload.insert("state", &self.state);
-        return self
-            .fetch_access_token(&self.client_id, &self.client_secret, &payload)
-            .await;
+        self.fetch_access_token(&self.client_id, &self.client_secret, &payload)
+            .await
     }
 
     /// gets the access_token for the app with given the code
@@ -387,9 +386,8 @@ impl SpotifyOAuth {
         let mut payload = HashMap::new();
         payload.insert("refresh_token", refresh_token);
         payload.insert("grant_type", "refresh_token");
-        return self
-            .fetch_access_token(&self.client_id, &self.client_secret, &payload)
-            .await;
+        self.fetch_access_token(&self.client_id, &self.client_secret, &payload)
+            .await
     }
 
     /// after refresh access_token, the response may be empty

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -302,18 +302,22 @@ impl SpotifyOAuth {
             }
         }
     }
-    /// gets the access_token for the app given the code
-    pub async fn get_access_token(&self, code: &str) -> Option<TokenInfo> {
+    /// gets the access_token for the app with the given code without caching(without saving token to `cache_path`)
+    pub async fn get_access_token_without_cache(&self, code: &str) -> Option<TokenInfo> {
         let mut payload: HashMap<&str, &str> = HashMap::new();
         payload.insert("redirect_uri", &self.redirect_uri);
         payload.insert("code", code);
         payload.insert("grant_type", "authorization_code");
         payload.insert("scope", &self.scope);
         payload.insert("state", &self.state);
-        if let Some(token_info) = self
+        return self
             .fetch_access_token(&self.client_id, &self.client_secret, &payload)
-            .await
-        {
+            .await;
+    }
+
+    /// gets the access_token for the app with given the code
+    pub async fn get_access_token(&self, code: &str) -> Option<TokenInfo> {
+        if let Some(token_info) = self.get_access_token_without_cache(code).await {
             match serde_json::to_string(&token_info) {
                 Ok(token_info_string) => {
                     trace!("get_access_token->token_info[{:?}]", &token_info_string);
@@ -375,16 +379,23 @@ impl SpotifyOAuth {
         authorize_url
     }
 
-    /// after refresh access_token, the response may be empty
-    /// when refresh_token again
-    pub async fn refresh_access_token(&self, refresh_token: &str) -> Option<TokenInfo> {
+    /// refreshes token without saving token as cache.
+    pub async fn refresh_access_token_without_cache(
+        &self,
+        refresh_token: &str,
+    ) -> Option<TokenInfo> {
         let mut payload = HashMap::new();
         payload.insert("refresh_token", refresh_token);
         payload.insert("grant_type", "refresh_token");
-        if let Some(token_info) = self
+        return self
             .fetch_access_token(&self.client_id, &self.client_secret, &payload)
-            .await
-        {
+            .await;
+    }
+
+    /// after refresh access_token, the response may be empty
+    /// when refresh_token again
+    pub async fn refresh_access_token(&self, refresh_token: &str) -> Option<TokenInfo> {
+        if let Some(token_info) = self.refresh_access_token_without_cache(refresh_token).await {
             match serde_json::to_string(&token_info) {
                 Ok(token_info_string) => {
                     self.save_token_info(&token_info_string);

--- a/src/util.rs
+++ b/src/util.rs
@@ -89,6 +89,16 @@ pub async fn process_token(
     }
 }
 
+pub async fn process_token_without_cache(
+    spotify_oauth: &mut SpotifyOAuth,
+    input: &mut String,
+) -> Option<TokenInfo> {
+    match spotify_oauth.parse_response_code(input) {
+        Some(code) => spotify_oauth.get_access_token_without_cache(&code).await,
+        None => None,
+    }
+}
+
 /// get tokenInfo by Authorization
 pub async fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
     match spotify_oauth.get_cached_token().await {
@@ -102,6 +112,17 @@ pub async fn get_token(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
                 Err(_) => None,
             }
         }
+    }
+}
+
+/// get tokenInfo by Authorization without cache
+pub async fn get_token_without_cache(spotify_oauth: &mut SpotifyOAuth) -> Option<TokenInfo> {
+    request_token(spotify_oauth);
+    println!("Enter the URL you were redirected to: ");
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(_) => process_token_without_cache(spotify_oauth, &mut input).await,
+        Err(_) => None,
     }
 }
 


### PR DESCRIPTION
add a new feature to get access token and refresh token without saving token into `cache_path`, trying to complete this request: https://github.com/ramsayleung/rspotify/issues/96