### PR TITLE
Fix pull requests running CI twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: master
 
 name: Continuous Integration
 


### PR DESCRIPTION
I noticed that the Continuous Integration was running twice in each PR: one because of a `push`, and another because of a `pull_request`. This should fix that by only running for `push` when it's on `master`.