### PR TITLE
Extern crate, Cargo.toml cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ reqwest-default-tls ={ version = "0.10", features=["json","socks"], optional = t
 reqwest-native-tls ={ version = "0.10", features=["json","socks", "native-tls"], default-features = false, optional = true,  package = "reqwest"}
 reqwest-native-tls-vendored ={ version = "0.10", features=["json","socks", "native-tls-vendored"], default-features = false, optional = true, package = "reqwest" }
 reqwest-rustls-tls ={ version = "0.10", features=["json","socks", "rustls-tls"], default-features = false, optional = true, package = "reqwest" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "1.6.0"
 webbrowser = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,289 +63,241 @@ path = "examples/blocking/categories.rs"
 name = "blocking_current_playback"
 required-features = ["blocking"]
 path = "examples/blocking/current_playback.rs"
-            
 
 [[example]]
 name = "blocking_current_playing"
 required-features = ["blocking"]
 path = "examples/blocking/current_playing.rs"
-            
 
 [[example]]
 name = "current_user_followed_artists"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_followed_artists.rs"
-            
 
 [[example]]
 name = "current_user_playing_track"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_playing_track.rs"
-            
 
 [[example]]
 name = "current_user_playlists"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_playlists.rs"
             
-
 [[example]]
 name = "current_user_recently_played"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_recently_played.rs"
             
-
 [[example]]
 name = "current_user_saved_albums_add"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_albums_add.rs"
             
-
 [[example]]
 name = "current_user_saved_albums_contains"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_albums_contains.rs"
             
-
 [[example]]
 name = "current_user_saved_albums_delete"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_albums_delete.rs"
             
-
 [[example]]
 name = "current_user_saved_albums"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_albums.rs"
             
-
 [[example]]
 name = "current_user_saved_tracks_add"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_tracks_add.rs"
             
-
 [[example]]
 name = "current_user_saved_tracks_contains"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_tracks_contains.rs"
             
-
 [[example]]
 name = "current_user_saved_tracks_delete"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_tracks_delete.rs"
             
-
 [[example]]
 name = "current_user_saved_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_saved_tracks.rs"
             
-
 [[example]]
 name = "current_user_top_artists"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_top_artists.rs"
             
-
 [[example]]
 name = "current_user_top_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/current_user_top_tracks.rs"
             
-
 [[example]]
 name = "featured_playlists"
 required-features = ["blocking"]
 path = "examples/blocking/featured_playlists.rs"
             
-
 [[example]]
 name = "me"
 required-features = ["blocking"]
 path = "examples/blocking/me.rs"
             
-
 [[example]]
 name = "new_releases"
 required-features = ["blocking"]
 path = "examples/blocking/new_releases.rs"
             
-
 [[example]]
 name = "next_playback"
 required-features = ["blocking"]
 path = "examples/blocking/next_playback.rs"
             
-
 [[example]]
 name = "pause_playback"
 required-features = ["blocking"]
 path = "examples/blocking/pause_playback.rs"
             
-
 [[example]]
 name = "playlist"
 required-features = ["blocking"]
 path = "examples/blocking/playlist.rs"
             
-
 [[example]]
 name = "previous_playback"
 required-features = ["blocking"]
 path = "examples/blocking/previous_playback.rs"
             
-
 [[example]]
 name = "recommendations"
 required-features = ["blocking"]
 path = "examples/blocking/recommendations.rs"
             
-
 [[example]]
 name = "repeat"
 required-features = ["blocking"]
 path = "examples/blocking/repeat.rs"
             
-
 [[example]]
 name = "blocking_search"
 required-features = ["blocking"]
 path = "examples/blocking/search.rs"
             
-
 [[example]]
 name = "seek_track"
 required-features = ["blocking"]
 path = "examples/blocking/seek_track.rs"
             
-
 [[example]]
 name = "shuffle"
 required-features = ["blocking"]
 path = "examples/blocking/shuffle.rs"
             
-
 [[example]]
 name = "start_playback"
 required-features = ["blocking"]
 path = "examples/blocking/start_playback.rs"
             
-
 [[example]]
 name = "transfer_playback"
 required-features = ["blocking"]
 path = "examples/blocking/transfer_playback.rs"
             
-
 [[example]]
 name = "user_artist_check_follow"
 required-features = ["blocking"]
 path = "examples/blocking/user_artist_check_follow.rs"
             
-
 [[example]]
 name = "user_follow_artists"
 required-features = ["blocking"]
 path = "examples/blocking/user_follow_artists.rs"
-            
 
 [[example]]
 name = "user_follow_users"
 required-features = ["blocking"]
 path = "examples/blocking/user_follow_users.rs"
-            
 
 [[example]]
 name = "user_playlist_add_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_add_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist_change_detail"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_change_detail.rs"
-            
 
 [[example]]
 name = "user_playlist_check_follow"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_check_follow.rs"
-            
 
 [[example]]
 name = "user_playlist_create"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_create.rs"
-            
 
 [[example]]
 name = "user_playlist_follow_playlist"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_follow_playlist.rs"
-            
 
 [[example]]
 name = "user_playlist_recorder_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_recorder_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist_remove_all_occurrences_of_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_remove_all_occurrences_of_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist_remove_specific_occurrenes_of_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_remove_specific_occurrenes_of_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist_replace_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_replace_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist.rs"
-            
 
 [[example]]
 name = "user_playlists"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlists.rs"
-            
 
 [[example]]
 name = "user_playlist_tracks"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_tracks.rs"
-            
 
 [[example]]
 name = "user_playlist_unfollow"
 required-features = ["blocking"]
 path = "examples/blocking/user_playlist_unfollow.rs"
-            
 
 [[example]]
 name = "user_unfollow_artists"
 required-features = ["blocking"]
 path = "examples/blocking/user_unfollow_artists.rs"
             
-
 [[example]]
 name = "user_unfollow_users"
 required-features = ["blocking"]
 path = "examples/blocking/user_unfollow_users.rs"
-            
 
 [[example]]
 name = "volume"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ repository="https://github.com/samrayleung/rspotify"
 keywords=["spotify","api"]
 edition = "2018"
 [dependencies]
-base64 = "0.10.0"
 dotenv = "0.13.0"
-env_logger = "0.6.0"
 itertools = "0.8.0"
 log = "0.4"
 percent-encoding = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,7 @@ lazy_static = "1.0"
 log = "0.4"
 percent-encoding = "1.0.1"
 rand = "0.6.5"
-reqwest-default-tls ={ version = "0.10", features=["json","socks"], optional = true, package = "reqwest" }
-reqwest-native-tls ={ version = "0.10", features=["json","socks", "native-tls"], default-features = false, optional = true,  package = "reqwest"}
-reqwest-native-tls-vendored ={ version = "0.10", features=["json","socks", "native-tls-vendored"], default-features = false, optional = true, package = "reqwest" }
-reqwest-rustls-tls ={ version = "0.10", features=["json","socks", "rustls-tls"], default-features = false, optional = true, package = "reqwest" }
+reqwest = { version = "0.10", features = ["json", "socks"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 webbrowser = "0.5.0"
@@ -31,16 +28,15 @@ tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 
 [features]
-blocking = ["reqwest-default-tls/blocking"]
-default = ["default-tls"]
-default-tls = ["reqwest-default-tls"]
-# Enables native-tls specific functionality not available by default.
-native-tls = ["reqwest-native-tls"]
-native-tls-blocking = ["reqwest-native-tls/blocking"]
-native-tls-vendored = ["reqwest-native-tls-vendored"]
-native-tls-vendored-blocking = ["reqwest-native-tls-vendored/blocking"]
-rustls-tls = ["reqwest-rustls-tls"]
-rustls-tls-blocking = ["reqwest-rustls-tls/blocking"]
+default = ["reqwest/default-tls"]
+blocking = ["reqwest/default-tls", "reqwest/blocking"]
+# Passing the TLS features to reqwest.
+native-tls = ["reqwest/native-tls"]
+native-tls-blocking = ["reqwest/native-tls", "reqwest/blocking"]
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+native-tls-vendored-blocking = ["reqwest/native-tls-vendored", "reqwest/blocking"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-blocking = ["reqwest/rustls-tls", "reqwest/blocking"]
 
 [[example]]
 name = "device"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,13 @@ homepage="https://github.com/samrayleung/rspotify"
 repository="https://github.com/samrayleung/rspotify"
 keywords=["spotify","api"]
 edition = "2018"
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
 dotenv = "0.13.0"
+failure = "0.1"
 itertools = "0.8.0"
+lazy_static = "1.0"
 log = "0.4"
 percent-encoding = "1.0.1"
 rand = "0.6.5"
@@ -24,17 +27,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "1.6.0"
 webbrowser = "0.5.0"
-lazy_static = "1.0"
-failure = "0.1"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 
 [features]
+blocking = ["reqwest-default-tls/blocking"]
 default = ["default-tls"]
 default-tls = ["reqwest-default-tls"]
-blocking = ["reqwest-default-tls/blocking"]
 # Enables native-tls specific functionality not available by default.
 native-tls = ["reqwest-native-tls"]
 native-tls-blocking = ["reqwest-native-tls/blocking"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ reqwest-native-tls-vendored ={ version = "0.10", features=["json","socks", "nati
 reqwest-rustls-tls ={ version = "0.10", features=["json","socks", "rustls-tls"], default-features = false, optional = true, package = "reqwest" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-url = "1.6.0"
 webbrowser = "0.5.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
 dotenv = "0.13.0"
 failure = "0.1"
-itertools = "0.8.0"
 lazy_static = "1.0"
 log = "0.4"
 percent-encoding = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository="https://github.com/samrayleung/rspotify"
 keywords=["spotify","api"]
 edition = "2018"
 [dependencies]
+chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
 dotenv = "0.13.0"
 itertools = "0.8.0"
 log = "0.4"
@@ -26,10 +27,6 @@ url = "1.6.0"
 webbrowser = "0.5.0"
 lazy_static = "1.0"
 failure = "0.1"
-
-[dependencies.chrono]
-features = ["serde", "rustc-serialize"]
-version = "0.4"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ tokio = { version = "0.2", features = ["full"] }
 ```
 
 ``` rust
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 use rspotify::senum::Country;
@@ -91,8 +89,6 @@ rspotify = { version = "0.10.0", features=["blocking"]}
 ```
 
 ``` rust
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::SpotifyClientCredentials;
 use rspotify::senum::Country;

--- a/examples/add_to_queue.rs
+++ b/examples/add_to_queue.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::util::get_token;

--- a/examples/album.rs
+++ b/examples/album.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/album_tracks.rs
+++ b/examples/album_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/albums.rs
+++ b/examples/albums.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/artist.rs
+++ b/examples/artist.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/artist_related_artists.rs
+++ b/examples/artist_related_artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/artist_top_tracks.rs
+++ b/examples/artist_top_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;

--- a/examples/artists.rs
+++ b/examples/artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/artists_albums.rs
+++ b/examples/artists_albums.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 use rspotify::senum::{AlbumType, Country};

--- a/examples/audio_analysis.rs
+++ b/examples/audio_analysis.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/audio_features.rs
+++ b/examples/audio_features.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/audios_features.rs
+++ b/examples/audios_features.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/blocking/add_to_queue.rs
+++ b/examples/blocking/add_to_queue.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::SpotifyClientCredentials;

--- a/examples/blocking/artist_top_tracks.rs
+++ b/examples/blocking/artist_top_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::SpotifyClientCredentials;
 use rspotify::senum::Country;

--- a/examples/blocking/categories.rs
+++ b/examples/blocking/categories.rs
@@ -1,6 +1,3 @@
-extern crate chrono;
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/check_users_saved_shows.rs
+++ b/examples/blocking/check_users_saved_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_playback.rs
+++ b/examples/blocking/current_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_playing.rs
+++ b/examples/blocking/current_playing.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_followed_artists.rs
+++ b/examples/blocking/current_user_followed_artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_playing_track.rs
+++ b/examples/blocking/current_user_playing_track.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_playlists.rs
+++ b/examples/blocking/current_user_playlists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_recently_played.rs
+++ b/examples/blocking/current_user_recently_played.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_albums.rs
+++ b/examples/blocking/current_user_saved_albums.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_albums_add.rs
+++ b/examples/blocking/current_user_saved_albums_add.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_albums_contains.rs
+++ b/examples/blocking/current_user_saved_albums_contains.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_albums_delete.rs
+++ b/examples/blocking/current_user_saved_albums_delete.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_tracks.rs
+++ b/examples/blocking/current_user_saved_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_tracks_add.rs
+++ b/examples/blocking/current_user_saved_tracks_add.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_tracks_contains.rs
+++ b/examples/blocking/current_user_saved_tracks_contains.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_saved_tracks_delete.rs
+++ b/examples/blocking/current_user_saved_tracks_delete.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_top_artists.rs
+++ b/examples/blocking/current_user_top_artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/current_user_top_tracks.rs
+++ b/examples/blocking/current_user_top_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/device.rs
+++ b/examples/blocking/device.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/featured_playlists.rs
+++ b/examples/blocking/featured_playlists.rs
@@ -1,6 +1,3 @@
-extern crate chrono;
-extern crate rspotify;
-
 use chrono::prelude::*;
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/blocking/get_a_show.rs
+++ b/examples/blocking/get_a_show.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/get_access_token_without_cache.rs
+++ b/examples/blocking/get_access_token_without_cache.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token_without_cache;

--- a/examples/blocking/get_an_episode.rs
+++ b/examples/blocking/get_an_episode.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/get_saved_show.rs
+++ b/examples/blocking/get_saved_show.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/get_several_episodes.rs
+++ b/examples/blocking/get_several_episodes.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/get_several_shows.rs
+++ b/examples/blocking/get_several_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/get_shows_episodes.rs
+++ b/examples/blocking/get_shows_episodes.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/me.rs
+++ b/examples/blocking/me.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/new_releases.rs
+++ b/examples/blocking/new_releases.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/next_playback.rs
+++ b/examples/blocking/next_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/pause_playback.rs
+++ b/examples/blocking/pause_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/playlist.rs
+++ b/examples/blocking/playlist.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/previous_playback.rs
+++ b/examples/blocking/previous_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/recommendations.rs
+++ b/examples/blocking/recommendations.rs
@@ -1,6 +1,3 @@
-extern crate rspotify;
-extern crate serde_json;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/remove_users_saved_shows.rs
+++ b/examples/blocking/remove_users_saved_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/repeat.rs
+++ b/examples/blocking/repeat.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/save_shows.rs
+++ b/examples/blocking/save_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/search.rs
+++ b/examples/blocking/search.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/seek_track.rs
+++ b/examples/blocking/seek_track.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/shuffle.rs
+++ b/examples/blocking/shuffle.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/start_playback.rs
+++ b/examples/blocking/start_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::model::offset::for_position;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/blocking/transfer_playback.rs
+++ b/examples/blocking/transfer_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_artist_check_follow.rs
+++ b/examples/blocking/user_artist_check_follow.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_follow_artists.rs
+++ b/examples/blocking/user_follow_artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_follow_users.rs
+++ b/examples/blocking/user_follow_users.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist.rs
+++ b/examples/blocking/user_playlist.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_add_tracks.rs
+++ b/examples/blocking/user_playlist_add_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_change_detail.rs
+++ b/examples/blocking/user_playlist_change_detail.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_check_follow.rs
+++ b/examples/blocking/user_playlist_check_follow.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_create.rs
+++ b/examples/blocking/user_playlist_create.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_follow_playlist.rs
+++ b/examples/blocking/user_playlist_follow_playlist.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_recorder_tracks.rs
+++ b/examples/blocking/user_playlist_recorder_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_remove_all_occurrences_of_tracks.rs
+++ b/examples/blocking/user_playlist_remove_all_occurrences_of_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_remove_specific_occurrenes_of_tracks.rs
+++ b/examples/blocking/user_playlist_remove_specific_occurrenes_of_tracks.rs
@@ -1,6 +1,3 @@
-extern crate rspotify;
-extern crate serde_json;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_replace_tracks.rs
+++ b/examples/blocking/user_playlist_replace_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_tracks.rs
+++ b/examples/blocking/user_playlist_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlist_unfollow.rs
+++ b/examples/blocking/user_playlist_unfollow.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_playlists.rs
+++ b/examples/blocking/user_playlists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_unfollow_artists.rs
+++ b/examples/blocking/user_unfollow_artists.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/user_unfollow_users.rs
+++ b/examples/blocking/user_unfollow_users.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/blocking/volume.rs
+++ b/examples/blocking/volume.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::blocking::client::Spotify;
 use rspotify::blocking::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::blocking::util::get_token;

--- a/examples/categories.rs
+++ b/examples/categories.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/check_users_saved_shows.rs
+++ b/examples/check_users_saved_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::util::get_token;

--- a/examples/current_playback.rs
+++ b/examples/current_playback.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::AdditionalType;

--- a/examples/current_playing.rs
+++ b/examples/current_playing.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::AdditionalType;

--- a/examples/current_user_followed_artists.rs
+++ b/examples/current_user_followed_artists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_playing_track.rs
+++ b/examples/current_user_playing_track.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_playlists.rs
+++ b/examples/current_user_playlists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_recently_played.rs
+++ b/examples/current_user_recently_played.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_albums.rs
+++ b/examples/current_user_saved_albums.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_albums_add.rs
+++ b/examples/current_user_saved_albums_add.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_albums_contains.rs
+++ b/examples/current_user_saved_albums_contains.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_albums_delete.rs
+++ b/examples/current_user_saved_albums_delete.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_tracks.rs
+++ b/examples/current_user_saved_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_tracks_add.rs
+++ b/examples/current_user_saved_tracks_add.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_tracks_contains.rs
+++ b/examples/current_user_saved_tracks_contains.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_saved_tracks_delete.rs
+++ b/examples/current_user_saved_tracks_delete.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_top_artists.rs
+++ b/examples/current_user_top_artists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/current_user_top_tracks.rs
+++ b/examples/current_user_top_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/device.rs
+++ b/examples/device.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/featured_playlists.rs
+++ b/examples/featured_playlists.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-extern crate rspotify;
 
 use chrono::prelude::*;
 use rspotify::client::Spotify;

--- a/examples/get_a_show.rs
+++ b/examples/get_a_show.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/get_access_token_without_cache.rs
+++ b/examples/get_access_token_without_cache.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::util::get_token_without_cache;

--- a/examples/get_an_episode.rs
+++ b/examples/get_an_episode.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/get_saved_show.rs
+++ b/examples/get_saved_show.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::util::get_token;

--- a/examples/get_several_episodes.rs
+++ b/examples/get_several_episodes.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/get_several_shows.rs
+++ b/examples/get_several_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/get_shows_episodes.rs
+++ b/examples/get_shows_episodes.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/me.rs
+++ b/examples/me.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/new_releases.rs
+++ b/examples/new_releases.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/next_playback.rs
+++ b/examples/next_playback.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/pause_playback.rs
+++ b/examples/pause_playback.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/playlist.rs
+++ b/examples/playlist.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/previous_playback.rs
+++ b/examples/previous_playback.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/recommendations.rs
+++ b/examples/recommendations.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-extern crate serde_json;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/remove_users_saved_shows.rs
+++ b/examples/remove_users_saved_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::Country;

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/save_shows.rs
+++ b/examples/save_shows.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::util::get_token;

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
 use rspotify::senum::{Country, SearchType};

--- a/examples/seek_track.rs
+++ b/examples/seek_track.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/shuffle.rs
+++ b/examples/shuffle.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/start_playback.rs
+++ b/examples/start_playback.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::model::offset::for_position;

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/tracks.rs
+++ b/examples/tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/transfer_playback.rs
+++ b/examples/transfer_playback.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user.rs
+++ b/examples/user.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-
 use rspotify::client::Spotify;
 use rspotify::oauth2::SpotifyClientCredentials;
 

--- a/examples/user_artist_check_follow.rs
+++ b/examples/user_artist_check_follow.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_follow_artists.rs
+++ b/examples/user_follow_artists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_follow_users.rs
+++ b/examples/user_follow_users.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist.rs
+++ b/examples/user_playlist.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_add_tracks.rs
+++ b/examples/user_playlist_add_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_change_detail.rs
+++ b/examples/user_playlist_change_detail.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_check_follow.rs
+++ b/examples/user_playlist_check_follow.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_create.rs
+++ b/examples/user_playlist_create.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_follow_playlist.rs
+++ b/examples/user_playlist_follow_playlist.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_recorder_tracks.rs
+++ b/examples/user_playlist_recorder_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_remove_all_occurrences_of_tracks.rs
+++ b/examples/user_playlist_remove_all_occurrences_of_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_remove_specific_occurrenes_of_tracks.rs
+++ b/examples/user_playlist_remove_specific_occurrenes_of_tracks.rs
@@ -1,5 +1,3 @@
-extern crate rspotify;
-extern crate serde_json;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_replace_tracks.rs
+++ b/examples/user_playlist_replace_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_tracks.rs
+++ b/examples/user_playlist_tracks.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlist_unfollow.rs
+++ b/examples/user_playlist_unfollow.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_playlists.rs
+++ b/examples/user_playlists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_unfollow_artists.rs
+++ b/examples/user_unfollow_artists.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/user_unfollow_users.rs
+++ b/examples/user_unfollow_users.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -1,4 +1,3 @@
-extern crate rspotify;
 
 use rspotify::client::Spotify;
 use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -10,6 +10,7 @@ use serde_json::map::Map;
 use serde_json::Value;
 use log::{trace, error};
 use lazy_static::lazy_static;
+use itertools::iproduct;
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -2,7 +2,6 @@
 // 3rd-part library
 use chrono::prelude::*;
 use failure::format_err;
-use itertools::iproduct;
 use lazy_static::lazy_static;
 use log::{error, trace};
 use reqwest::blocking::Client;
@@ -1414,7 +1413,7 @@ impl Spotify {
         if let Some(_country) = country {
             params.insert("market".to_owned(), _country.as_str().to_owned());
         }
-        let attributes = vec![
+        let attributes = [
             "acousticness",
             "danceability",
             "duration_ms",
@@ -1430,23 +1429,15 @@ impl Spotify {
             "time_signature",
             "valence",
         ];
-        let prefixes = vec!["min_", "max_", "target_"];
-        for (attribute, prefix) in iproduct!(attributes, prefixes) {
-            let param = prefix.to_owned() + attribute;
-            if let Some(value) = payload.get(&param) {
-                params.insert(param, value.to_string());
+        let prefixes = ["min", "max", "target"];
+        for attribute in attributes.iter() {
+            for prefix in prefixes.iter() {
+                let param = format!("{}_{}", prefix, attribute);
+                if let Some(value) = payload.get(&param) {
+                    params.insert(param, value.to_string());
+                }
             }
         }
-        // for attribute in attributes {
-        //     for prefix in prefixes {
-        //         let param = prefix.to_owned() + attribute;
-        //         if let Some(value) = payload.get(&param) {
-        //             if let Some(value_str) = value.as_str() {
-        //                 params.insert(&param, value_str.to_owned());
-        //             }
-        //         }
-        //     }
-        // }
         let url = String::from("recommendations");
         let result = self.get(&url, &mut params)?;
         self.convert_result::<Recommendations>(&result)

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -5,13 +5,13 @@ use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Method;
 use reqwest::StatusCode;
-use serde::de::Deserialize;
 use serde_json::map::Map;
-use serde_json::Value;
+use serde_json::{Value, json};
 use log::{trace, error};
 use lazy_static::lazy_static;
 use itertools::iproduct;
 use failure::format_err;
+use serde::{Serialize, Deserialize};
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -9,6 +9,7 @@ use serde::de::Deserialize;
 use serde_json::map::Map;
 use serde_json::Value;
 use log::{trace, error};
+use lazy_static::lazy_static;
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,17 +1,17 @@
 //! Client to Spotify API endpoint
 // 3rd-part library
 use chrono::prelude::*;
+use failure::format_err;
+use itertools::iproduct;
+use lazy_static::lazy_static;
+use log::{error, trace};
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Method;
 use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
 use serde_json::map::Map;
-use serde_json::{Value, json};
-use log::{trace, error};
-use lazy_static::lazy_static;
-use itertools::iproduct;
-use failure::format_err;
-use serde::{Serialize, Deserialize};
+use serde_json::{json, Value};
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -8,6 +8,7 @@ use reqwest::StatusCode;
 use serde::de::Deserialize;
 use serde_json::map::Map;
 use serde_json::Value;
+use log::{trace, error};
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use log::{trace, error};
 use lazy_static::lazy_static;
 use itertools::iproduct;
+use failure::format_err;
 
 //  Built-in battery
 use std::borrow::Cow;

--- a/src/blocking/oauth2.rs
+++ b/src/blocking/oauth2.rs
@@ -6,6 +6,7 @@ use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::blocking::Client;
 use serde_json;
 use log::{trace, debug, error};
+use serde::{Serialize, Deserialize};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/blocking/oauth2.rs
+++ b/src/blocking/oauth2.rs
@@ -2,11 +2,11 @@
 // use 3rd party library
 use chrono::prelude::*;
 use dotenv::dotenv;
+use log::{debug, error, trace};
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
 use serde_json;
-use log::{trace, debug, error};
-use serde::{Serialize, Deserialize};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/blocking/oauth2.rs
+++ b/src/blocking/oauth2.rs
@@ -5,6 +5,7 @@ use dotenv::dotenv;
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::blocking::Client;
 use serde_json;
+use log::{trace, debug, error};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,13 +5,13 @@ use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Client;
 use reqwest::Method;
 use reqwest::StatusCode;
-use serde::de::Deserialize;
 use serde_json::map::Map;
-use serde_json::Value;
+use serde_json::{Value, json};
 use log::{trace, error};
 use lazy_static::lazy_static;
 use itertools::iproduct;
 use failure::format_err;
+use serde::{Serialize, Deserialize};
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,6 @@
 // 3rd-part library
 use chrono::prelude::*;
 use failure::format_err;
-use itertools::iproduct;
 use lazy_static::lazy_static;
 use log::{error, trace};
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
@@ -1396,7 +1395,7 @@ impl Spotify {
         if let Some(_country) = country {
             params.insert("market".to_owned(), _country.as_str().to_owned());
         }
-        let attributes = vec![
+        let attributes = [
             "acousticness",
             "danceability",
             "duration_ms",
@@ -1412,23 +1411,15 @@ impl Spotify {
             "time_signature",
             "valence",
         ];
-        let prefixes = vec!["min_", "max_", "target_"];
-        for (attribute, prefix) in iproduct!(attributes, prefixes) {
-            let param = prefix.to_owned() + attribute;
-            if let Some(value) = payload.get(&param) {
-                params.insert(param, value.to_string());
+        let prefixes = ["min", "max", "target"];
+        for attribute in attributes.iter() {
+            for prefix in prefixes.iter() {
+                let param = format!("{}_{}", prefix, attribute);
+                if let Some(value) = payload.get(&param) {
+                    params.insert(param, value.to_string());
+                }
             }
         }
-        // for attribute in attributes {
-        //     for prefix in prefixes {
-        //         let param = prefix.to_owned() + attribute;
-        //         if let Some(value) = payload.get(&param) {
-        //             if let Some(value_str) = value.as_str() {
-        //                 params.insert(&param, value_str.to_owned());
-        //             }
-        //         }
-        //     }
-        // }
         let url = String::from("recommendations");
         let result = self.get(&url, &mut params).await?;
         self.convert_result::<Recommendations>(&result)

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,7 @@ use reqwest::StatusCode;
 use serde::de::Deserialize;
 use serde_json::map::Map;
 use serde_json::Value;
+use log::{trace, error};
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use log::{trace, error};
 use lazy_static::lazy_static;
 use itertools::iproduct;
+use failure::format_err;
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,17 +1,17 @@
 //! Client to Spotify API endpoint
 // 3rd-part library
 use chrono::prelude::*;
+use failure::format_err;
+use itertools::iproduct;
+use lazy_static::lazy_static;
+use log::{error, trace};
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Client;
 use reqwest::Method;
 use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
 use serde_json::map::Map;
-use serde_json::{Value, json};
-use log::{trace, error};
-use lazy_static::lazy_static;
-use itertools::iproduct;
-use failure::format_err;
-use serde::{Serialize, Deserialize};
+use serde_json::{json, Value};
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use serde_json::map::Map;
 use serde_json::Value;
 use log::{trace, error};
 use lazy_static::lazy_static;
+use itertools::iproduct;
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use serde::de::Deserialize;
 use serde_json::map::Map;
 use serde_json::Value;
 use log::{trace, error};
+use lazy_static::lazy_static;
 
 // Built-in battery
 use std::borrow::Cow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,6 @@
 //! [current_user_recently_played](https://github.com/samrayleung/rspotify/blob/master/examples/current_user_recently_played.rs). This is
 //! the example code:
 //! ``` rust
-//! extern crate rspotify;
-//!
 //! use rspotify::client::Spotify;
 //! use rspotify::util::get_token;
 //! use rspotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
@@ -80,24 +78,8 @@
 //!
 //! ```
 
-#[cfg(any(feature = "default-tls", feature = "blocking"))]
-extern crate reqwest_default_tls as reqwest;
-
-#[cfg(any(feature = "native-tls-crate", feature = "native-tls-crate-blocking"))]
-extern crate reqwest_native_tls as reqwest;
-
-#[cfg(any(
-    feature = "native-tls-vendored",
-    feature = "native-tls-vendored-blocking"
-))]
-extern crate reqwest_native_tls_vendored as reqwest;
-
-#[cfg(any(feature = "rustls-tls", feature = "rustls-tls-blocking"))]
-extern crate reqwest_rustls_tls as reqwest;
-
 #[cfg(feature = "blocking")]
 pub mod blocking;
-
 pub mod client;
 pub mod model;
 pub mod oauth2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ extern crate failure;
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
-extern crate dotenv;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 extern crate dotenv;
-extern crate percent_encoding;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
-extern crate webbrowser;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ extern crate lazy_static;
 extern crate dotenv;
 extern crate percent_encoding;
 extern crate rand;
-extern crate url;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,12 +95,6 @@ extern crate reqwest_native_tls_vendored as reqwest;
 #[cfg(any(feature = "rustls-tls", feature = "rustls-tls-blocking"))]
 extern crate reqwest_rustls_tls as reqwest;
 
-extern crate serde;
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-
 #[cfg(feature = "blocking")]
 pub mod blocking;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ extern crate reqwest_rustls_tls as reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
-extern crate chrono;
 #[macro_use]
 extern crate serde_derive;
 extern crate webbrowser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@
 //!
 //! ```
 
-extern crate env_logger;
-
 #[cfg(any(feature = "default-tls", feature = "blocking"))]
 extern crate reqwest_default_tls as reqwest;
 
@@ -111,8 +109,6 @@ extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 extern crate dotenv;
-// use serde_json::Error;
-extern crate base64;
 extern crate percent_encoding;
 extern crate rand;
 extern crate url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@
 //!
 //! ```
 
-#[macro_use]
-extern crate log;
 extern crate env_logger;
 
 #[cfg(any(feature = "default-tls", feature = "blocking"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,6 @@ extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 extern crate webbrowser;
-#[macro_use]
-extern crate failure;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,6 @@ extern crate itertools;
 extern crate lazy_static;
 extern crate dotenv;
 extern crate percent_encoding;
-extern crate rand;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,6 @@ extern crate webbrowser;
 extern crate failure;
 #[macro_use]
 extern crate itertools;
-#[macro_use]
-extern crate lazy_static;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,6 @@ extern crate serde_derive;
 extern crate webbrowser;
 #[macro_use]
 extern crate failure;
-#[macro_use]
-extern crate itertools;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -1,6 +1,6 @@
 //! All objects related to album defined by Spotify API
 use chrono::prelude::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -1,5 +1,6 @@
 //! All objects related to album defined by Spotify API
 use chrono::prelude::*;
+use serde::{Serialize, Deserialize};
 
 use std::collections::HashMap;
 

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -1,4 +1,5 @@
 //! All objects related to artist defined by Spotify API
+use serde::{Serialize, Deserialize};
 
 use super::image::Image;
 use super::page::CursorBasedPage;

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -1,5 +1,5 @@
 //! All objects related to artist defined by Spotify API
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::image::Image;
 use super::page::CursorBasedPage;

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -1,5 +1,5 @@
 //! All objects related to artist defined by Spotify API
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// [audio feature object](https://developer.spotify.com/web-api/object-model/#audio-features-object)
 /// Audio Feature object

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -1,4 +1,5 @@
 //! All objects related to artist defined by Spotify API
+use serde::{Serialize, Deserialize};
 
 /// [audio feature object](https://developer.spotify.com/web-api/object-model/#audio-features-object)
 /// Audio Feature object

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -1,7 +1,7 @@
 //! All object related to category
-use serde::{Serialize, Deserialize};
 use super::image::Image;
 use super::page::Page;
+use serde::{Deserialize, Serialize};
 /// category object
 /// [category object](https://developer.spotify.com/web-api/get-list-categories/#categoryobject)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -1,4 +1,5 @@
 //! All object related to category
+use serde::{Serialize, Deserialize};
 use super::image::Image;
 use super::page::Page;
 /// category object

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -1,5 +1,6 @@
 //! All objects related to context
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 use super::device::Device;
 use super::track::FullTrack;

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -1,6 +1,6 @@
 //! All objects related to context
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
 
 use super::device::Device;
 use super::track::FullTrack;

--- a/src/model/cud_result.rs
+++ b/src/model/cud_result.rs
@@ -1,4 +1,6 @@
 //! The result of post/put/delete request
+use serde::{Serialize, Deserialize};
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CUDResult {
     pub snapshot_id: String,

--- a/src/model/cud_result.rs
+++ b/src/model/cud_result.rs
@@ -1,5 +1,5 @@
 //! The result of post/put/delete request
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CUDResult {

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -1,5 +1,5 @@
-use serde::{Serialize, Deserialize};
 use crate::senum::DeviceType;
+use serde::{Deserialize, Serialize};
 
 /// All objects related to device
 /// [get a users available devices](https://developer.spotify.com/web-api/get-a-users-available-devices/)

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -1,6 +1,8 @@
+use serde::{Serialize, Deserialize};
+use crate::senum::DeviceType;
+
 /// All objects related to device
 /// [get a users available devices](https://developer.spotify.com/web-api/get-a-users-available-devices/)
-use crate::senum::DeviceType;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Device {
     pub id: String,

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -1,4 +1,6 @@
 //! Image object
+use serde::{Serialize, Deserialize};
+
 /// [image object](https://developer.spotify.com/web-api/object-model/#image-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Image {

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -1,5 +1,5 @@
 //! Image object
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// [image object](https://developer.spotify.com/web-api/object-model/#image-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -17,6 +17,8 @@ pub mod show;
 pub mod track;
 pub mod user;
 
+use serde::{Serialize, Deserialize};
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PlayingItem {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -17,7 +17,7 @@ pub mod show;
 pub mod track;
 pub mod user;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/src/model/offset.rs
+++ b/src/model/offset.rs
@@ -1,4 +1,6 @@
 //! Offset object
+use serde::{Serialize, Deserialize};
+
 /// [offset object](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Offset {

--- a/src/model/offset.rs
+++ b/src/model/offset.rs
@@ -1,5 +1,5 @@
 //! Offset object
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// [offset object](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -1,4 +1,6 @@
 //! All kinds of page object
+use serde::{Serialize, Deserialize};
+
 /// Basic page
 /// ppaging abject(https://developer.spotify.com/web-api/object-model/#paging-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -1,5 +1,5 @@
 //! All kinds of page object
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Basic page
 /// ppaging abject(https://developer.spotify.com/web-api/object-model/#paging-object)

--- a/src/model/playing.rs
+++ b/src/model/playing.rs
@@ -1,5 +1,6 @@
 //! All kinds of play object
 use chrono::prelude::*;
+use serde::{Serialize, Deserialize};
 
 use super::context::Context;
 use super::track::FullTrack;

--- a/src/model/playing.rs
+++ b/src/model/playing.rs
@@ -1,6 +1,6 @@
 //! All kinds of play object
 use chrono::prelude::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::context::Context;
 use super::track::FullTrack;

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -1,6 +1,6 @@
 //! All kinds of playlists objects
 use chrono::prelude::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -1,5 +1,6 @@
 //! All kinds of playlists objects
 use chrono::prelude::*;
+use serde::{Serialize, Deserialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/src/model/recommend.rs
+++ b/src/model/recommend.rs
@@ -1,6 +1,6 @@
 //! All objects related to recommendation
-use serde::{Serialize, Deserialize};
 use super::track::SimplifiedTrack;
+use serde::{Deserialize, Serialize};
 
 /// [Recommendations object](https://developer.spotify.com/web-api/object-model/#recommendations-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/recommend.rs
+++ b/src/model/recommend.rs
@@ -1,5 +1,7 @@
 //! All objects related to recommendation
+use serde::{Serialize, Deserialize};
 use super::track::SimplifiedTrack;
+
 /// [Recommendations object](https://developer.spotify.com/web-api/object-model/#recommendations-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Recommendations {

--- a/src/model/search.rs
+++ b/src/model/search.rs
@@ -5,7 +5,7 @@ use super::page::Page;
 use super::playlist::SimplifiedPlaylist;
 use super::show::{SimplifiedEpisode, SimplifiedShow};
 use super::track::FullTrack;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 ///[Search item](https://developer.spotify.com/web-api/search-item/);
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/search.rs
+++ b/src/model/search.rs
@@ -5,6 +5,7 @@ use super::page::Page;
 use super::playlist::SimplifiedPlaylist;
 use super::show::{SimplifiedEpisode, SimplifiedShow};
 use super::track::FullTrack;
+use serde::{Serialize, Deserialize};
 
 ///[Search item](https://developer.spotify.com/web-api/search-item/);
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -1,6 +1,7 @@
 use super::image::Image;
 use super::page::Page;
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 /// Show object(simplified)
 /// [Show object simplified](https://developer.spotify.com/documentation/web-api/reference/object-model/#show-object-simplified)

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -1,7 +1,7 @@
 use super::image::Image;
 use super::page::Page;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
 
 /// Show object(simplified)
 /// [Show object simplified](https://developer.spotify.com/documentation/web-api/reference/object-model/#show-object-simplified)

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -1,5 +1,6 @@
 //! All kinds of tracks object
 use chrono::prelude::*;
+use serde::{Serialize, Deserialize};
 
 use std::collections::HashMap;
 

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -1,6 +1,6 @@
 //! All kinds of tracks object
 use chrono::prelude::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,5 +1,6 @@
 //! All kinds of user object
 use chrono::NaiveDate;
+use serde::{Serialize, Deserialize};
 use serde_json::Value;
 
 use std::collections::HashMap;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,6 +1,6 @@
 //! All kinds of user object
 use chrono::NaiveDate;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use std::collections::HashMap;

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -2,10 +2,10 @@
 // Use 3rd party library
 use chrono::prelude::*;
 use dotenv::dotenv;
+use log::{debug, error, trace};
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::Client;
-use log::{trace, debug, error};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -5,6 +5,7 @@ use dotenv::dotenv;
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::Client;
 use log::{trace, debug, error};
+use serde::{Serialize, Deserialize};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -4,6 +4,7 @@ use chrono::prelude::*;
 use dotenv::dotenv;
 use percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use reqwest::Client;
+use log::{trace, debug, error};
 
 // Use built-in library
 use std::collections::{HashMap, HashSet};

--- a/src/senum.rs
+++ b/src/senum.rs
@@ -1,8 +1,8 @@
 //! All enums for rspotify
+use serde::{Deserialize, Serialize};
 use std::error;
 use std::fmt;
 use std::str::FromStr;
-use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Debug)]
 pub struct Error {

--- a/src/senum.rs
+++ b/src/senum.rs
@@ -2,6 +2,8 @@
 use std::error;
 use std::fmt;
 use std::str::FromStr;
+use serde::{Serialize, Deserialize};
+
 #[derive(Clone, Debug)]
 pub struct Error {
     kind: ErrorKind,

--- a/tests/test_device.rs
+++ b/tests/test_device.rs
@@ -1,17 +1,3 @@
-#[cfg(feature = "default-tls")]
-extern crate reqwest_default_tls as reqwest;
-
-#[cfg(feature = "native-tls-crate")]
-extern crate reqwest_native_tls as reqwest;
-
-#[cfg(feature = "native-tls-vendored")]
-extern crate reqwest_native_tls_vendored as reqwest;
-
-#[cfg(feature = "rustls-tls")]
-extern crate reqwest_rustls_tls as reqwest;
-
-extern crate rspotify;
-
 //TODO waitting for mutable mockito test framework
 #[test]
 #[ignore]

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -1,19 +1,16 @@
-extern crate rspotify;
-#[macro_use]
-extern crate lazy_static;
-
 use rspotify::client::Spotify;
-
 use rspotify::oauth2::SpotifyClientCredentials;
 use rspotify::senum::{AlbumType, Country};
 
 use std::sync::Mutex;
 
+use lazy_static::lazy_static;
+
 lazy_static! {
-   // Set client_id and client_secret in .env file or
+    // Set client_id and client_secret in .env file or
     // export CLIENT_ID="your client_id"
     // export CLIENT_SECRET="secret"
-static ref CLIENT_CREDENTIAL: Mutex<SpotifyClientCredentials> = Mutex::new(SpotifyClientCredentials::default().build());
+    static ref CLIENT_CREDENTIAL: Mutex<SpotifyClientCredentials> = Mutex::new(SpotifyClientCredentials::default().build());
 }
 
 #[tokio::test]

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -1,7 +1,3 @@
-extern crate chrono;
-extern crate rspotify;
-extern crate serde_json;
-
 use chrono::prelude::*;
 use serde_json::map::Map;
 


### PR DESCRIPTION
`extern crate` is no longer needed after Rust 2018, so I've removed all of them, using `use` in its place.

I also removed some unnecessary crates:
* `base64`: not used at all
* `env_logger`: not used at all
* `url`: not used at all
* `itertools`: only used once in `client.rs`, found a cleaner solution to avoid using `iproduct`

And other small improvements in `Cargo.toml`.

The one thing I don't know how to solve is the `reqwest`-related features. Wouldn't it make sense to just remove these `extern crate`? The `Cargo.toml` will already make sure the correct features for `reqwest` are being used.