### PR TITLE
Upgraded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,21 @@ keywords=["spotify","api"]
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
-dotenv = "0.13.0"
-failure = "0.1"
-lazy_static = "1.0"
-log = "0.4"
-percent-encoding = "1.0.1"
-rand = "0.6.5"
-reqwest = { version = "0.10", features = ["json", "socks"], default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-webbrowser = "0.5.0"
+chrono = { version = "0.4.13", features = ["serde", "rustc-serialize"] }
+dotenv = "0.15.0"
+failure = "0.1.8"
+lazy_static = "1.4.0"
+log = "0.4.11"
+percent-encoding = "2.1.0"
+rand = "0.7.3"
+reqwest = { version = "0.10.7", features = ["json", "socks"], default-features = false }
+serde = { version = "1.0.115", features = ["derive"] }
+serde_json = "1.0.57"
+webbrowser = "0.5.5"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
-futures = "0.3"
+tokio = { version = "0.2.22", features = ["full"] }
+futures = "0.3.5"
 
 [features]
 default = ["reqwest/default-tls"]

--- a/src/blocking/oauth2.rs
+++ b/src/blocking/oauth2.rs
@@ -3,7 +3,7 @@
 use chrono::prelude::*;
 use dotenv::dotenv;
 use log::{debug, error, trace};
-use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -19,6 +19,9 @@ use std::path::{Path, PathBuf};
 
 // Use customized library
 use super::util::{convert_map_to_string, datetime_to_timestamp, generate_random_string};
+
+// The encoding ASCII set for `utf8_percent_encode`.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS.add(b'%').add(b'/');
 
 /// Client credentials object for spotify
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -3,7 +3,7 @@
 use chrono::prelude::*;
 use dotenv::dotenv;
 use log::{debug, error, trace};
-use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +18,9 @@ use std::path::{Path, PathBuf};
 
 // Use customized library
 use super::util::{convert_map_to_string, datetime_to_timestamp, generate_random_string};
+
+// The encoding ASCII set for `utf8_percent_encode`.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS.add(b'%').add(b'/');
 
 /// Client credentials object for spotify
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
I ran a `cargo upgrade` from `cargo-edit` to update the dependencies used in this module. I strongly suggest integrating [Dependabot](https://dependabot.com/) here so that this is taken care of automatically. It's really easy to use and avoids having to update all dependencies at once.

The only change I had to make so that the examples compiled was upgrading `percent_encoding` to v2.X. I simply followed the instructions indicated [on their repo](https://github.com/servo/rust-url/blob/master/UPGRADING.md#upgrading-from-percent-encoding-1x-to-2x) for the [encoding set this module used](https://docs.diesel.rs/1.4.x/src/percent_encoding/lib.rs.html#143).

On a side note: I think the `base64` dependency may be unnecessary. I don't see where it's exactly being used, and the examples still compile after removing it from `Cargo.toml` and the `extern crate` from `lib.rs`.

Edit: please merge #106 first so that I can update this afterwards.