### PR TITLE
Reducing boilerplate for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.57"
 webbrowser = "0.5.5"
 
 [dev-dependencies]
+async_once = { version = "0.1.0", features = ["tokio"] }
 tokio = { version = "0.2.22", features = ["full"] }
 futures = "0.3.5"
 

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -10,74 +10,65 @@ lazy_static! {
     // Set client_id and client_secret in .env file or
     // export CLIENT_ID="your client_id"
     // export CLIENT_SECRET="secret"
-    static ref CLIENT_CREDENTIAL: Mutex<SpotifyClientCredentials> = Mutex::new(SpotifyClientCredentials::default().build());
+    static ref CLIENT_CREDENTIAL: Mutex<SpotifyClientCredentials>
+        = Mutex::new(SpotifyClientCredentials::default().build());
+}
+
+macro_rules! async_client {
+    () => {
+        // Or set client_id and client_secret explictly
+        // let client_credential = SpotifyClientCredentials::default()
+        //     .client_id("this-is-my-client-id")
+        //     .client_secret("this-is-my-client-secret")
+        //     .build();
+        Spotify::default()
+            .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
+            .build()
+    };
 }
 
 #[tokio::test]
 async fn test_album() {
-    // Or set client_id and client_secret explictly
-    // let client_credential = SpotifyClientCredentials::default()
-    //     .client_id("this-is-my-client-id")
-    //     .client_secret("this-is-my-client-secret")
-    //     .build();
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:album:0sNOF9WDwhWunNAHPD3Baj";
-    let albums = spotify.album(birdy_uri).await;
+    let albums = async_client!().album(birdy_uri).await;
     assert!(albums.is_ok());
 }
 
 #[tokio::test]
 async fn test_albums() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri1 = String::from("spotify:album:41MnTivkwTO3UUJ8DrqEJJ");
     let birdy_uri2 = String::from("spotify:album:6JWc4iAiJ9FjyK0B59ABb4");
     let birdy_uri3 = String::from("spotify:album:6UXCm6bOO4gFlDQZV5yL37");
     let track_uris = vec![birdy_uri1, birdy_uri2, birdy_uri3];
-    let albums = spotify.albums(track_uris).await;
+    let albums = async_client!().albums(track_uris).await;
     assert!(albums.is_ok())
 }
 
 #[tokio::test]
 async fn test_album_tracks() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:album:6akEvsycLGftJxYudPjmqK";
-    let tracks = spotify.album_track(birdy_uri, Some(2), None).await;
+    let tracks = async_client!().album_track(birdy_uri, Some(2), None).await;
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 async fn test_artist_related_artists() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:artist:43ZHCT0cAZBISjO8DG9PnE";
-    let artist = spotify.artist_related_artists(birdy_uri).await;
+    let artist = async_client!().artist_related_artists(birdy_uri).await;
     assert!(artist.is_ok())
 }
 
 #[tokio::test]
 async fn test_artist() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let artist = spotify.artist(birdy_uri).await;
+    let artist = async_client!().artist(birdy_uri).await;
     assert!(artist.is_ok());
 }
 
 #[tokio::test]
 async fn test_artists_albums() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let albums = spotify
+    let albums = async_client!()
         .artist_albums(
             birdy_uri,
             Some(AlbumType::Album),
@@ -86,129 +77,92 @@ async fn test_artists_albums() {
             None,
         )
         .await;
-    dbg!(&albums);
     assert!(albums.is_ok());
 }
 
 #[tokio::test]
 async fn test_artists() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri1 = String::from("spotify:artist:0oSGxfWSnnOXhD2fKuz2Gy");
     let birdy_uri2 = String::from("spotify:artist:3dBVyJ7JuOMt4GE9607Qin");
     let artist_uris = vec![birdy_uri1, birdy_uri2];
-    let artists = spotify.artists(artist_uris).await;
+    let artists = async_client!().artists(artist_uris).await;
     assert!(artists.is_ok());
 }
 
 #[tokio::test]
 async fn test_artist_top_tracks() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let tracks = spotify
+    let tracks = async_client!()
         .artist_top_tracks(birdy_uri, Country::UnitedStates)
         .await;
-    dbg!(&tracks);
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 async fn test_audio_analysis() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let track = "06AKEBrKUckW0KREUWRnvT";
-    let analysis = spotify.audio_analysis(track).await;
+    let analysis = async_client!().audio_analysis(track).await;
     assert!(analysis.is_ok());
 }
 
 #[tokio::test]
 async fn test_audio_features() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let track = "spotify:track:06AKEBrKUckW0KREUWRnvT";
-    let features = spotify.audio_features(track).await;
+    let features = async_client!().audio_features(track).await;
     assert!(features.is_ok());
 }
 
 #[tokio::test]
 async fn test_audios_features() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let mut tracks_ids = vec![];
     let track_id1 = String::from("spotify:track:4JpKVNYnVcJ8tuMKjAj50A");
     tracks_ids.push(track_id1);
     let track_id2 = String::from("spotify:track:24JygzOLM0EmRQeGtFcIcG");
     tracks_ids.push(track_id2);
-    let features = spotify.audios_features(&tracks_ids).await;
+    let features = async_client!().audios_features(&tracks_ids).await;
     assert!(features.is_ok())
 }
 
 #[tokio::test]
 async fn test_user() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-    dbg!(&spotify);
     let birdy_uri = String::from("tuggareutangranser");
-    let user = spotify.user(&birdy_uri).await;
+    let user = async_client!().user(&birdy_uri).await;
     assert!(user.is_ok());
 }
 
 #[tokio::test]
 async fn test_track() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri = "spotify:track:6rqhFgbbKwnb9MLmUQDhG6";
-    let track = spotify.track(birdy_uri).await;
+    let track = async_client!().track(birdy_uri).await;
     assert!(track.is_ok());
 }
 
 #[tokio::test]
 async fn test_tracks() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
     let birdy_uri1 = "spotify:track:3n3Ppam7vgaVa1iaRUc9Lp";
     let birdy_uri2 = "spotify:track:3twNvmDtFQtAd5gMKedhLD";
     let track_uris = vec![birdy_uri1, birdy_uri2];
-    let tracks = spotify.tracks(track_uris, None).await;
+    let tracks = async_client!().tracks(track_uris, None).await;
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 async fn test_existing_playlist() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-
-    let playlist = spotify.playlist("37i9dQZF1DZ06evO45P0Eo", None, None).await;
+    let playlist = async_client!()
+        .playlist("37i9dQZF1DZ06evO45P0Eo", None, None)
+        .await;
     assert!(playlist.is_ok());
 }
 
 #[tokio::test]
 async fn test_fake_playlist() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-
-    let playlist = spotify.playlist("fake_id", None, None).await;
+    let playlist = async_client!().playlist("fake_id", None, None).await;
     assert!(!playlist.is_ok());
 }
 
 #[tokio::test]
 async fn test_add_queue() {
-    let spotify = Spotify::default()
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-
     let birdy_uri = String::from("spotify:track:6rqhFgbbKwnb9MLmUQDhG6");
-    let res = spotify.add_item_to_queue(birdy_uri, None).await;
+    let res = async_client!().add_item_to_queue(birdy_uri, None).await;
     assert!(!res.is_ok());
 }

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -14,23 +14,21 @@ lazy_static! {
         = Mutex::new(SpotifyClientCredentials::default().build());
 }
 
-macro_rules! async_client {
-    () => {
-        // Or set client_id and client_secret explictly
-        // let client_credential = SpotifyClientCredentials::default()
-        //     .client_id("this-is-my-client-id")
-        //     .client_secret("this-is-my-client-secret")
-        //     .build();
-        Spotify::default()
-            .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-            .build()
-    };
+fn async_client() -> Spotify {
+    // Or set client_id and client_secret explictly
+    // let client_credential = SpotifyClientCredentials::default()
+    //     .client_id("this-is-my-client-id")
+    //     .client_secret("this-is-my-client-secret")
+    //     .build();
+    Spotify::default()
+        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
+        .build()
 }
 
 #[tokio::test]
 async fn test_album() {
     let birdy_uri = "spotify:album:0sNOF9WDwhWunNAHPD3Baj";
-    let albums = async_client!().album(birdy_uri).await;
+    let albums = async_client().album(birdy_uri).await;
     assert!(albums.is_ok());
 }
 
@@ -40,35 +38,35 @@ async fn test_albums() {
     let birdy_uri2 = String::from("spotify:album:6JWc4iAiJ9FjyK0B59ABb4");
     let birdy_uri3 = String::from("spotify:album:6UXCm6bOO4gFlDQZV5yL37");
     let track_uris = vec![birdy_uri1, birdy_uri2, birdy_uri3];
-    let albums = async_client!().albums(track_uris).await;
+    let albums = async_client().albums(track_uris).await;
     assert!(albums.is_ok())
 }
 
 #[tokio::test]
 async fn test_album_tracks() {
     let birdy_uri = "spotify:album:6akEvsycLGftJxYudPjmqK";
-    let tracks = async_client!().album_track(birdy_uri, Some(2), None).await;
+    let tracks = async_client().album_track(birdy_uri, Some(2), None).await;
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 async fn test_artist_related_artists() {
     let birdy_uri = "spotify:artist:43ZHCT0cAZBISjO8DG9PnE";
-    let artist = async_client!().artist_related_artists(birdy_uri).await;
+    let artist = async_client().artist_related_artists(birdy_uri).await;
     assert!(artist.is_ok())
 }
 
 #[tokio::test]
 async fn test_artist() {
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let artist = async_client!().artist(birdy_uri).await;
+    let artist = async_client().artist(birdy_uri).await;
     assert!(artist.is_ok());
 }
 
 #[tokio::test]
 async fn test_artists_albums() {
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let albums = async_client!()
+    let albums = async_client()
         .artist_albums(
             birdy_uri,
             Some(AlbumType::Album),
@@ -85,14 +83,14 @@ async fn test_artists() {
     let birdy_uri1 = String::from("spotify:artist:0oSGxfWSnnOXhD2fKuz2Gy");
     let birdy_uri2 = String::from("spotify:artist:3dBVyJ7JuOMt4GE9607Qin");
     let artist_uris = vec![birdy_uri1, birdy_uri2];
-    let artists = async_client!().artists(artist_uris).await;
+    let artists = async_client().artists(artist_uris).await;
     assert!(artists.is_ok());
 }
 
 #[tokio::test]
 async fn test_artist_top_tracks() {
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-    let tracks = async_client!()
+    let tracks = async_client()
         .artist_top_tracks(birdy_uri, Country::UnitedStates)
         .await;
     assert!(tracks.is_ok());
@@ -101,14 +99,14 @@ async fn test_artist_top_tracks() {
 #[tokio::test]
 async fn test_audio_analysis() {
     let track = "06AKEBrKUckW0KREUWRnvT";
-    let analysis = async_client!().audio_analysis(track).await;
+    let analysis = async_client().audio_analysis(track).await;
     assert!(analysis.is_ok());
 }
 
 #[tokio::test]
 async fn test_audio_features() {
     let track = "spotify:track:06AKEBrKUckW0KREUWRnvT";
-    let features = async_client!().audio_features(track).await;
+    let features = async_client().audio_features(track).await;
     assert!(features.is_ok());
 }
 
@@ -119,21 +117,21 @@ async fn test_audios_features() {
     tracks_ids.push(track_id1);
     let track_id2 = String::from("spotify:track:24JygzOLM0EmRQeGtFcIcG");
     tracks_ids.push(track_id2);
-    let features = async_client!().audios_features(&tracks_ids).await;
+    let features = async_client().audios_features(&tracks_ids).await;
     assert!(features.is_ok())
 }
 
 #[tokio::test]
 async fn test_user() {
     let birdy_uri = String::from("tuggareutangranser");
-    let user = async_client!().user(&birdy_uri).await;
+    let user = async_client().user(&birdy_uri).await;
     assert!(user.is_ok());
 }
 
 #[tokio::test]
 async fn test_track() {
     let birdy_uri = "spotify:track:6rqhFgbbKwnb9MLmUQDhG6";
-    let track = async_client!().track(birdy_uri).await;
+    let track = async_client().track(birdy_uri).await;
     assert!(track.is_ok());
 }
 
@@ -142,13 +140,13 @@ async fn test_tracks() {
     let birdy_uri1 = "spotify:track:3n3Ppam7vgaVa1iaRUc9Lp";
     let birdy_uri2 = "spotify:track:3twNvmDtFQtAd5gMKedhLD";
     let track_uris = vec![birdy_uri1, birdy_uri2];
-    let tracks = async_client!().tracks(track_uris, None).await;
+    let tracks = async_client().tracks(track_uris, None).await;
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 async fn test_existing_playlist() {
-    let playlist = async_client!()
+    let playlist = async_client()
         .playlist("37i9dQZF1DZ06evO45P0Eo", None, None)
         .await;
     assert!(playlist.is_ok());
@@ -156,13 +154,13 @@ async fn test_existing_playlist() {
 
 #[tokio::test]
 async fn test_fake_playlist() {
-    let playlist = async_client!().playlist("fake_id", None, None).await;
+    let playlist = async_client().playlist("fake_id", None, None).await;
     assert!(!playlist.is_ok());
 }
 
 #[tokio::test]
 async fn test_add_queue() {
     let birdy_uri = String::from("spotify:track:6rqhFgbbKwnb9MLmUQDhG6");
-    let res = async_client!().add_item_to_queue(birdy_uri, None).await;
+    let res = async_client().add_item_to_queue(birdy_uri, None).await;
     assert!(!res.is_ok());
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -43,12 +43,19 @@ lazy_static! {
     });
 }
 
+// Even easier to use and change in the future by using a macro.
+macro_rules! async_client {
+    () => {
+        SPOTIFY
+            .get()
+            .await
+    }
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_categories() {
-    let categories = SPOTIFY
-        .get()
-        .await
+    let categories = async_client!()
         .categories(None, Some(Country::UnitedStates), 10, 0)
         .await;
     assert!(categories.is_ok());
@@ -57,13 +64,13 @@ async fn test_categories() {
 #[tokio::test]
 #[ignore]
 async fn test_current_playback() {
-    let context = SPOTIFY.get().await.current_playback(None, None).await;
+    let context = async_client!().current_playback(None, None).await;
     assert!(context.is_ok());
 }
 #[tokio::test]
 #[ignore]
 async fn test_current_playing() {
-    let context = SPOTIFY.get().await.current_playing(None, None).await;
+    let context = async_client!().current_playing(None, None).await;
     assert!(context.is_ok());
 }
 

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -47,13 +47,14 @@ lazy_static! {
 macro_rules! async_client {
     () => {
         async { SPOTIFY.get().await }
-    }
+    };
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_categories() {
-    let categories = async_client!().await
+    let categories = async_client!()
+        .await
         .categories(None, Some(Country::UnitedStates), 10, 0)
         .await;
     assert!(categories.is_ok());
@@ -76,7 +77,8 @@ async fn test_current_playing() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_followed_artists() {
-    let artists = async_client!().await
+    let artists = async_client!()
+        .await
         .current_user_followed_artists(10, None)
         .await;
     assert!(artists.is_ok())
@@ -111,7 +113,10 @@ async fn test_current_user_saved_albums_add() {
     let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
     album_ids.push(album_id2);
     album_ids.push(album_id1);
-    let result = async_client!().await.current_user_saved_albums_add(&album_ids).await;
+    let result = async_client!()
+        .await
+        .current_user_saved_albums_add(&album_ids)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -123,7 +128,10 @@ async fn test_current_user_saved_albums_delete() {
     let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
     album_ids.push(album_id2);
     album_ids.push(album_id1);
-    let result = async_client!().await.current_user_saved_albums_delete(&album_ids).await;
+    let result = async_client!()
+        .await
+        .current_user_saved_albums_delete(&album_ids)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -142,7 +150,10 @@ async fn test_current_user_saved_tracks_add() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!().await.current_user_saved_tracks_add(&tracks_ids).await;
+    let result = async_client!()
+        .await
+        .current_user_saved_tracks_add(&tracks_ids)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -154,7 +165,8 @@ async fn test_current_user_saved_tracks_contains() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .current_user_saved_tracks_contains(&tracks_ids)
         .await;
     assert!(result.is_ok());
@@ -168,7 +180,10 @@ async fn test_current_user_saved_tracks_delete() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!().await.current_user_saved_tracks_delete(&tracks_ids).await;
+    let result = async_client!()
+        .await
+        .current_user_saved_tracks_delete(&tracks_ids)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -182,7 +197,8 @@ async fn test_current_user_saved_tracks() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_artists() {
-    let artist = async_client!().await
+    let artist = async_client!()
+        .await
         .current_user_top_artists(10, 0, TimeRange::ShortTerm)
         .await;
     assert!(artist.is_ok());
@@ -191,7 +207,8 @@ async fn test_current_user_top_artists() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_tracks() {
-    let tracks = async_client!().await
+    let tracks = async_client!()
+        .await
         .current_user_top_tracks(10, 0, TimeRange::ShortTerm)
         .await;
     assert!(tracks.is_ok());
@@ -225,7 +242,10 @@ async fn test_me() {
 #[tokio::test]
 #[ignore]
 async fn test_new_releases() {
-    let albums = async_client!().await.new_releases(Some(Country::Sweden), 10, 0).await;
+    let albums = async_client!()
+        .await
+        .new_releases(Some(Country::Sweden), 10, 0)
+        .await;
     assert!(albums.is_ok());
 }
 
@@ -261,7 +281,8 @@ async fn test_recommendations() {
     let seed_tracks = vec!["0c6xIDDpzE81m2q797ordA".to_owned()];
     payload.insert("min_energy".to_owned(), 0.4.into());
     payload.insert("min_popularity".to_owned(), 50.into());
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .recommendations(
             Some(seed_artists),
             None,
@@ -277,7 +298,10 @@ async fn test_recommendations() {
 #[tokio::test]
 #[ignore]
 async fn test_repeat() {
-    let result = async_client!().await.repeat(RepeatState::Context, None).await;
+    let result = async_client!()
+        .await
+        .repeat(RepeatState::Context, None)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -285,7 +309,8 @@ async fn test_repeat() {
 #[ignore]
 async fn test_search_album() {
     let query = "album:arrival artist:abba";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .search(query, SearchType::Album, 10, 0, None, None)
         .await;
     assert!(result.is_ok());
@@ -295,7 +320,8 @@ async fn test_search_album() {
 #[ignore]
 async fn test_search_artist() {
     let query = "tania bowra";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .search(
             query,
             SearchType::Artist,
@@ -312,7 +338,8 @@ async fn test_search_artist() {
 #[ignore]
 async fn test_search_playlist() {
     let query = "\"doom metal\"";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .search(
             query,
             SearchType::Playlist,
@@ -329,7 +356,8 @@ async fn test_search_playlist() {
 #[ignore]
 async fn test_search_track() {
     let query = "abba";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .search(
             query,
             SearchType::Track,
@@ -361,7 +389,8 @@ async fn test_shuffle() {
 async fn test_start_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
     let uris = vec!["spotify:track:4iV5W9uYEdYUVa79Axb7Rh".to_owned()];
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .start_playback(Some(device_id), None, Some(uris), for_position(0), None)
         .await;
     assert!(result.is_ok());
@@ -371,7 +400,10 @@ async fn test_start_playback() {
 #[ignore]
 async fn test_transfer_playback() {
     let device_id = "74ASZWbe4lXaubB36ztrGX";
-    let result = async_client!().await.transfer_playback(device_id, true).await;
+    let result = async_client!()
+        .await
+        .transfer_playback(device_id, true)
+        .await;
     assert!(result.is_ok());
 }
 
@@ -429,7 +461,8 @@ async fn test_user_playlist_add_tracks() {
     tracks_ids.push(track_id1);
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .user_playlist_add_tracks(user_id, playlist_id, &tracks_ids, None)
         .await;
     assert!(result.is_ok());
@@ -441,7 +474,8 @@ async fn test_user_playlist_change_detail() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let playlist_name = "A New Playlist-update";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .user_playlist_change_detail(
             user_id,
             playlist_id,
@@ -464,7 +498,8 @@ async fn test_user_playlist_check_follow() {
     user_ids.push(user_id1);
     let user_id2 = String::from("elogain");
     user_ids.push(user_id2);
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .user_playlist_check_follow(owner_id, playlist_id, &user_ids)
         .await;
     assert!(result.is_ok());
@@ -475,7 +510,8 @@ async fn test_user_playlist_check_follow() {
 async fn test_user_playlist_create() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_name = "A New Playlist";
-    let playlists = async_client!().await
+    let playlists = async_client!()
+        .await
         .user_playlist_create(user_id, playlist_name, false, None)
         .await;
     assert!(playlists.is_ok());
@@ -486,7 +522,8 @@ async fn test_user_playlist_create() {
 async fn test_user_playlist_follow_playlist() {
     let owner_id = "jmperezperez";
     let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .user_playlist_follow_playlist(owner_id, playlist_id, true)
         .await;
     assert!(result.is_ok());
@@ -500,7 +537,8 @@ async fn test_user_playlist_recorder_tracks() {
     let range_start = 0;
     let insert_before = 1;
     let range_length = 1;
-    let result = async_client!().await
+    let result = async_client!()
+        .await
         .user_playlist_recorder_tracks(
             user_id,
             playlist_id,
@@ -523,13 +561,9 @@ async fn test_user_playlist_remove_all_occurrences_of_tracks() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!().await
-        .user_playlist_remove_all_occurrences_of_tracks(
-            user_id,
-            playlist_id,
-            &tracks_ids,
-            None,
-        )
+    let result = async_client!()
+        .await
+        .user_playlist_remove_all_occurrences_of_tracks(user_id, playlist_id, &tracks_ids, None)
         .await;
     assert!(result.is_ok());
 }
@@ -559,13 +593,9 @@ async fn test_user_playlist_remove_specific_occurrenes_of_tracks() {
     );
     map2.insert("position".to_string(), position2.into());
     tracks.push(map2);
-    let result = async_client!().await
-        .user_playlist_remove_specific_occurrenes_of_tracks(
-            user_id,
-            &playlist_id,
-            tracks,
-            None,
-        )
+    let result = async_client!()
+        .await
+        .user_playlist_remove_specific_occurrenes_of_tracks(user_id, &playlist_id, tracks, None)
         .await;
     assert!(result.is_ok());
 }
@@ -580,7 +610,8 @@ async fn test_user_playlist_replace_tracks() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    async_client!().await
+    async_client!()
+        .await
         .user_playlist_replace_tracks(user_id, playlist_id, &tracks_ids)
         .await
         .expect("replace tracks in a playlist failed");
@@ -592,7 +623,8 @@ async fn test_user_playlist_replace_tracks() {
 async fn test_user_playlist() {
     let user_id = "spotify";
     let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
-    let playlists = async_client!().await
+    let playlists = async_client!()
+        .await
         .user_playlist(user_id, Some(&mut playlist_id), None, None)
         .await;
     assert!(playlists.is_ok());
@@ -602,7 +634,10 @@ async fn test_user_playlist() {
 #[ignore]
 async fn test_user_playlists() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
-    let playlists = async_client!().await.user_playlists(user_id, Some(10), None).await;
+    let playlists = async_client!()
+        .await
+        .user_playlists(user_id, Some(10), None)
+        .await;
     assert!(playlists.is_ok());
 }
 
@@ -611,7 +646,8 @@ async fn test_user_playlists() {
 async fn test_user_playlist_tracks() {
     let user_id = "spotify";
     let playlist_id = String::from("spotify:playlist:59ZbFPES4DQwEjBpWHzrtC");
-    let playlists = async_client!().await
+    let playlists = async_client!()
+        .await
         .user_playlist_tracks(user_id, &playlist_id, None, Some(2), None, None)
         .await;
     assert!(playlists.is_ok());
@@ -622,7 +658,10 @@ async fn test_user_playlist_tracks() {
 async fn test_user_playlist_unfollow() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_id = "65V6djkcVRyOStLd8nza8E";
-    let result = async_client!().await.user_playlist_unfollow(user_id, playlist_id).await;
+    let result = async_client!()
+        .await
+        .user_playlist_unfollow(user_id, playlist_id)
+        .await;
     assert!(result.is_ok());
 }
 

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -45,19 +45,15 @@ lazy_static! {
 }
 
 // Even easier to use and change in the future by using a macro.
-macro_rules! async_client {
-    () => {
-        async {
-            let creds = CLIENT_CREDENTIAL.get().await;
-            Spotify::default().client_credentials_manager(creds).build()
-        }
-    };
+async fn async_client() -> Spotify {
+    let creds = CLIENT_CREDENTIAL.get().await;
+    Spotify::default().client_credentials_manager(creds).build()
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_categories() {
-    let categories = async_client!()
+    let categories = async_client()
         .await
         .categories(None, Some(Country::UnitedStates), 10, 0)
         .await;
@@ -67,21 +63,21 @@ async fn test_categories() {
 #[tokio::test]
 #[ignore]
 async fn test_current_playback() {
-    let context = async_client!().await.current_playback(None, None).await;
+    let context = async_client().await.current_playback(None, None).await;
     assert!(context.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_playing() {
-    let context = async_client!().await.current_playing(None, None).await;
+    let context = async_client().await.current_playing(None, None).await;
     assert!(context.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_followed_artists() {
-    let artists = async_client!()
+    let artists = async_client()
         .await
         .current_user_followed_artists(10, None)
         .await;
@@ -91,21 +87,21 @@ async fn test_current_user_followed_artists() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_playing_track() {
-    let playing = async_client!().await.current_user_playing_track().await;
+    let playing = async_client().await.current_user_playing_track().await;
     assert!(playing.is_ok())
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_playlists() {
-    let playlists = async_client!().await.current_user_playlists(10, None).await;
+    let playlists = async_client().await.current_user_playlists(10, None).await;
     assert!(playlists.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_recently_played() {
-    let history = async_client!().await.current_user_recently_played(10).await;
+    let history = async_client().await.current_user_recently_played(10).await;
     assert!(history.is_ok());
 }
 
@@ -117,7 +113,7 @@ async fn test_current_user_saved_albums_add() {
     let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
     album_ids.push(album_id2);
     album_ids.push(album_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .current_user_saved_albums_add(&album_ids)
         .await;
@@ -132,7 +128,7 @@ async fn test_current_user_saved_albums_delete() {
     let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
     album_ids.push(album_id2);
     album_ids.push(album_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .current_user_saved_albums_delete(&album_ids)
         .await;
@@ -142,7 +138,7 @@ async fn test_current_user_saved_albums_delete() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_albums() {
-    let albums = async_client!().await.current_user_saved_albums(10, 0).await;
+    let albums = async_client().await.current_user_saved_albums(10, 0).await;
     assert!(albums.is_ok());
 }
 
@@ -154,7 +150,7 @@ async fn test_current_user_saved_tracks_add() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .current_user_saved_tracks_add(&tracks_ids)
         .await;
@@ -169,7 +165,7 @@ async fn test_current_user_saved_tracks_contains() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .current_user_saved_tracks_contains(&tracks_ids)
         .await;
@@ -184,7 +180,7 @@ async fn test_current_user_saved_tracks_delete() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .current_user_saved_tracks_delete(&tracks_ids)
         .await;
@@ -194,14 +190,14 @@ async fn test_current_user_saved_tracks_delete() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_tracks() {
-    let tracks = async_client!().await.current_user_saved_tracks(10, 0).await;
+    let tracks = async_client().await.current_user_saved_tracks(10, 0).await;
     assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_artists() {
-    let artist = async_client!()
+    let artist = async_client()
         .await
         .current_user_top_artists(10, 0, TimeRange::ShortTerm)
         .await;
@@ -211,7 +207,7 @@ async fn test_current_user_top_artists() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_tracks() {
-    let tracks = async_client!()
+    let tracks = async_client()
         .await
         .current_user_top_tracks(10, 0, TimeRange::ShortTerm)
         .await;
@@ -221,7 +217,7 @@ async fn test_current_user_top_tracks() {
 #[tokio::test]
 #[ignore]
 async fn test_device() {
-    let devices = async_client!().await.device().await;
+    let devices = async_client().await.device().await;
     assert!(devices.is_ok());
 }
 
@@ -229,7 +225,7 @@ async fn test_device() {
 #[ignore]
 async fn test_featured_playlists() {
     let now: DateTime<Utc> = Utc::now();
-    let playlists = async_client!()
+    let playlists = async_client()
         .await
         .featured_playlists(None, None, Some(now), 10, 0)
         .await;
@@ -239,14 +235,14 @@ async fn test_featured_playlists() {
 #[tokio::test]
 #[ignore]
 async fn test_me() {
-    let user = async_client!().await.me().await;
+    let user = async_client().await.me().await;
     assert!(user.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_new_releases() {
-    let albums = async_client!()
+    let albums = async_client()
         .await
         .new_releases(Some(Country::Sweden), 10, 0)
         .await;
@@ -257,7 +253,7 @@ async fn test_new_releases() {
 #[ignore]
 async fn test_next_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-    let result = async_client!().await.next_track(Some(device_id)).await;
+    let result = async_client().await.next_track(Some(device_id)).await;
     assert!(result.is_ok());
 }
 
@@ -265,7 +261,7 @@ async fn test_next_playback() {
 #[ignore]
 async fn test_pause_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-    let result = async_client!().await.pause_playback(Some(device_id)).await;
+    let result = async_client().await.pause_playback(Some(device_id)).await;
     assert!(result.is_ok());
 }
 
@@ -273,7 +269,7 @@ async fn test_pause_playback() {
 #[ignore]
 async fn test_previous_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-    let result = async_client!().await.previous_track(Some(device_id)).await;
+    let result = async_client().await.previous_track(Some(device_id)).await;
     assert!(result.is_ok());
 }
 
@@ -285,7 +281,7 @@ async fn test_recommendations() {
     let seed_tracks = vec!["0c6xIDDpzE81m2q797ordA".to_owned()];
     payload.insert("min_energy".to_owned(), 0.4.into());
     payload.insert("min_popularity".to_owned(), 50.into());
-    let result = async_client!()
+    let result = async_client()
         .await
         .recommendations(
             Some(seed_artists),
@@ -302,7 +298,7 @@ async fn test_recommendations() {
 #[tokio::test]
 #[ignore]
 async fn test_repeat() {
-    let result = async_client!()
+    let result = async_client()
         .await
         .repeat(RepeatState::Context, None)
         .await;
@@ -313,7 +309,7 @@ async fn test_repeat() {
 #[ignore]
 async fn test_search_album() {
     let query = "album:arrival artist:abba";
-    let result = async_client!()
+    let result = async_client()
         .await
         .search(query, SearchType::Album, 10, 0, None, None)
         .await;
@@ -324,7 +320,7 @@ async fn test_search_album() {
 #[ignore]
 async fn test_search_artist() {
     let query = "tania bowra";
-    let result = async_client!()
+    let result = async_client()
         .await
         .search(
             query,
@@ -342,7 +338,7 @@ async fn test_search_artist() {
 #[ignore]
 async fn test_search_playlist() {
     let query = "\"doom metal\"";
-    let result = async_client!()
+    let result = async_client()
         .await
         .search(
             query,
@@ -360,7 +356,7 @@ async fn test_search_playlist() {
 #[ignore]
 async fn test_search_track() {
     let query = "abba";
-    let result = async_client!()
+    let result = async_client()
         .await
         .search(
             query,
@@ -377,14 +373,14 @@ async fn test_search_track() {
 #[tokio::test]
 #[ignore]
 async fn test_seek_track() {
-    let result = async_client!().await.seek_track(25000, None).await;
+    let result = async_client().await.seek_track(25000, None).await;
     assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_shuffle() {
-    let result = async_client!().await.shuffle(true, None).await;
+    let result = async_client().await.shuffle(true, None).await;
     assert!(result.is_ok());
 }
 
@@ -393,7 +389,7 @@ async fn test_shuffle() {
 async fn test_start_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
     let uris = vec!["spotify:track:4iV5W9uYEdYUVa79Axb7Rh".to_owned()];
-    let result = async_client!()
+    let result = async_client()
         .await
         .start_playback(Some(device_id), None, Some(uris), for_position(0), None)
         .await;
@@ -404,7 +400,7 @@ async fn test_start_playback() {
 #[ignore]
 async fn test_transfer_playback() {
     let device_id = "74ASZWbe4lXaubB36ztrGX";
-    let result = async_client!()
+    let result = async_client()
         .await
         .transfer_playback(device_id, true)
         .await;
@@ -419,7 +415,7 @@ async fn test_user_follow_artist() {
     let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
     artists.push(artist_id2);
     artists.push(artist_id1);
-    let result = async_client!().await.user_follow_artists(&artists).await;
+    let result = async_client().await.user_follow_artists(&artists).await;
     assert!(result.is_ok());
 }
 
@@ -431,7 +427,7 @@ async fn test_user_unfollow_artist() {
     let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
     artists.push(artist_id2);
     artists.push(artist_id1);
-    let result = async_client!().await.user_unfollow_artists(&artists).await;
+    let result = async_client().await.user_unfollow_artists(&artists).await;
     assert!(result.is_ok());
 }
 
@@ -441,7 +437,7 @@ async fn test_user_follow_users() {
     let mut users = vec![];
     let user_id1 = String::from("exampleuser01");
     users.push(user_id1);
-    let result = async_client!().await.user_follow_users(&users).await;
+    let result = async_client().await.user_follow_users(&users).await;
     assert!(result.is_ok());
 }
 
@@ -451,7 +447,7 @@ async fn test_user_unfollow_users() {
     let mut users = vec![];
     let user_id1 = String::from("exampleuser01");
     users.push(user_id1);
-    let result = async_client!().await.user_unfollow_users(&users).await;
+    let result = async_client().await.user_unfollow_users(&users).await;
     assert!(result.is_ok());
 }
 
@@ -465,7 +461,7 @@ async fn test_user_playlist_add_tracks() {
     tracks_ids.push(track_id1);
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_add_tracks(user_id, playlist_id, &tracks_ids, None)
         .await;
@@ -478,7 +474,7 @@ async fn test_user_playlist_change_detail() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let playlist_name = "A New Playlist-update";
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_change_detail(
             user_id,
@@ -502,7 +498,7 @@ async fn test_user_playlist_check_follow() {
     user_ids.push(user_id1);
     let user_id2 = String::from("elogain");
     user_ids.push(user_id2);
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_check_follow(owner_id, playlist_id, &user_ids)
         .await;
@@ -514,7 +510,7 @@ async fn test_user_playlist_check_follow() {
 async fn test_user_playlist_create() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_name = "A New Playlist";
-    let playlists = async_client!()
+    let playlists = async_client()
         .await
         .user_playlist_create(user_id, playlist_name, false, None)
         .await;
@@ -526,7 +522,7 @@ async fn test_user_playlist_create() {
 async fn test_user_playlist_follow_playlist() {
     let owner_id = "jmperezperez";
     let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_follow_playlist(owner_id, playlist_id, true)
         .await;
@@ -541,7 +537,7 @@ async fn test_user_playlist_recorder_tracks() {
     let range_start = 0;
     let insert_before = 1;
     let range_length = 1;
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_recorder_tracks(
             user_id,
@@ -565,7 +561,7 @@ async fn test_user_playlist_remove_all_occurrences_of_tracks() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_remove_all_occurrences_of_tracks(user_id, playlist_id, &tracks_ids, None)
         .await;
@@ -597,7 +593,7 @@ async fn test_user_playlist_remove_specific_occurrenes_of_tracks() {
     );
     map2.insert("position".to_string(), position2.into());
     tracks.push(map2);
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_remove_specific_occurrenes_of_tracks(user_id, &playlist_id, tracks, None)
         .await;
@@ -614,7 +610,7 @@ async fn test_user_playlist_replace_tracks() {
     let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
     tracks_ids.push(track_id2);
     tracks_ids.push(track_id1);
-    async_client!()
+    async_client()
         .await
         .user_playlist_replace_tracks(user_id, playlist_id, &tracks_ids)
         .await
@@ -627,7 +623,7 @@ async fn test_user_playlist_replace_tracks() {
 async fn test_user_playlist() {
     let user_id = "spotify";
     let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
-    let playlists = async_client!()
+    let playlists = async_client()
         .await
         .user_playlist(user_id, Some(&mut playlist_id), None, None)
         .await;
@@ -638,7 +634,7 @@ async fn test_user_playlist() {
 #[ignore]
 async fn test_user_playlists() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
-    let playlists = async_client!()
+    let playlists = async_client()
         .await
         .user_playlists(user_id, Some(10), None)
         .await;
@@ -650,7 +646,7 @@ async fn test_user_playlists() {
 async fn test_user_playlist_tracks() {
     let user_id = "spotify";
     let playlist_id = String::from("spotify:playlist:59ZbFPES4DQwEjBpWHzrtC");
-    let playlists = async_client!()
+    let playlists = async_client()
         .await
         .user_playlist_tracks(user_id, &playlist_id, None, Some(2), None, None)
         .await;
@@ -662,7 +658,7 @@ async fn test_user_playlist_tracks() {
 async fn test_user_playlist_unfollow() {
     let user_id = "2257tjys2e2u2ygfke42niy2q";
     let playlist_id = "65V6djkcVRyOStLd8nza8E";
-    let result = async_client!()
+    let result = async_client()
         .await
         .user_playlist_unfollow(user_id, playlist_id)
         .await;
@@ -672,6 +668,6 @@ async fn test_user_playlist_unfollow() {
 #[tokio::test]
 #[ignore]
 async fn test_volume() {
-    let result = async_client!().await.volume(78, None).await;
+    let result = async_client().await.volume(78, None).await;
     assert!(result.is_ok());
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -46,16 +46,14 @@ lazy_static! {
 // Even easier to use and change in the future by using a macro.
 macro_rules! async_client {
     () => {
-        SPOTIFY
-            .get()
-            .await
+        async { SPOTIFY.get().await }
     }
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_categories() {
-    let categories = async_client!()
+    let categories = async_client!().await
         .categories(None, Some(Country::UnitedStates), 10, 0)
         .await;
     assert!(categories.is_ok());
@@ -64,22 +62,21 @@ async fn test_categories() {
 #[tokio::test]
 #[ignore]
 async fn test_current_playback() {
-    let context = async_client!().current_playback(None, None).await;
+    let context = async_client!().await.current_playback(None, None).await;
     assert!(context.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_current_playing() {
-    let context = async_client!().current_playing(None, None).await;
+    let context = async_client!().await.current_playing(None, None).await;
     assert!(context.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_followed_artists() {
-    let artists = SPOTIFY
-        .get()
-        .await
+    let artists = async_client!().await
         .current_user_followed_artists(10, None)
         .await;
     assert!(artists.is_ok())
@@ -88,1158 +85,550 @@ async fn test_current_user_followed_artists() {
 #[tokio::test]
 #[ignore]
 async fn test_current_user_playing_track() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-read-currently-playing user-read-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let playing = spotify.current_user_playing_track().await;
-            assert!(playing.is_ok())
-        }
-        None => assert!(false),
-    };
+    let playing = async_client!().await.current_user_playing_track().await;
+    assert!(playing.is_ok())
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_playlists() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-read-private")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let playlists = spotify.current_user_playlists(10, None).await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let playlists = async_client!().await.current_user_playlists(10, None).await;
+    assert!(playlists.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_current_user_recently_played() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-read-recently-played")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let history = spotify.current_user_recently_played(10).await;
-            assert!(history.is_ok());
-        }
-        None => assert!(false),
-    };
+    let history = async_client!().await.current_user_recently_played(10).await;
+    assert!(history.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_albums_add() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut album_ids = vec![];
-            let album_id1 = String::from("6akEvsycLGftJxYudPjmqK");
-            let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
-            album_ids.push(album_id2);
-            album_ids.push(album_id1);
-            let result = spotify.current_user_saved_albums_add(&album_ids).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut album_ids = vec![];
+    let album_id1 = String::from("6akEvsycLGftJxYudPjmqK");
+    let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
+    album_ids.push(album_id2);
+    album_ids.push(album_id1);
+    let result = async_client!().await.current_user_saved_albums_add(&album_ids).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_albums_delete() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut album_ids = vec![];
-            let album_id1 = String::from("6akEvsycLGftJxYudPjmqK");
-            let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
-            album_ids.push(album_id2);
-            album_ids.push(album_id1);
-            let result = spotify.current_user_saved_albums_delete(&album_ids).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut album_ids = vec![];
+    let album_id1 = String::from("6akEvsycLGftJxYudPjmqK");
+    let album_id2 = String::from("628oezqK2qfmCjC6eXNors");
+    album_ids.push(album_id2);
+    album_ids.push(album_id1);
+    let result = async_client!().await.current_user_saved_albums_delete(&album_ids).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_albums() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let albums = spotify.current_user_saved_albums(10, 0).await;
-            assert!(albums.is_ok());
-        }
-        None => assert!(false),
-    };
+    let albums = async_client!().await.current_user_saved_albums(10, 0).await;
+    assert!(albums.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_tracks_add() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            tracks_ids.push(track_id1);
-            let result = spotify.current_user_saved_tracks_add(&tracks_ids).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    tracks_ids.push(track_id1);
+    let result = async_client!().await.current_user_saved_tracks_add(&tracks_ids).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_tracks_contains() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            tracks_ids.push(track_id1);
-            let result = spotify
-                .current_user_saved_tracks_contains(&tracks_ids)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    tracks_ids.push(track_id1);
+    let result = async_client!().await
+        .current_user_saved_tracks_contains(&tracks_ids)
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_tracks_delete() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            tracks_ids.push(track_id1);
-            let result = spotify.current_user_saved_tracks_delete(&tracks_ids).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    tracks_ids.push(track_id1);
+    let result = async_client!().await.current_user_saved_tracks_delete(&tracks_ids).await;
+    assert!(result.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_current_user_saved_tracks() {
-    let mut oauth = SpotifyOAuth::default().scope("user-library-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let tracks = spotify.current_user_saved_tracks(10, 0).await;
-            assert!(tracks.is_ok());
-        }
-        None => assert!(false),
-    }
+    let tracks = async_client!().await.current_user_saved_tracks(10, 0).await;
+    assert!(tracks.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_artists() {
-    let mut oauth = SpotifyOAuth::default().scope("user-top-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let artist = spotify
-                .current_user_top_artists(10, 0, TimeRange::ShortTerm)
-                .await;
-            assert!(artist.is_ok());
-        }
-        None => assert!(false),
-    };
+    let artist = async_client!().await
+        .current_user_top_artists(10, 0, TimeRange::ShortTerm)
+        .await;
+    assert!(artist.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_current_user_top_tracks() {
-    let mut oauth = SpotifyOAuth::default().scope("user-top-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let tracks = spotify
-                .current_user_top_tracks(10, 0, TimeRange::ShortTerm)
-                .await;
-            assert!(tracks.is_ok());
-        }
-        None => assert!(false),
-    };
+    let tracks = async_client!().await
+        .current_user_top_tracks(10, 0, TimeRange::ShortTerm)
+        .await;
+    assert!(tracks.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_device() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-read-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let devices = spotify.device().await;
-            assert!(devices.is_ok());
-        }
-        None => assert!(false),
-    };
+    let devices = async_client!().await.device().await;
+    assert!(devices.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_featured_playlists() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-
-            let now: DateTime<Utc> = Utc::now();
-            let playlists = spotify
-                .featured_playlists(None, None, Some(now), 10, 0)
-                .await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let now: DateTime<Utc> = Utc::now();
+    let playlists = async_client!()
+        .await
+        .featured_playlists(None, None, Some(now), 10, 0)
+        .await;
+    assert!(playlists.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_me() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-read-birthdate user-read-private user-read-email")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user = spotify.me().await;
-            assert!(user.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user = async_client!().await.me().await;
+    assert!(user.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_new_releases() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-read").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-
-            let albums = spotify.new_releases(Some(Country::Sweden), 10, 0).await;
-            assert!(albums.is_ok());
-        }
-        None => assert!(false),
-    };
+    let albums = async_client!().await.new_releases(Some(Country::Sweden), 10, 0).await;
+    assert!(albums.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_next_playback() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-            let result = spotify.next_track(Some(device_id)).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let result = async_client!().await.next_track(Some(device_id)).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_pause_playback() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-            let result = spotify.pause_playback(Some(device_id)).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let result = async_client!().await.pause_playback(Some(device_id)).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_previous_playback() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-            let result = spotify.previous_track(Some(device_id)).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let result = async_client!().await.previous_track(Some(device_id)).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_recommendations() {
-    let mut oauth = SpotifyOAuth::default().scope("user-read-private").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut payload = Map::new();
-            let seed_artists = vec!["4NHQUGzhtTLFvgF5SZesLK".to_owned()];
-            let seed_tracks = vec!["0c6xIDDpzE81m2q797ordA".to_owned()];
-            payload.insert("min_energy".to_owned(), 0.4.into());
-            payload.insert("min_popularity".to_owned(), 50.into());
-            let result = spotify
-                .recommendations(
-                    Some(seed_artists),
-                    None,
-                    Some(seed_tracks),
-                    10,
-                    Some(Country::UnitedStates),
-                    &payload,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut payload = Map::new();
+    let seed_artists = vec!["4NHQUGzhtTLFvgF5SZesLK".to_owned()];
+    let seed_tracks = vec!["0c6xIDDpzE81m2q797ordA".to_owned()];
+    payload.insert("min_energy".to_owned(), 0.4.into());
+    payload.insert("min_popularity".to_owned(), 50.into());
+    let result = async_client!().await
+        .recommendations(
+            Some(seed_artists),
+            None,
+            Some(seed_tracks),
+            10,
+            Some(Country::UnitedStates),
+            &payload,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_repeat() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let result = spotify.repeat(RepeatState::Context, None).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let result = async_client!().await.repeat(RepeatState::Context, None).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_search_album() {
-    let mut oauth = SpotifyOAuth::default().scope("user-read-private").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let query = "album:arrival artist:abba";
-            let result = spotify
-                .search(query, SearchType::Album, 10, 0, None, None)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let query = "album:arrival artist:abba";
+    let result = async_client!().await
+        .search(query, SearchType::Album, 10, 0, None, None)
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_search_artist() {
-    let mut oauth = SpotifyOAuth::default().scope("user-read-private").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let query = "tania bowra";
-            let result = spotify
-                .search(
-                    query,
-                    SearchType::Artist,
-                    10,
-                    0,
-                    Some(Country::UnitedStates),
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let query = "tania bowra";
+    let result = async_client!().await
+        .search(
+            query,
+            SearchType::Artist,
+            10,
+            0,
+            Some(Country::UnitedStates),
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_search_playlist() {
-    let mut oauth = SpotifyOAuth::default().scope("user-read-private").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let query = "\"doom metal\"";
-            let result = spotify
-                .search(
-                    query,
-                    SearchType::Playlist,
-                    10,
-                    0,
-                    Some(Country::UnitedStates),
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let query = "\"doom metal\"";
+    let result = async_client!().await
+        .search(
+            query,
+            SearchType::Playlist,
+            10,
+            0,
+            Some(Country::UnitedStates),
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_search_track() {
-    let mut oauth = SpotifyOAuth::default().scope("user-read-private").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let query = "abba";
-            let result = spotify
-                .search(
-                    query,
-                    SearchType::Track,
-                    10,
-                    0,
-                    Some(Country::UnitedStates),
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let query = "abba";
+    let result = async_client!().await
+        .search(
+            query,
+            SearchType::Track,
+            10,
+            0,
+            Some(Country::UnitedStates),
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_seek_track() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let result = spotify.seek_track(25000, None).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let result = async_client!().await.seek_track(25000, None).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_shuffle() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let result = spotify.shuffle(true, None).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let result = async_client!().await.shuffle(true, None).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_start_playback() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
-            let uris = vec!["spotify:track:4iV5W9uYEdYUVa79Axb7Rh".to_owned()];
-            let result = spotify
-                .start_playback(Some(device_id), None, Some(uris), for_position(0), None)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let uris = vec!["spotify:track:4iV5W9uYEdYUVa79Axb7Rh".to_owned()];
+    let result = async_client!().await
+        .start_playback(Some(device_id), None, Some(uris), for_position(0), None)
+        .await;
+    assert!(result.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_transfer_playback() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let device_id = "74ASZWbe4lXaubB36ztrGX";
-            let result = spotify.transfer_playback(device_id, true).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let device_id = "74ASZWbe4lXaubB36ztrGX";
+    let result = async_client!().await.transfer_playback(device_id, true).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_follow_artist() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut artists = vec![];
-            let artist_id1 = String::from("74ASZWbe4lXaubB36ztrGX");
-            let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
-            artists.push(artist_id2);
-            artists.push(artist_id1);
-            let result = spotify.user_follow_artists(&artists).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut artists = vec![];
+    let artist_id1 = String::from("74ASZWbe4lXaubB36ztrGX");
+    let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
+    artists.push(artist_id2);
+    artists.push(artist_id1);
+    let result = async_client!().await.user_follow_artists(&artists).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_unfollow_artist() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut artists = vec![];
-            let artist_id1 = String::from("74ASZWbe4lXaubB36ztrGX");
-            let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
-            artists.push(artist_id2);
-            artists.push(artist_id1);
-            let result = spotify.user_unfollow_artists(&artists).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut artists = vec![];
+    let artist_id1 = String::from("74ASZWbe4lXaubB36ztrGX");
+    let artist_id2 = String::from("08td7MxkoHQkXnWAYD8d6Q");
+    artists.push(artist_id2);
+    artists.push(artist_id1);
+    let result = async_client!().await.user_unfollow_artists(&artists).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_follow_users() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut users = vec![];
-            let user_id1 = String::from("exampleuser01");
-            users.push(user_id1);
-            let result = spotify.user_follow_users(&users).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut users = vec![];
+    let user_id1 = String::from("exampleuser01");
+    users.push(user_id1);
+    let result = async_client!().await.user_follow_users(&users).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_unfollow_users() {
-    let mut oauth = SpotifyOAuth::default().scope("user-follow-modify").build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let mut users = vec![];
-            let user_id1 = String::from("exampleuser01");
-            users.push(user_id1);
-            let result = spotify.user_unfollow_users(&users).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let mut users = vec![];
+    let user_id1 = String::from("exampleuser01");
+    users.push(user_id1);
+    let result = async_client!().await.user_unfollow_users(&users).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_add_tracks() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            tracks_ids.push(track_id1);
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            let result = spotify
-                .user_playlist_add_tracks(user_id, playlist_id, &tracks_ids, None)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    tracks_ids.push(track_id1);
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    let result = async_client!().await
+        .user_playlist_add_tracks(user_id, playlist_id, &tracks_ids, None)
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_change_detail() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
-            let playlist_name = "A New Playlist-update";
-            let result = spotify
-                .user_playlist_change_detail(
-                    user_id,
-                    playlist_id,
-                    Some(playlist_name),
-                    Some(false),
-                    None,
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
+    let playlist_name = "A New Playlist-update";
+    let result = async_client!().await
+        .user_playlist_change_detail(
+            user_id,
+            playlist_id,
+            Some(playlist_name),
+            Some(false),
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_check_follow() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let owner_id = "jmperezperez";
-            let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
-            let mut user_ids: Vec<String> = vec![];
-            let user_id1 = String::from("possan");
-            user_ids.push(user_id1);
-            let user_id2 = String::from("elogain");
-            user_ids.push(user_id2);
-            let result = spotify
-                .user_playlist_check_follow(owner_id, playlist_id, &user_ids)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let owner_id = "jmperezperez";
+    let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
+    let mut user_ids: Vec<String> = vec![];
+    let user_id1 = String::from("possan");
+    user_ids.push(user_id1);
+    let user_id2 = String::from("elogain");
+    user_ids.push(user_id2);
+    let result = async_client!().await
+        .user_playlist_check_follow(owner_id, playlist_id, &user_ids)
+        .await;
+    assert!(result.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_create() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_name = "A New Playlist";
-            let playlists = spotify
-                .user_playlist_create(user_id, playlist_name, false, None)
-                .await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_name = "A New Playlist";
+    let playlists = async_client!().await
+        .user_playlist_create(user_id, playlist_name, false, None)
+        .await;
+    assert!(playlists.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_follow_playlist() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let owner_id = "jmperezperez";
-            let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
-            let result = spotify
-                .user_playlist_follow_playlist(owner_id, playlist_id, true)
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let owner_id = "jmperezperez";
+    let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
+    let result = async_client!().await
+        .user_playlist_follow_playlist(owner_id, playlist_id, true)
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_recorder_tracks() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
-            let range_start = 0;
-            let insert_before = 1;
-            let range_length = 1;
-            let result = spotify
-                .user_playlist_recorder_tracks(
-                    user_id,
-                    playlist_id,
-                    range_start,
-                    range_length,
-                    insert_before,
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
+    let range_start = 0;
+    let insert_before = 1;
+    let range_length = 1;
+    let result = async_client!().await
+        .user_playlist_recorder_tracks(
+            user_id,
+            playlist_id,
+            range_start,
+            range_length,
+            insert_before,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_remove_all_occurrences_of_tracks() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            tracks_ids.push(track_id1);
-            let result = spotify
-                .user_playlist_remove_all_occurrences_of_tracks(
-                    user_id,
-                    playlist_id,
-                    &tracks_ids,
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    tracks_ids.push(track_id1);
+    let result = async_client!().await
+        .user_playlist_remove_all_occurrences_of_tracks(
+            user_id,
+            playlist_id,
+            &tracks_ids,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_remove_specific_occurrenes_of_tracks() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = String::from("5jAOgWXCBKuinsGiZxjDQ5");
-            let mut tracks = vec![];
-            let mut map1 = Map::new();
-            let mut position1 = vec![];
-            position1.push(0);
-            position1.push(3);
-            map1.insert(
-                "uri".to_string(),
-                "spotify:track:4iV5W9uYEdYUVa79Axb7Rh".into(),
-            );
-            map1.insert("position".to_string(), position1.into());
-            tracks.push(map1);
-            let mut map2 = Map::new();
-            let mut position2 = vec![];
-            position2.push(7);
-            map2.insert(
-                "uri".to_string(),
-                "spotify:track:1301WleyT98MSxVHPZCA6M".into(),
-            );
-            map2.insert("position".to_string(), position2.into());
-            tracks.push(map2);
-            let result = spotify
-                .user_playlist_remove_specific_occurrenes_of_tracks(
-                    user_id,
-                    &playlist_id,
-                    tracks,
-                    None,
-                )
-                .await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = String::from("5jAOgWXCBKuinsGiZxjDQ5");
+    let mut tracks = vec![];
+    let mut map1 = Map::new();
+    let mut position1 = vec![];
+    position1.push(0);
+    position1.push(3);
+    map1.insert(
+        "uri".to_string(),
+        "spotify:track:4iV5W9uYEdYUVa79Axb7Rh".into(),
+    );
+    map1.insert("position".to_string(), position1.into());
+    tracks.push(map1);
+    let mut map2 = Map::new();
+    let mut position2 = vec![];
+    position2.push(7);
+    map2.insert(
+        "uri".to_string(),
+        "spotify:track:1301WleyT98MSxVHPZCA6M".into(),
+    );
+    map2.insert("position".to_string(), position2.into());
+    tracks.push(map2);
+    let result = async_client!().await
+        .user_playlist_remove_specific_occurrenes_of_tracks(
+            user_id,
+            &playlist_id,
+            tracks,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_replace_tracks() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
-            let mut tracks_ids = vec![];
-            let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
-            let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
-            tracks_ids.push(track_id2);
-            tracks_ids.push(track_id1);
-            spotify
-                .user_playlist_replace_tracks(user_id, playlist_id, &tracks_ids)
-                .await
-                .expect("replace tracks in a playlist failed");
-            assert!(true);
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
+    let mut tracks_ids = vec![];
+    let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
+    let track_id2 = String::from("spotify:track:1301WleyT98MSxVHPZCA6M");
+    tracks_ids.push(track_id2);
+    tracks_ids.push(track_id1);
+    async_client!().await
+        .user_playlist_replace_tracks(user_id, playlist_id, &tracks_ids)
+        .await
+        .expect("replace tracks in a playlist failed");
+    assert!(true);
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist() {
-    let mut spotify_oauth = SpotifyOAuth::default().build();
-    match get_token(&mut spotify_oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "spotify";
-            let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
-            let playlists = spotify
-                .user_playlist(user_id, Some(&mut playlist_id), None, None)
-                .await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "spotify";
+    let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
+    let playlists = async_client!().await
+        .user_playlist(user_id, Some(&mut playlist_id), None, None)
+        .await;
+    assert!(playlists.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlists() {
-    let mut spotify_oauth = SpotifyOAuth::default()
-        .scope("playlist-read-private, playlist-read-collaborative")
-        .build();
-    match get_token(&mut spotify_oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlists = spotify.user_playlists(user_id, Some(10), None).await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlists = async_client!().await.user_playlists(user_id, Some(10), None).await;
+    assert!(playlists.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_tracks() {
-    let mut spotify_oauth = SpotifyOAuth::default().build();
-    match get_token(&mut spotify_oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "spotify";
-            let playlist_id = String::from("spotify:playlist:59ZbFPES4DQwEjBpWHzrtC");
-            let playlists = spotify
-                .user_playlist_tracks(user_id, &playlist_id, None, Some(2), None, None)
-                .await;
-            assert!(playlists.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "spotify";
+    let playlist_id = String::from("spotify:playlist:59ZbFPES4DQwEjBpWHzrtC");
+    let playlists = async_client!().await
+        .user_playlist_tracks(user_id, &playlist_id, None, Some(2), None, None)
+        .await;
+    assert!(playlists.is_ok());
 }
+
 #[tokio::test]
 #[ignore]
 async fn test_user_playlist_unfollow() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("playlist-modify-private playlist-modify-public")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let user_id = "2257tjys2e2u2ygfke42niy2q";
-            let playlist_id = "65V6djkcVRyOStLd8nza8E";
-            let result = spotify.user_playlist_unfollow(user_id, playlist_id).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let user_id = "2257tjys2e2u2ygfke42niy2q";
+    let playlist_id = "65V6djkcVRyOStLd8nza8E";
+    let result = async_client!().await.user_playlist_unfollow(user_id, playlist_id).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_volume() {
-    let mut oauth = SpotifyOAuth::default()
-        .scope("user-modify-playback-state")
-        .build();
-    match get_token(&mut oauth).await {
-        Some(token_info) => {
-            let client_credential = SpotifyClientCredentials::default()
-                .token_info(token_info)
-                .build();
-            let spotify = Spotify::default()
-                .client_credentials_manager(client_credential)
-                .build();
-            let result = spotify.volume(78, None).await;
-            assert!(result.is_ok());
-        }
-        None => assert!(false),
-    };
+    let result = async_client!().await.volume(78, None).await;
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
**test_device:** Not sure what that's for. Can it be removed?
**test_with_credential:** Just a function to reduce the boilerplate a bit.
**test_oauth:** This creates a single spotify client so that it can be used from each test. This way, you don't have to open a browser tab for each test, and there's much less copy-pasted code. This is specially useful in case we figure out how to run these tests on Travis, because it'll be very easy to change the authentication process.