### PR TITLE
Removed unnecessary attributes in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-// #![feature(non_ascii_idents)]
-#![allow(clippy::needless_doctest_main)]
-#![allow(dead_code)]
 //! ## Description
 //! Rspotify is a lightweight wrapper for the [Spotify Web API](https://developer.spotify.com/web-api/) It includes helper functions for
 //! **all Spotify's endpoints**, such as fetching metadata (search and look-up of


### PR DESCRIPTION
This just removes the unnecessary attributes found at the top of `lib.rs` to clean up a bit, since they seem to be used only for debugging/developing purposes.