### PR TITLE
Dependencies cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,12 @@ keywords=["spotify","api"]
 edition = "2018"
 [dependencies]
 base64 = "0.10.0"
-derive_builder = "0.7"
 dotenv = "0.13.0"
 env_logger = "0.6.0"
 itertools = "0.8.0"
 log = "0.4"
 percent-encoding = "1.0.1"
 rand = "0.6.5"
-random = "0.12.2"
 reqwest-default-tls ={ version = "0.10", features=["json","socks"], optional = true, package = "reqwest" }
 reqwest-native-tls ={ version = "0.10", features=["json","socks", "native-tls"], default-features = false, optional = true,  package = "reqwest"}
 reqwest-native-tls-vendored ={ version = "0.10", features=["json","socks", "native-tls-vendored"], default-features = false, optional = true, package = "reqwest" }


### PR DESCRIPTION
I was checking out the `Cargo.toml` file and found a couple dependencies useless, as they aren't used anywhere. `random` is a crate that hasn't been updated in four years, and I haven't found any matches of `#[derive(Builder)]`, so it seems useless to me. I obtained these by running the following script I made:

```sh
#!/bin/sh

for name in base64 derive_builder dotenv env_logger itertools log percent-encoding rand random reqwest-default-tls reqwest-native-tls reqwest-native-tls-vendored reqwest-rustls-tls serde serde_derive serde_json url webbrowser lazy_static failure; do
    for pkg in "$name" $(echo "$name" | tr '-' '_'); do
        if grep -qrE "use $pkg|$pkg::|extern crate $pkg" src; then
            continue 2
        fi
    done

    echo "UNUSED $name"
done
```

I am completely new to the project, so if I'm wrong please let me know. Can anyone check if I missed any other useless dependencies?