### PR TITLE
Fix playlist related endpoints

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -896,21 +896,16 @@ impl Spotify {
     /// Add the current authenticated user as a follower of a playlist.
     ///
     /// Parameters:
-    /// - playlist_owner_id - the user id of the playlist owner
     /// - playlist_id - the id of the playlist
     ///
     /// [Reference](https://developer.spotify.com/web-api/follow-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_follow_playlist<P: Into<Option<bool>>>(
+    pub async fn playlist_follow<P: Into<Option<bool>>>(
         &self,
-        playlist_owner_id: &str,
         playlist_id: &str,
         public: P,
     ) -> ClientResult<()> {
-        let url = format!(
-            "users/{}/playlists/{}/followers",
-            playlist_owner_id, playlist_id
-        );
+        let url = format!("playlists/{}/followers", playlist_id);
 
         self.put(
             &url,

--- a/src/client.rs
+++ b/src/client.rs
@@ -799,16 +799,14 @@ impl Spotify {
     /// Removes all occurrences of the given tracks from the given playlist.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     /// - track_ids - the list of track ids to add to the playlist
     /// - snapshot_id - optional id of the playlist snapshot
     ///
     /// [Reference](https://developer.spotify.com/web-api/remove-tracks-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_remove_all_occurrences_of_tracks(
+    pub async fn playlist_remove_all_occurrences_of_tracks(
         &self,
-        user_id: &str,
         playlist_id: &str,
         track_ids: &[String],
         snapshot_id: Option<String>,
@@ -830,7 +828,7 @@ impl Spotify {
         if let Some(snapshot_id) = snapshot_id {
             json_insert!(params, "snapshot_id", snapshot_id);
         }
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         let result = self.delete(&url, None, &params).await?;
         self.convert_result(&result)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -743,9 +743,8 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/replace-playlists-tracks/)
     #[maybe_async]
-    pub async fn user_playlist_replace_tracks(
+    pub async fn playlist_replace_tracks(
         &self,
-        user_id: &str,
         playlist_id: &str,
         track_ids: &[String],
     ) -> ClientResult<()> {
@@ -757,7 +756,7 @@ impl Spotify {
         // let mut params = Map::new();
         // params.insert("uris".to_owned(), uris.into());
         let params = json!({ "uris": uris });
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         self.put(&url, None, &params).await?;
 
         Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -836,7 +836,6 @@ impl Spotify {
     /// Removes specfic occurrences of the given tracks from the given playlist.
     ///
     /// Parameters:
-    /// - user_id: the id of the user
     /// - playlist_id: the id of the playlist
     /// - tracks: an array of map containing Spotify URIs of the tracks to remove
     /// with their current positions in the playlist. For example:
@@ -864,9 +863,8 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/remove-tracks-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_remove_specific_occurrences_of_tracks(
+    pub async fn playlist_remove_specific_occurrences_of_tracks(
         &self,
-        user_id: &str,
         playlist_id: &str,
         tracks: Vec<Map<String, Value>>,
         snapshot_id: Option<String>,
@@ -890,7 +888,7 @@ impl Spotify {
         if let Some(snapshot_id) = snapshot_id {
             json_insert!(params, "snapshot_id", snapshot_id);
         }
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         let result = self.delete(&url, None, &params).await?;
         self.convert_result(&result)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -597,7 +597,6 @@ impl Spotify {
     /// Get full details of the tracks of a playlist owned by a user.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     /// - fields - which fields to return
     /// - limit - the maximum number of tracks to return
@@ -606,9 +605,8 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-playlists-tracks/)
     #[maybe_async]
-    pub async fn user_playlist_tracks<L: Into<Option<u32>>, O: Into<Option<u32>>>(
+    pub async fn playlist_tracks<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
-        user_id: &str,
         playlist_id: &str,
         fields: Option<&str>,
         limit: L,
@@ -625,7 +623,7 @@ impl Spotify {
             params.insert("fields".to_owned(), fields.to_owned());
         }
         let plid = self.get_id(Type::Playlist, playlist_id);
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         let result = self.get(&url, None, &params).await?;
         self.convert_result(&result)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -922,16 +922,14 @@ impl Spotify {
     /// Check to see if the given users are following the given playlist.
     ///
     /// Parameters:
-    /// - playlist_owner_id - the user id of the playlist owner
     /// - playlist_id - the id of the playlist
     /// - user_ids - the ids of the users that you want to
     /// check to see if they follow the playlist. Maximum: 5 ids.
     ///
     /// [Reference](https://developer.spotify.com/web-api/check-user-following-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_check_follow(
+    pub async fn playlist_check_follow(
         &self,
-        playlist_owner_id: &str,
         playlist_id: &str,
         user_ids: &[String],
     ) -> ClientResult<Vec<bool>> {
@@ -939,8 +937,7 @@ impl Spotify {
             error!("The maximum length of user ids is limited to 5 :-)");
         }
         let url = format!(
-            "users/{}/playlists/{}/followers/contains?ids={}",
-            playlist_owner_id,
+            "playlists/{}/followers/contains?ids={}",
             playlist_id,
             user_ids.join(",")
         );

--- a/src/client.rs
+++ b/src/client.rs
@@ -660,7 +660,6 @@ impl Spotify {
     /// Changes a playlist's name and/or public/private state.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     /// - name - optional name of the playlist
     /// - public - optional is the playlist public
@@ -669,9 +668,8 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/change-playlist-details/)
     #[maybe_async]
-    pub async fn user_playlist_change_detail(
+    pub async fn playlist_change_detail(
         &self,
-        user_id: &str,
         playlist_id: &str,
         name: Option<&str>,
         public: Option<bool>,
@@ -691,7 +689,7 @@ impl Spotify {
         if let Some(description) = description {
             json_insert!(params, "description", description);
         }
-        let url = format!("users/{}/playlists/{}", user_id, playlist_id);
+        let url = format!("playlists/{}", playlist_id);
         self.put(&url, None, &params).await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -708,16 +708,14 @@ impl Spotify {
     /// Adds tracks to a playlist.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     /// - track_ids - a list of track URIs, URLs or IDs
     /// - position - the position to add the tracks
     ///
     /// [Reference](https://developer.spotify.com/web-api/add-tracks-to-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_add_tracks(
+    pub async fn playlist_add_tracks(
         &self,
-        user_id: &str,
         playlist_id: &str,
         track_ids: &[String],
         position: Option<i32>,
@@ -731,7 +729,7 @@ impl Spotify {
         if let Some(position) = position {
             json_insert!(params, "position", position);
         }
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         let result = self.post(&url, None, &params).await?;
         self.convert_result(&result)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -696,17 +696,12 @@ impl Spotify {
     /// Unfollows (deletes) a playlist for a user.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     ///
     /// [Reference](https://developer.spotify.com/web-api/unfollow-playlist/)
     #[maybe_async]
-    pub async fn user_playlist_unfollow(
-        &self,
-        user_id: &str,
-        playlist_id: &str,
-    ) -> ClientResult<String> {
-        let url = format!("users/{}/playlists/{}/followers", user_id, playlist_id);
+    pub async fn playlist_unfollow(&self, playlist_id: &str) -> ClientResult<String> {
+        let url = format!("playlists/{}/followers", playlist_id);
         self.delete(&url, None, &json!({})).await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -765,7 +765,6 @@ impl Spotify {
     /// Reorder tracks in a playlist.
     ///
     /// Parameters:
-    /// - user_id - the id of the user
     /// - playlist_id - the id of the playlist
     /// - range_start - the position of the first track to be reordered
     /// - range_length - optional the number of tracks to be reordered (default: 1)
@@ -774,9 +773,8 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/reorder-playlists-tracks/)
     #[maybe_async]
-    pub async fn user_playlist_recorder_tracks<R: Into<Option<u32>>>(
+    pub async fn playlist_reorder_tracks<R: Into<Option<u32>>>(
         &self,
-        user_id: &str,
         playlist_id: &str,
         range_start: i32,
         range_length: R,
@@ -793,7 +791,7 @@ impl Spotify {
             json_insert!(params, "snapshot_id", snapshot_id);
         }
 
-        let url = format!("users/{}/playlists/{}/tracks", user_id, plid);
+        let url = format!("playlists/{}/tracks", plid);
         let result = self.put(&url, None, &params).await?;
         self.convert_result(&result)
     }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -554,8 +554,7 @@ async fn test_user_unfollow_users() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_add_tracks() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_add_tracks() {
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let mut tracks_ids = vec![];
     let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
@@ -564,7 +563,7 @@ async fn test_user_playlist_add_tracks() {
     tracks_ids.push(track_id2);
     oauth_client()
         .await
-        .user_playlist_add_tracks(user_id, playlist_id, &tracks_ids, None)
+        .playlist_add_tracks(playlist_id, &tracks_ids, None)
         .await
         .unwrap();
 }
@@ -572,20 +571,12 @@ async fn test_user_playlist_add_tracks() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_change_detail() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_change_detail() {
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let playlist_name = "A New Playlist-update";
     oauth_client()
         .await
-        .user_playlist_change_detail(
-            user_id,
-            playlist_id,
-            Some(playlist_name),
-            Some(false),
-            None,
-            None,
-        )
+        .playlist_change_detail(playlist_id, Some(playlist_name), Some(false), None, None)
         .await
         .unwrap();
 }
@@ -593,8 +584,7 @@ async fn test_user_playlist_change_detail() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_check_follow() {
-    let owner_id = "jmperezperez";
+async fn test_playlist_check_follow() {
     let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
     let mut user_ids: Vec<String> = vec![];
     let user_id1 = String::from("possan");
@@ -603,7 +593,7 @@ async fn test_user_playlist_check_follow() {
     user_ids.push(user_id2);
     oauth_client()
         .await
-        .user_playlist_check_follow(owner_id, playlist_id, &user_ids)
+        .playlist_check_follow(playlist_id, &user_ids)
         .await
         .unwrap();
 }
@@ -624,12 +614,11 @@ async fn test_user_playlist_create() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_follow_playlist() {
-    let owner_id = "jmperezperez";
+async fn test_playlist_follow_playlist() {
     let playlist_id = "2v3iNvBX8Ay1Gt2uXtUKUT";
     oauth_client()
         .await
-        .user_playlist_follow_playlist(owner_id, playlist_id, true)
+        .playlist_follow(playlist_id, true)
         .await
         .unwrap();
 }
@@ -637,22 +626,14 @@ async fn test_user_playlist_follow_playlist() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_recorder_tracks() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_recorder_tracks() {
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let range_start = 0;
     let insert_before = 1;
     let range_length = 1;
     oauth_client()
         .await
-        .user_playlist_recorder_tracks(
-            user_id,
-            playlist_id,
-            range_start,
-            range_length,
-            insert_before,
-            None,
-        )
+        .playlist_reorder_tracks(playlist_id, range_start, range_length, insert_before, None)
         .await
         .unwrap();
 }
@@ -660,8 +641,7 @@ async fn test_user_playlist_recorder_tracks() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_remove_all_occurrences_of_tracks() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_remove_all_occurrences_of_tracks() {
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let mut tracks_ids = vec![];
     let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
@@ -670,7 +650,7 @@ async fn test_user_playlist_remove_all_occurrences_of_tracks() {
     tracks_ids.push(track_id1);
     oauth_client()
         .await
-        .user_playlist_remove_all_occurrences_of_tracks(user_id, playlist_id, &tracks_ids, None)
+        .playlist_remove_all_occurrences_of_tracks(playlist_id, &tracks_ids, None)
         .await
         .unwrap();
 }
@@ -678,8 +658,7 @@ async fn test_user_playlist_remove_all_occurrences_of_tracks() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_remove_specific_occurrences_of_tracks() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_remove_specific_occurrences_of_tracks() {
     let playlist_id = String::from("5jAOgWXCBKuinsGiZxjDQ5");
     let mut tracks = vec![];
     let mut map1 = Map::new();
@@ -703,7 +682,7 @@ async fn test_user_playlist_remove_specific_occurrences_of_tracks() {
     tracks.push(map2);
     oauth_client()
         .await
-        .user_playlist_remove_specific_occurrences_of_tracks(user_id, &playlist_id, tracks, None)
+        .playlist_remove_specific_occurrences_of_tracks(&playlist_id, tracks, None)
         .await
         .unwrap();
 }
@@ -711,8 +690,7 @@ async fn test_user_playlist_remove_specific_occurrences_of_tracks() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_replace_tracks() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_replace_tracks() {
     let playlist_id = "5jAOgWXCBKuinsGiZxjDQ5";
     let mut tracks_ids = vec![];
     let track_id1 = String::from("spotify:track:4iV5W9uYEdYUVa79Axb7Rh");
@@ -721,7 +699,7 @@ async fn test_user_playlist_replace_tracks() {
     tracks_ids.push(track_id1);
     oauth_client()
         .await
-        .user_playlist_replace_tracks(user_id, playlist_id, &tracks_ids)
+        .playlist_replace_tracks(playlist_id, &tracks_ids)
         .await
         .unwrap();
 }
@@ -754,12 +732,11 @@ async fn test_user_playlists() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_tracks() {
-    let user_id = "spotify";
+async fn test_playlist_tracks() {
     let playlist_id = String::from("spotify:playlist:59ZbFPES4DQwEjBpWHzrtC");
     oauth_client()
         .await
-        .user_playlist_tracks(user_id, &playlist_id, None, Some(2), None, None)
+        .playlist_tracks(&playlist_id, None, Some(2), None, None)
         .await
         .unwrap();
 }
@@ -767,12 +744,11 @@ async fn test_user_playlist_tracks() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
-async fn test_user_playlist_unfollow() {
-    let user_id = "2257tjys2e2u2ygfke42niy2q";
+async fn test_playlist_unfollow() {
     let playlist_id = "65V6djkcVRyOStLd8nza8E";
     oauth_client()
         .await
-        .user_playlist_unfollow(user_id, playlist_id)
+        .playlist_unfollow(playlist_id)
         .await
         .unwrap();
 }


### PR DESCRIPTION
Most of the API for handling playlists required a user ID in addition to the playlist ID. However, the Spotify API only requires the playlist ID for its endpoints, [see here](https://developer.spotify.com/documentation/web-api/reference/playlists/).

I suppose that in a previous version of the Spotify API, the owner ID was needed to correctly identify a playlist, but it seems to no longer be the case.

This PR fixes the calls to the playlist related actions, and renames the methods of the client for more clarity. 