### PR TITLE
PlayHistory returns FullTrack despite Spotify documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Renamed environmental variables to `RSPOTIFY_CLIENT_ID`, `RSPOTIFY_CLIENT_SECRET` and `RSPOTIFY_REDIRECT_URI` to avoid name collisions with other libraries that use OAuth2 ([#118](https://github.com/ramsayleung/rspotify/issues/118)).
 - Fix typo in `user_playlist_remove_specific_occurrenes_of_tracks`, now it's `user_playlist_remove_specific_occurrences_of_tracks`.
 - All fallible calls in the client return a `ClientError` rather than using `failure`.
+- Changed type of `track` in `PlayHistory` to `FullTrack` ([#139](https://github.com/ramsayleung/rspotify/pull/139)).
 
 ## 0.10 (2020/07/01)
 

--- a/src/model/playing.rs
+++ b/src/model/playing.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use super::context::Context;
 use super::track::FullTrack;
-use super::track::SimplifiedTrack;
 /// Current playing track
 /// [get the users currently playing track](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -20,7 +19,7 @@ pub struct Playing {
 /// [play history object](https://developer.spotify.com/web-api/object-model/#play-history-object)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PlayHistory {
-    pub track: SimplifiedTrack,
+    pub track: FullTrack,
     pub played_at: DateTime<Utc>,
     pub context: Option<Context>,
 }


### PR DESCRIPTION
Despite what the Spotify documentation [specifies](https://developer.spotify.com/documentation/web-api/reference/player/get-recently-played/), the `play history object` has a `FullTrack` track field. This can be seen by [using the endpoint](https://developer.spotify.com/console/get-recently-played/) and noticing that all fields are returned in the track object (notice the album, popularity, and other fields):

```json
{
  "items": [
    {
      "track": {
        "album": {
          "album_type": "album",
          "artists": [
            {
              "external_urls": {
                "spotify": "https://open.spotify.com/artist/0DtXHIvJ8NWBg5pGvsgWnR"
              },
              "href": "https://api.spotify.com/v1/artists/0DtXHIvJ8NWBg5pGvsgWnR",
              "id": "0DtXHIvJ8NWBg5pGvsgWnR",
              "name": "Leikeli47",
              "type": "artist",
              "uri": "spotify:artist:0DtXHIvJ8NWBg5pGvsgWnR"
            }
          ],
          "available_markets": [
            "..."
          ],
          "external_urls": {
            "spotify": "https://open.spotify.com/album/1VAZdFNZ1t5BYugJ3NfaZh"
          },
          "href": "https://api.spotify.com/v1/albums/1VAZdFNZ1t5BYugJ3NfaZh",
          "id": "1VAZdFNZ1t5BYugJ3NfaZh",
          "images": [
            {
              "height": 640,
              "url": "https://i.scdn.co/image/ab67616d0000b273ba578345104c3175c5b97625",
              "width": 640
            },
            {
              "height": 300,
              "url": "https://i.scdn.co/image/ab67616d00001e02ba578345104c3175c5b97625",
              "width": 300
            },
            {
              "height": 64,
              "url": "https://i.scdn.co/image/ab67616d00004851ba578345104c3175c5b97625",
              "width": 64
            }
          ],
          "name": "Wash & Set",
          "release_date": "2017-09-08",
          "release_date_precision": "day",
          "total_tracks": 14,
          "type": "album",
          "uri": "spotify:album:1VAZdFNZ1t5BYugJ3NfaZh"
        },
        "artists": [
          {
            "external_urls": {
              "spotify": "https://open.spotify.com/artist/0DtXHIvJ8NWBg5pGvsgWnR"
            },
            "href": "https://api.spotify.com/v1/artists/0DtXHIvJ8NWBg5pGvsgWnR",
            "id": "0DtXHIvJ8NWBg5pGvsgWnR",
            "name": "Leikeli47",
            "type": "artist",
            "uri": "spotify:artist:0DtXHIvJ8NWBg5pGvsgWnR"
          }
        ],
        "available_markets": [
          "..."
        ],
        "disc_number": 1,
        "duration_ms": 218040,
        "explicit": true,
        "external_ids": {
          "isrc": "USRC11701108"
        },
        "external_urls": {
          "spotify": "https://open.spotify.com/track/6r60QMPjupH9mfPRBw1jva"
        },
        "href": "https://api.spotify.com/v1/tracks/6r60QMPjupH9mfPRBw1jva",
        "id": "6r60QMPjupH9mfPRBw1jva",
        "is_local": false,
        "name": "O.M.C.",
        "popularity": 30,
        "preview_url": "https://p.scdn.co/mp3-preview/434b7014f009a3a53fdb16daf9ca047d2d853df5?cid=774b29d4f13844c495f206cafdad9c86",
        "track_number": 5,
        "type": "track",
        "uri": "spotify:track:6r60QMPjupH9mfPRBw1jva"
      },
      "played_at": "2020-10-15T21:15:04.622Z",
      "context": null
    }
  ],
  "next": "https://api.spotify.com/v1/me/player/recently-played?before=1602796504622&limit=1",
  "cursors": {
    "after": "1602796504622",
    "before": "1602796504622"
  },
  "limit": 1,
  "href": "https://api.spotify.com/v1/me/player/recently-played?limit=1"
}
```
