### PR TITLE
Replace failure with anyhow and thiserror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `dotenv` support is now optional. You can enable it with the `env-file` feature to have the same behavior as before ([#108](https://github.com/ramsayleung/rspotify/issues/108)).
 - Renamed environmental variables to `RSPOTIFY_CLIENT_ID`, `RSPOTIFY_CLIENT_SECRET` and `RSPOTIFY_REDIRECT_URI` to avoid name collisions with other libraries that use OAuth2 ([#118](https://github.com/ramsayleung/rspotify/issues/118)).
 - Fix typo in `user_playlist_remove_specific_occurrenes_of_tracks`, now it's `user_playlist_remove_specific_occurrences_of_tracks`.
+- All fallible calls in the client return a `ClientError` rather than using `failure`.
 
 ## 0.10 (2020/07/01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.13", features = ["serde", "rustc-serialize"] }
 dotenv = { version = "0.15.0", optional = true }
-failure = "0.1.8"
 lazy_static = "1.4.0"
 log = "0.4.11"
 percent-encoding = "2.1.0"
@@ -22,6 +21,7 @@ reqwest = { version = "0.10.7", features = ["json", "socks"], default-features =
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 webbrowser = { version = "0.5.5", optional = true }
+thiserror = "1.0.20"
 
 [dev-dependencies]
 async_once = { version = "0.1.0", features = ["tokio"] }


### PR DESCRIPTION
As described in #122 , `failure` is deprecated. This replaces it with anyhow and thiserror.

Closes #122