### PR TITLE
Keep polishing the models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `FullTracks` struct with `pub (in crate)`, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
   + Constrain visibility of `AudioFeaturesPayload` struct with `pub (in crate)`, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
   + Constrain visibility of `FullAlbums` struct with `pub (in crate)`, make `albums` endpoints return a `Vec<FullAlbum>` instead.
+  + Constrain visibility of `PageSimpliedAlbums` struct with `pub (in crate)`, make `new_releases` endpoints return a `Page<SimplifiedAlbum>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
   + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
+  + Remove `SimplifiedPlayingContext`, since it's useless.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `CurrentPlaybackContext.progress_ms` to `progress`, and change its type from `Option<u32>` to `Option<std::time::Duration>`.
   + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
+  + Change `Offset.position`'s type from `Option<u32>` to `Option<std::time::Duration>`
   + Remove `SimplifiedPlayingContext`, since it's useless.
 
 ## 0.10 (2020/07/01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `AudioFeaturesPayload` struct with `pub (in crate)`, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
   + Constrain visibility of `FullAlbums` struct with `pub (in crate)`, make `albums` endpoints return a `Vec<FullAlbum>` instead.
   + Constrain visibility of `PageSimpliedAlbums` struct with `pub (in crate)`, make `new_releases` endpoints return a `Page<SimplifiedAlbum>` instead.
+  + Constrain visibility of `CursorPageFullArtists` struct with `pub (in crate)`, make `current_user_followed_artists` endpoints return a `CursorBasedPage<FullArtist>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `PageSimpliedAlbums` struct with `pub (in crate)`, make `new_releases` endpoints return a `Page<SimplifiedAlbum>` instead.
   + Constrain visibility of `CursorPageFullArtists` struct with `pub (in crate)`, make `current_user_followed_artists` endpoints return a `CursorBasedPage<FullArtist>` instead.
   + Constrain visibility of `PageCategory` struct with `pub (in crate)`, make `categories` endpoints return a `Page<Category>` instead.
+  + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,8 +167,10 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
   + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
   + Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
-  + Rename `FulEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `FullEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
   + Rename `SimplifiedEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `FullTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `SimplifiedTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `CursorPageFullArtists` struct with `pub (in crate)`, make `current_user_followed_artists` endpoints return a `CursorBasedPage<FullArtist>` instead.
   + Constrain visibility of `PageCategory` struct with `pub (in crate)`, make `categories` endpoints return a `Page<Category>` instead.
   + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
+  + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,9 +157,9 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Replace `Actions::disallows` with a `Vec<DisallowKey>` by removing all entires whose value is false, which will result in a simpler API
   + Replace `{FullAlbum, SimplifiedEpisode, FullEpisode}::release_date_precision` from `String` to `DatePrecision` enum, makes it easier to use.
 - ([#157](https://github.com/ramsayleung/rspotify/pull/157))Keep polishing models to make it easier to use:
-  + Remove `FullArtists` struct, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
-  + Remove `FullTracks` struct, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
-  + Remove `AudioFeaturesPayload` struct, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
+  + Constrain visibility of `FullArtists` struct with `pub (in crate)`, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
+  + Constrain visibility of `FullTracks` struct with `pub (in crate)`, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
+  + Constrain visibility of  `AudioFeaturesPayload` struct with `pub (in crate)`, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
   + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
   + Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `FulEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `SimplifiedTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
   + Rename `CurrentlyPlayingContext.progress_ms` to `progress`, and change its type from `Option<u32>` to `Option<std::time::Duration>`.
+  + Rename `CurrentPlaybackContext.progress_ms` to `progress`, and change its type from `Option<u32>` to `Option<std::time::Duration>`.
   + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Remove `SimplifiedPlayingContext`, since it's useless.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
   + Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
   + Rename `FulEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `SimplifiedEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `FullTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `SimplifiedTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `CurrentlyPlayingContext.progress_ms` to `progress`, and change its type from `Option<u32>` to `Option<std::time::Duration>`.
   + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Remove `SimplifiedPlayingContext`, since it's useless.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `FullAlbums` struct with `pub (in crate)`, make `albums` endpoints return a `Vec<FullAlbum>` instead.
   + Constrain visibility of `PageSimpliedAlbums` struct with `pub (in crate)`, make `new_releases` endpoints return a `Page<SimplifiedAlbum>` instead.
   + Constrain visibility of `CursorPageFullArtists` struct with `pub (in crate)`, make `current_user_followed_artists` endpoints return a `CursorBasedPage<FullArtist>` instead.
+  + Constrain visibility of `PageCategory` struct with `pub (in crate)`, make `categories` endpoints return a `Page<Category>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `FullTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `SimplifiedTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
+  + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ If we missed any change or there's something you'd like to discuss about this ve
 - ([#157](https://github.com/ramsayleung/rspotify/pull/157))Keep polishing models to make it easier to use:
   + Remove `FullArtists` struct, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
   + Remove `FullTracks` struct, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
+  + Remove `AudioFeaturesPayload` struct, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `PageCategory` struct with `pub (in crate)`, make `categories` endpoints return a `Page<Category>` instead.
   + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
   + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
+  + Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ If we missed any change or there's something you'd like to discuss about this ve
   + `FullAlbum`
   + `SimplifiedArtist`
   + `FullArtist`
-  + `FullArtists`
   + `CursorPageFullArtists`
   + `AudioFeatures`
   + `AudioFeaturesPayload`
@@ -158,6 +157,8 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Change `{FullArtist, FullPlaylist, PublicUser, PrivateUser}::followers` from `HashMap<String, Option<Value>>` to struct `Followers`
   + Replace `Actions::disallows` with a `Vec<DisallowKey>` by removing all entires whose value is false, which will result in a simpler API
   + Replace `{FullAlbum, SimplifiedEpisode, FullEpisode}::release_date_precision` from `String` to `DatePrecision` enum, makes it easier to use.
+- ([#157](https://github.com/ramsayleung/rspotify/pull/157))Keep polishing models to make it easier to use:
+  + Remove `FullArtists` struct, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ If we missed any change or there's something you'd like to discuss about this ve
   + `ResumePoint`
   + `FullTrack`
   + `TrackLink`
-  + `FullTracks`
   + `SimplifiedTrack`
   + `TrackRestriction`
   + `SavedTrack`
@@ -159,6 +158,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Replace `{FullAlbum, SimplifiedEpisode, FullEpisode}::release_date_precision` from `String` to `DatePrecision` enum, makes it easier to use.
 - ([#157](https://github.com/ramsayleung/rspotify/pull/157))Keep polishing models to make it easier to use:
   + Remove `FullArtists` struct, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
+  + Remove `FullTracks` struct, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,8 @@ If we missed any change or there's something you'd like to discuss about this ve
 - ([#157](https://github.com/ramsayleung/rspotify/pull/157))Keep polishing models to make it easier to use:
   + Constrain visibility of `FullArtists` struct with `pub (in crate)`, make `artists` and `artist_related_artists` endpoints return a `Vec<FullArtist>` instead.
   + Constrain visibility of `FullTracks` struct with `pub (in crate)`, make `tracks` and `artist_top_tracks` endpoints return a `Vec<FullTrack>` instead.
-  + Constrain visibility of  `AudioFeaturesPayload` struct with `pub (in crate)`, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
+  + Constrain visibility of `AudioFeaturesPayload` struct with `pub (in crate)`, make `tracks_features` endpoints return a `Vec<AudioFeatures>` instead.
+  + Constrain visibility of `FullAlbums` struct with `pub (in crate)`, make `albums` endpoints return a `Vec<FullAlbum>` instead.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `SimplifiedTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
   + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
   + Change `CurrentlyPlayingContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
+  + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,11 +166,12 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Constrain visibility of `PageCategory` struct with `pub (in crate)`, make `categories` endpoints return a `Page<Category>` instead.
   + Constrain visibility of `DevicePayload` struct with `pub (in crate)`, make `device` endpoints return a `Vec<Device>` instead.
   + Constrain visibility of `SeversalSimplifiedShows` struct with `pub (in crate)`, make `get_several_shows` endpoints return a `Vec<SimplifiedShow>` instead.
-  + Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
-  + Rename `FullEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
-  + Rename `SimplifiedEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
-  + Rename `FullTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
-  + Rename `SimplifiedTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+  + Rename `AudioFeatures.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `FullEpisode.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `SimplifiedEpisode.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `FullTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `SimplifiedTrack.duration_ms` to `duration`, and change its type from `u32` to `std::time::Duration`.
+  + Rename `ResumePoint.resume_position_ms` to `resume_position`, and change its type from `u32` to `std::time::Duration`.
 
 ## 0.10 (2020/07/01)
 

--- a/examples/with_refresh_token.rs
+++ b/examples/with_refresh_token.rs
@@ -39,7 +39,7 @@ async fn do_things(spotify: Spotify) {
         .expect("couldn't get user followed artists");
     println!(
         "User currently follows at least {} artists.",
-        followed.artists.items.len()
+        followed.items.len()
     );
 
     spotify

--- a/src/client.rs
+++ b/src/client.rs
@@ -1957,7 +1957,7 @@ impl Spotify {
         &self,
         ids: impl IntoIterator<Item = &'a str>,
         market: Option<Country>,
-    ) -> ClientResult<SeversalSimplifiedShows> {
+    ) -> ClientResult<Vec<SimplifiedShow>> {
         // TODO: This can probably be better
         let mut params = Query::with_capacity(1);
         params.insert(
@@ -1968,7 +1968,8 @@ impl Spotify {
             params.insert("country".to_owned(), market.to_string());
         }
         let result = self.get("shows", None, &params).await?;
-        self.convert_result(&result)
+        self.convert_result::<SeversalSimplifiedShows>(&result)
+            .map(|x| x.shows)
     }
 
     /// Get Spotify catalog information about an show’s episodes. Optional

--- a/src/client.rs
+++ b/src/client.rs
@@ -1400,7 +1400,7 @@ impl Spotify {
         country: Option<Country>,
         limit: L,
         offset: O,
-    ) -> ClientResult<PageSimpliedAlbums> {
+    ) -> ClientResult<Page<SimplifiedAlbum>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
@@ -1409,7 +1409,7 @@ impl Spotify {
         }
 
         let result = self.get("browse/new-releases", None, &params).await?;
-        self.convert_result(&result)
+        self.convert_result::<PageSimpliedAlbums>(&result).map(|x|x.albums)
     }
 
     /// Get a list of new album releases featured in Spotify

--- a/src/client.rs
+++ b/src/client.rs
@@ -232,11 +232,6 @@ impl Spotify {
             params.insert("market".to_owned(), market.to_string());
         }
 
-        #[derive(Deserialize)]
-        struct FullTracks {
-            tracks: Vec<FullTrack>,
-        }
-
         let url = format!("tracks/?ids={}", ids.join(","));
         let result = self.get(&url, None, &params).await?;
         self.convert_result::<FullTracks>(&result).map(|x| x.tracks)
@@ -274,10 +269,6 @@ impl Spotify {
         let url = format!("artists/?ids={}", ids.join(","));
         let result = self.get(&url, None, &Query::new()).await?;
 
-        #[derive(Deserialize)]
-        struct FullArtists {
-            artists: Vec<FullArtist>,
-        }
         self.convert_result::<FullArtists>(&result)
             .map(|x| x.artists)
     }
@@ -342,12 +333,6 @@ impl Spotify {
 
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/top-tracks", trid);
-
-        #[derive(Deserialize)]
-        struct FullTracks {
-            tracks: Vec<FullTrack>,
-        }
-
         let result = self.get(&url, None, &params).await?;
         self.convert_result::<FullTracks>(&result).map(|x| x.tracks)
     }
@@ -365,10 +350,6 @@ impl Spotify {
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/related-artists", trid);
         let result = self.get(&url, None, &Query::new()).await?;
-        #[derive(Deserialize)]
-        struct FullArtists {
-            artists: Vec<FullArtist>,
-        }
         self.convert_result::<FullArtists>(&result)
             .map(|x| x.artists)
     }
@@ -1579,10 +1560,6 @@ impl Spotify {
         if result.is_empty() {
             Ok(None)
         } else {
-            #[derive(Deserialize)]
-            struct AudioFeaturesPayload {
-                audio_features: Vec<AudioFeatures>,
-            }
             self.convert_result::<Option<AudioFeaturesPayload>>(&result)
                 .map(|option_payload| option_payload.map(|x| x.audio_features))
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -379,14 +379,14 @@ impl Spotify {
     pub async fn albums<'a>(
         &self,
         album_ids: impl IntoIterator<Item = &'a str>,
-    ) -> ClientResult<FullAlbums> {
+    ) -> ClientResult<Vec<FullAlbum>> {
         let mut ids: Vec<String> = vec![];
         for album_id in album_ids {
             ids.push(self.get_id(Type::Album, album_id));
         }
         let url = format!("albums/?ids={}", ids.join(","));
         let result = self.get(&url, None, &Query::new()).await?;
-        self.convert_result(&result)
+        self.convert_result::<FullAlbums>(&result).map(|x| x.albums)
     }
 
     /// Search for an Item. Get Spotify catalog information about artists,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1433,7 +1433,7 @@ impl Spotify {
         country: Option<Country>,
         limit: L,
         offset: O,
-    ) -> ClientResult<PageCategory> {
+    ) -> ClientResult<Page<Category>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
@@ -1444,7 +1444,8 @@ impl Spotify {
             params.insert("country".to_owned(), country.to_string());
         }
         let result = self.get("browse/categories", None, &params).await?;
-        self.convert_result(&result)
+        self.convert_result::<PageCategory>(&result)
+            .map(|x| x.categories)
     }
 
     /// Get Recommendations Based on Seeds

--- a/src/client.rs
+++ b/src/client.rs
@@ -1586,9 +1586,10 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-a-users-available-devices/)
     #[maybe_async]
-    pub async fn device(&self) -> ClientResult<DevicePayload> {
+    pub async fn device(&self) -> ClientResult<Vec<Device>> {
         let result = self.get("me/player/devices", None, &Query::new()).await?;
-        self.convert_result(&result)
+        self.convert_result::<DevicePayload>(&result)
+            .map(|x| x.devices)
     }
 
     /// Get Information About The User’s Current Playback

--- a/src/client.rs
+++ b/src/client.rs
@@ -1021,7 +1021,7 @@ impl Spotify {
         &self,
         limit: L,
         after: Option<String>,
-    ) -> ClientResult<CursorPageFullArtists> {
+    ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("type".to_owned(), Type::Artist.to_string());
@@ -1030,7 +1030,8 @@ impl Spotify {
         }
 
         let result = self.get("me/following", None, &params).await?;
-        self.convert_result(&result)
+        self.convert_result::<CursorPageFullArtists>(&result)
+            .map(|x| x.artists)
     }
 
     /// Remove one or more tracks from the current user's "Your Music" library.
@@ -1409,7 +1410,8 @@ impl Spotify {
         }
 
         let result = self.get("browse/new-releases", None, &params).await?;
-        self.convert_result::<PageSimpliedAlbums>(&result).map(|x|x.albums)
+        self.convert_result::<PageSimpliedAlbums>(&result)
+            .map(|x| x.albums)
     }
 
     /// Get a list of new album releases featured in Spotify

--- a/src/client.rs
+++ b/src/client.rs
@@ -1568,7 +1568,7 @@ impl Spotify {
     pub async fn tracks_features<'a>(
         &self,
         tracks: impl IntoIterator<Item = &'a str>,
-    ) -> ClientResult<Option<AudioFeaturesPayload>> {
+    ) -> ClientResult<Option<Vec<AudioFeatures>>> {
         let ids: Vec<String> = tracks
             .into_iter()
             .map(|track| self.get_id(Type::Track, track))
@@ -1579,7 +1579,12 @@ impl Spotify {
         if result.is_empty() {
             Ok(None)
         } else {
-            self.convert_result(&result)
+            #[derive(Deserialize)]
+            struct AudioFeaturesPayload {
+                audio_features: Vec<AudioFeatures>,
+            }
+            self.convert_result::<Option<AudioFeaturesPayload>>(&result)
+                .map(|option_payload| option_payload.map(|x| x.audio_features))
         }
     }
 

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -74,9 +74,8 @@ pub(in crate) struct FullAlbums {
 /// Simplified Albums wrapped by Page object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-list-new-releases/)
-// TODO: Reduce this wrapper object to `Page<SimplifiedAlbum>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct PageSimpliedAlbums {
+#[derive(Deserialize)]
+pub (in crate) struct PageSimpliedAlbums {
     pub albums: Page<SimplifiedAlbum>,
 }
 

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -75,7 +75,7 @@ pub(in crate) struct FullAlbums {
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-list-new-releases/)
 #[derive(Deserialize)]
-pub (in crate) struct PageSimpliedAlbums {
+pub(in crate) struct PageSimpliedAlbums {
     pub albums: Page<SimplifiedAlbum>,
 }
 

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -66,9 +66,8 @@ pub struct FullAlbum {
 /// Full Albums wrapped by Vec object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/albums/get-several-albums/)
-// TODO: Reduce this wrapper object to `Vec<FullAlbum>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct FullAlbums {
+#[derive(Deserialize)]
+pub(in crate) struct FullAlbums {
     pub albums: Vec<FullAlbum>,
 }
 

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -48,8 +48,7 @@ pub(in crate) struct FullArtists {
 /// Full Artists vector wrapped by cursor-based-page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)
-// TODO: Reduce this wrapper object to `CursorBasedPage<FullArtist>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct CursorPageFullArtists {
+#[derive(Deserialize)]
+pub (in crate) struct CursorPageFullArtists {
     pub artists: CursorBasedPage<FullArtist>,
 }

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -40,7 +40,7 @@ pub struct FullArtist {
 /// Full artist object wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Deserialize)]
 pub(in crate) struct FullArtists {
     pub artists: Vec<FullArtist>,
 }

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -37,6 +37,14 @@ pub struct FullArtist {
     pub uri: String,
 }
 
+/// Full artist object wrapped by `Vec`
+///
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(in crate) struct FullArtists {
+    pub artists: Vec<FullArtist>,
+}
+
 /// Full Artists vector wrapped by cursor-based-page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -49,6 +49,6 @@ pub(in crate) struct FullArtists {
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)
 #[derive(Deserialize)]
-pub (in crate) struct CursorPageFullArtists {
+pub(in crate) struct CursorPageFullArtists {
     pub artists: CursorBasedPage<FullArtist>,
 }

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -37,15 +37,6 @@ pub struct FullArtist {
     pub uri: String,
 }
 
-/// Full artist object wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/)
-// TODO: Reduce this wrapper object to `Vec<FullArtist>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FullArtists {
-    pub artists: Vec<FullArtist>,
-}
-
 /// Full Artists vector wrapped by cursor-based-page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -27,15 +27,6 @@ pub struct AudioFeatures {
     pub valence: f32,
 }
 
-/// Audio feature object wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/)
-// TODO: Reduce this wrapper object to `Vec<AudioFeatures>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct AudioFeaturesPayload {
-    pub audio_features: Vec<AudioFeatures>,
-}
-
 /// Audio analysis object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -30,7 +30,7 @@ pub struct AudioFeatures {
 /// Audio feature object wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Deserialize)]
 pub(in crate) struct AudioFeaturesPayload {
     pub audio_features: Vec<AudioFeatures>,
 }

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -27,6 +27,14 @@ pub struct AudioFeatures {
     pub valence: f32,
 }
 
+/// Audio feature object wrapped by `Vec`
+///
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub(in crate) struct AudioFeaturesPayload {
+    pub audio_features: Vec<AudioFeatures>,
+}
+
 /// Audio analysis object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -1,5 +1,7 @@
 //! All objects related to artist defined by Spotify API
+use crate::model::{from_duration_ms, to_duration_ms};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Audio Feature Object
 ///
@@ -9,7 +11,12 @@ pub struct AudioFeatures {
     pub acousticness: f32,
     pub analysis_url: String,
     pub danceability: f32,
-    pub duration_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "duration_ms"
+    )]
+    pub duration: Duration,
     pub energy: f32,
     pub id: String,
     pub instrumentalness: f32,

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -16,8 +16,7 @@ pub struct Category {
 /// Categories wrapped by page object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-list-categories/)
-// TODO: Reduce this wrapper object to `Page<Category>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct PageCategory {
+#[derive(Deserialize)]
+pub(in crate) struct PageCategory {
     pub categories: Page<Category>,
 }

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -57,7 +57,11 @@ pub struct CurrentPlaybackContext {
     pub repeat_state: RepeatState,
     pub shuffle_state: bool,
     pub context: Option<Context>,
-    pub timestamp: u64,
+    #[serde(
+        deserialize_with = "from_millisecond_timestamp",
+        serialize_with = "to_millisecond_timestamp"
+    )]
+    pub timestamp: DateTime<Utc>,
     pub progress_ms: Option<u32>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -21,18 +21,6 @@ pub struct Context {
     pub _type: Type,
 }
 
-/// Simplified playing context
-///
-/// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SimplifiedPlayingContext {
-    pub context: Option<Context>,
-    pub timestamp: u64,
-    pub progress_ms: Option<u32>,
-    pub is_playing: bool,
-    pub item: Option<FullTrack>,
-}
-
 /// Currently playing object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/)

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -1,6 +1,5 @@
 //! All objects related to context
 use super::device::Device;
-use super::track::FullTrack;
 use super::PlayingItem;
 use crate::model::{
     from_millisecond_timestamp, to_millisecond_timestamp, CurrentlyPlayingType, DisallowKey,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -56,7 +56,13 @@ pub struct CurrentPlaybackContext {
         serialize_with = "to_millisecond_timestamp"
     )]
     pub timestamp: DateTime<Utc>,
-    pub progress_ms: Option<u32>,
+    #[serde(default)]
+    #[serde(
+        deserialize_with = "from_option_duration_ms",
+        serialize_with = "to_option_duration_ms",
+        rename = "progress_ms"
+    )]
+    pub progress: Option<Duration>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,
     pub currently_playing_type: CurrentlyPlayingType,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -1,11 +1,14 @@
 //! All objects related to context
-use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
-
 use super::device::Device;
 use super::track::FullTrack;
 use super::PlayingItem;
-use crate::model::{CurrentlyPlayingType, DisallowKey, RepeatState, Type};
+use crate::model::{
+    from_millisecond_timestamp, to_millisecond_timestamp, CurrentlyPlayingType, DisallowKey,
+    RepeatState, Type,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashMap;
 /// Context object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
@@ -36,7 +39,11 @@ pub struct SimplifiedPlayingContext {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentlyPlayingContext {
     pub context: Option<Context>,
-    pub timestamp: u64,
+    #[serde(
+        deserialize_with = "from_millisecond_timestamp",
+        serialize_with = "to_millisecond_timestamp"
+    )]
+    pub timestamp: DateTime<Utc>,
     pub progress_ms: Option<u32>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -2,12 +2,13 @@
 use super::device::Device;
 use super::PlayingItem;
 use crate::model::{
-    from_millisecond_timestamp, to_millisecond_timestamp, CurrentlyPlayingType, DisallowKey,
-    RepeatState, Type,
+    from_millisecond_timestamp, from_option_duration_ms, to_millisecond_timestamp,
+    to_option_duration_ms, CurrentlyPlayingType, DisallowKey, RepeatState, Type,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
 /// Context object
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
@@ -31,7 +32,13 @@ pub struct CurrentlyPlayingContext {
         serialize_with = "to_millisecond_timestamp"
     )]
     pub timestamp: DateTime<Utc>,
-    pub progress_ms: Option<u32>,
+    #[serde(default)]
+    #[serde(
+        deserialize_with = "from_option_duration_ms",
+        serialize_with = "to_option_duration_ms",
+        rename = "progress_ms"
+    )]
+    pub progress: Option<Duration>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,
     pub currently_playing_type: CurrentlyPlayingType,

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -20,7 +20,26 @@ pub struct Device {
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/)
 // TODO: Reduce this wrapper object to `Vec<Device>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct DevicePayload {
+#[derive(Deserialize)]
+pub(in crate) struct DevicePayload {
     pub devices: Vec<Device>,
+}
+
+#[test]
+fn test_devices() {
+    let json_str = r#"
+        {
+            "devices" : [ {
+                "id" : "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
+                "is_active" : false,
+                "is_private_session": true,
+                "is_restricted" : false,
+                "name" : "My fridge",
+                "type" : "Computer",
+                "volume_percent" : 100
+            } ]
+        }
+"#;
+    let payload: DevicePayload = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(payload.devices[0]._type, DeviceType::Computer)
 }

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -19,7 +19,6 @@ pub struct Device {
 /// Device payload object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/)
-// TODO: Reduce this wrapper object to `Vec<Device>`
 #[derive(Deserialize)]
 pub(in crate) struct DevicePayload {
     pub devices: Vec<Device>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -48,15 +48,6 @@ where
 {
     s.serialize_u64(x.as_millis() as u64)
 }
-#[derive(Deserialize, Serialize, Debug)]
-struct Track {
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
-    duration: Duration,
-}
 /// Restriction object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-restriction-object)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -36,7 +36,7 @@ impl<'de> de::Visitor<'de> for DurationVisitor {
     }
 }
 
-/// Deserialize `std::time::Duration` from millisecond(represented as u64)
+/// Deserialize `std::time::Duration` from milliseconds (represented as u64)
 pub(in crate) fn from_duration_ms<'de, D>(d: D) -> Result<Duration, D::Error>
 where
     D: de::Deserializer<'de>,
@@ -44,7 +44,7 @@ where
     d.deserialize_u64(DurationVisitor)
 }
 
-/// Serialize `std::time::Duration` to millisecond(represented as u64)
+/// Serialize `std::time::Duration` to milliseconds (represented as u64)
 pub(in crate) fn to_duration_ms<S>(x: &Duration, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -86,7 +86,7 @@ where
     d.deserialize_u64(DateTimeVisitor)
 }
 
-/// Serialize DateTime<Utc>  to Unix millisecond timestamp
+/// Serialize DateTime<Utc> to Unix millisecond timestamp
 pub(in crate) fn to_millisecond_timestamp<S>(x: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -120,7 +120,7 @@ impl<'de> de::Visitor<'de> for OptionDurationVisitor {
     }
 }
 
-/// Deserialize `Option<std::time::Duration>` from millisecond(represented as u64)
+/// Deserialize `Option<std::time::Duration>` from milliseconds (represented as u64)
 pub(in crate) fn from_option_duration_ms<'de, D>(d: D) -> Result<Option<Duration>, D::Error>
 where
     D: de::Deserializer<'de>,
@@ -128,7 +128,7 @@ where
     d.deserialize_option(OptionDurationVisitor)
 }
 
-/// Serialize `Option<std::time::Duration>` to millisecond(represented as u64)
+/// Serialize `Option<std::time::Duration>` to milliseconds (represented as u64)
 pub(in crate) fn to_option_duration_ms<S>(x: &Option<Duration>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/src/model/offset.rs
+++ b/src/model/offset.rs
@@ -1,18 +1,25 @@
 //! Offset object
+use crate::model::{from_option_duration_ms, to_option_duration_ms};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Offset object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Offset {
-    pub position: Option<u32>,
+    #[serde(default)]
+    #[serde(
+        deserialize_with = "from_option_duration_ms",
+        serialize_with = "to_option_duration_ms"
+    )]
+    pub position: Option<Duration>,
     pub uri: Option<String>,
 }
 
-pub fn for_position(position: u32) -> Option<Offset> {
+pub fn for_position(position: u64) -> Option<Offset> {
     Some(Offset {
-        position: Some(position),
+        position: Some(Duration::from_millis(position)),
         uri: None,
     })
 }

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -120,7 +120,12 @@ pub struct SimplifiedEpisode {
 pub struct FullEpisode {
     pub audio_preview_url: Option<String>,
     pub description: String,
-    pub duration_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "duration_ms"
+    )]
+    pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
     pub href: String,

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -156,5 +156,10 @@ pub struct SeveralEpisodes {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResumePoint {
     pub fully_played: bool,
-    pub resume_position_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "resume_position_ms"
+    )]
+    pub resume_position: Duration,
 }

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -1,8 +1,9 @@
 use super::image::Image;
 use super::page::Page;
-use crate::model::{CopyrightType, DatePrecision};
+use crate::model::{from_duration_ms, to_duration_ms, CopyrightType, DatePrecision};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
 
 /// Copyright object
 ///
@@ -85,7 +86,12 @@ pub struct FullShow {
 pub struct SimplifiedEpisode {
     pub audio_preview_url: Option<String>,
     pub description: String,
-    pub duration_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "duration_ms"
+    )]
+    pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
     pub href: String,

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -40,9 +40,8 @@ pub struct SimplifiedShow {
 /// SimplifiedShows wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/)
-// TODO: Reduce this wrapper object to `Vec<SimplifiedShow>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SeversalSimplifiedShows {
+#[derive(Deserialize)]
+pub(in crate) struct SeversalSimplifiedShows {
     pub shows: Vec<SimplifiedShow>,
 }
 

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -57,7 +57,7 @@ pub struct TrackLink {
 /// Full track wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Deserialize)]
 pub(in crate) struct FullTracks {
     pub tracks: Vec<FullTrack>,
 }

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -54,15 +54,6 @@ pub struct TrackLink {
     pub uri: String,
 }
 
-/// Full track wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
-// TODO: Reduce wrapper object to `Vec<FullTrack>`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FullTracks {
-    pub tracks: Vec<FullTrack>,
-}
-
 /// Simplified track object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -54,6 +54,14 @@ pub struct TrackLink {
     pub uri: String,
 }
 
+/// Full track wrapped by `Vec`
+///
+/// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(in crate) struct FullTracks {
+    pub tracks: Vec<FullTrack>,
+}
+
 /// Simplified track object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -2,13 +2,13 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use super::album::SimplifiedAlbum;
 use super::artist::SimplifiedArtist;
 use super::Restriction;
 use crate::model::Type;
-
+use crate::model::{from_duration_ms, to_duration_ms};
 /// Full track object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full)
@@ -19,7 +19,12 @@ pub struct FullTrack {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub available_markets: Vec<String>,
     pub disc_number: i32,
-    pub duration_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "duration_ms"
+    )]
+    pub duration: Duration,
     pub explicit: bool,
     pub external_ids: HashMap<String, String>,
     pub external_urls: HashMap<String, String>,
@@ -70,7 +75,12 @@ pub struct SimplifiedTrack {
     pub artists: Vec<SimplifiedArtist>,
     pub available_markets: Option<Vec<String>>,
     pub disc_number: i32,
-    pub duration_ms: u32,
+    #[serde(
+        deserialize_with = "from_duration_ms",
+        serialize_with = "to_duration_ms",
+        rename = "duration_ms"
+    )]
+    pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
     #[serde(default)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use getrandom::getrandom;
 
-/// Convert datetime to unix timestampe
+/// Convert datetime to unix timestamp
 pub(in crate) fn datetime_to_timestamp(elapsed: u32) -> i64 {
     let utc: DateTime<Utc> = Utc::now();
     utc.timestamp() + i64::from(elapsed)

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
 use rspotify::model::*;
 use std::time::Duration;
 #[test]
@@ -585,4 +586,115 @@ fn test_resume_point() {
     let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
     let duration = Duration::from_millis(423432);
     assert_eq!(resume_point.resume_position, duration);
+}
+
+#[test]
+fn test_currently_playing_context() {
+    let json = r#"
+{
+  "timestamp": 1607769168429,
+  "context": {
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/2lgOc40hhHqjUGAKMWqGxO"
+    },
+    "href": "https://api.spotify.com/v1/albums/2lgOc40hhHqjUGAKMWqGxO",
+    "type": "album",
+    "uri": "spotify:album:2lgOc40hhHqjUGAKMWqGxO"
+  },
+  "progress_ms": 22270,
+  "item": {
+    "album": {
+      "album_type": "single",
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0cGUm45nv7Z6M6qdXYQGTX"
+          },
+          "href": "https://api.spotify.com/v1/artists/0cGUm45nv7Z6M6qdXYQGTX",
+          "id": "0cGUm45nv7Z6M6qdXYQGTX",
+          "name": "Kehlani",
+          "type": "artist",
+          "uri": "spotify:artist:0cGUm45nv7Z6M6qdXYQGTX"
+        }
+      ],
+      "external_urls": {
+        "spotify": "https://open.spotify.com/album/2lgOc40hhHqjUGAKMWqGxO"
+      },
+      "href": "https://api.spotify.com/v1/albums/2lgOc40hhHqjUGAKMWqGxO",
+      "id": "2lgOc40hhHqjUGAKMWqGxO",
+      "images": [
+        {
+          "height": 64,
+          "url": "https://i.scdn.co/image/ab67616d00004851fa7b2b60e85950ee93dcdc04",
+          "width": 64
+        }
+      ],
+      "name": "Playinwitme (feat. Kehlani)",
+      "release_date": "2018-03-20",
+      "release_date_precision": "day",
+      "total_tracks": 1,
+      "type": "album",
+      "uri": "spotify:album:2lgOc40hhHqjUGAKMWqGxO"
+    },
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/0cGUm45nv7Z6M6qdXYQGTX"
+        },
+        "href": "https://api.spotify.com/v1/artists/0cGUm45nv7Z6M6qdXYQGTX",
+        "id": "0cGUm45nv7Z6M6qdXYQGTX",
+        "name": "Kehlani",
+        "type": "artist",
+        "uri": "spotify:artist:0cGUm45nv7Z6M6qdXYQGTX"
+      }
+    ],
+    "available_markets": [],
+    "disc_number": 1,
+    "duration_ms": 191680,
+    "explicit": false,
+    "external_ids": {
+      "isrc": "USAT21801141"
+    },
+    "external_urls": {
+      "spotify": "https://open.spotify.com/track/4F1yvJfQ7gJkrcgFJQDjOr"
+    },
+    "href": "https://api.spotify.com/v1/tracks/4F1yvJfQ7gJkrcgFJQDjOr",
+    "id": "4F1yvJfQ7gJkrcgFJQDjOr",
+    "is_local": false,
+    "is_playable": true,
+    "linked_from": {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/43cFjTTCD9Cni4aSL0sORz"
+      },
+      "href": "https://api.spotify.com/v1/tracks/43cFjTTCD9Cni4aSL0sORz",
+      "id": "43cFjTTCD9Cni4aSL0sORz",
+      "type": "track",
+      "uri": "spotify:track:43cFjTTCD9Cni4aSL0sORz"
+    },
+    "name": "Playinwitme (feat. Kehlani)",
+    "popularity": 70,
+    "preview_url": "https://p.scdn.co/mp3-preview/05e8881d5c896a8d147d2e79150fb5480a4fb186?cid=774b29d4f13844c495f206cafdad9c86",
+    "track_number": 9,
+    "type": "track",
+    "uri": "spotify:track:4F1yvJfQ7gJkrcgFJQDjOr"
+  },
+  "currently_playing_type": "track",
+  "actions": {
+    "disallows": {
+      "resuming": true,
+      "skipping_prev": true
+    }
+  },
+  "is_playing": true
+}
+    "#;
+    let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607769168429;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(currently_playing_context.timestamp, dt);
 }

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1,5 +1,6 @@
 use rspotify::model::*;
 use serde::Deserialize;
+use std::time::Duration;
 #[test]
 fn test_simplified_track() {
     let json_str = r#"
@@ -409,4 +410,33 @@ fn test_full_playlist() {
         "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
     );
     assert_eq!(full_playlist.followers.total, 109);
+}
+
+#[test]
+fn test_audio_features() {
+    let json = r#"
+    {
+        "duration_ms" : 255349,
+        "key" : 5,
+        "mode" : 0,
+        "time_signature" : 4,
+        "acousticness" : 0.514,
+        "danceability" : 0.735,
+        "energy" : 0.578,
+        "instrumentalness" : 0.0902,
+        "liveness" : 0.159,
+        "loudness" : -11.840,
+        "speechiness" : 0.0461,
+        "valence" : 0.624,
+        "tempo" : 98.002,
+        "id" : "06AKEBrKUckW0KREUWRnvT",
+        "uri" : "spotify:track:06AKEBrKUckW0KREUWRnvT",
+        "track_href" : "https://api.spotify.com/v1/tracks/06AKEBrKUckW0KREUWRnvT",
+        "analysis_url" : "https://api.spotify.com/v1/audio-analysis/06AKEBrKUckW0KREUWRnvT",
+        "type" : "audio_features"
+    }
+    "#;
+    let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
+    let duration = Duration::from_millis(255349);
+    assert_eq!(audio_features.duration, duration);
 }

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -814,3 +814,24 @@ fn test_current_playback_context() {
     assert_eq!(current_playback_context.timestamp, dt);
     assert!(current_playback_context.progress.is_none());
 }
+
+#[test]
+fn test_offset() {
+    let json = r#"
+  {
+    "position": 5,
+    "uri": "spotify:track:1301WleyT98MSxVHPZCA6M"
+  }
+  "#;
+    let offset: Offset = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(5);
+    assert_eq!(offset.position, Some(duration));
+
+    let empty_json = r#"
+  {
+
+  }
+  "#;
+    let empty_offset: Offset = serde_json::from_str(&empty_json).unwrap();
+    assert!(empty_offset.position.is_none());
+}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1,5 +1,4 @@
 use rspotify::model::*;
-use serde::Deserialize;
 use std::time::Duration;
 #[test]
 fn test_simplified_track() {
@@ -175,18 +174,70 @@ fn test_simplified_episode() {
 
 #[test]
 fn test_full_episode() {
-    #[derive(Deserialize)]
-    struct TestStruct {
-        pub release_date_precision: DatePrecision,
-    }
     let json_str = r#"
-     
-        {
-            "release_date_precision": "day"
-        }
+    {
+        "audio_preview_url": "https://p.scdn.co/mp3-preview/566fcc94708f39bcddc09e4ce84a8e5db8f07d4d",
+        "description": "En ny tysk ",
+        "duration_ms": 1502795,
+        "explicit": false,
+        "external_urls": {
+            "spotify": "https://open.spotify.com/episode/512ojhOuo1ktJprKbVcKyQ"
+        },
+        "href": "https://api.spotify.com/v1/episodes/512ojhOuo1ktJprKbVcKyQ",
+        "id": "512ojhOuo1ktJprKbVcKyQ",
+        "images": [
+            {
+                "height": 64,
+                "url": "https://i.scdn.co/image/e29c75799cad73927fad713011edad574868d8da",
+                "width": 64
+            }
+        ],
+        "is_externally_hosted": false,
+        "is_playable": true,
+        "language": "sv",
+        "languages": [
+            "sv"
+        ],
+        "name": "Tredje rikets knarkande granskas",
+        "release_date": "2015-10-01",
+        "release_date_precision": "day",
+        "show": {
+            "available_markets": [
+                "ZA"
+            ],
+            "copyrights": [],
+            "description": "Vi är där historien är. Ansvarig utgivare: Nina Glans",
+            "explicit": false,
+            "external_urls": {
+                "spotify": "https://open.spotify.com/show/38bS44xjbVVZ3No3ByF1dJ"
+            },
+            "href": "https://api.spotify.com/v1/shows/38bS44xjbVVZ3No3ByF1dJ",
+            "id": "38bS44xjbVVZ3No3ByF1dJ",
+            "images": [
+                {
+                    "height": 64,
+                    "url": "https://i.scdn.co/image/3dc007829bc0663c24089e46743a9f4ae15e65f8",
+                    "width": 64
+                }
+            ],
+            "is_externally_hosted": false,
+            "languages": [
+                "sv"
+            ],
+            "media_type": "audio",
+            "name": "Vetenskapsradion Historia",
+            "publisher": "Sveriges Radio",
+            "type": "show",
+            "uri": "spotify:show:38bS44xjbVVZ3No3ByF1dJ"
+        },
+        "type": "episode",
+        "uri": "spotify:episode:512ojhOuo1ktJprKbVcKyQ"
+    }
         "#;
-    let test_struct: TestStruct = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(test_struct.release_date_precision, DatePrecision::Day);
+    let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
+    let duration = Duration::from_millis(1502795);
+    assert_eq!(full_episode.duration, duration);
 }
 
 #[test]

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -410,22 +410,3 @@ fn test_full_playlist() {
     );
     assert_eq!(full_playlist.followers.total, 109);
 }
-
-#[test]
-fn test_devices() {
-    let json_str = r#"
-        {
-            "devices" : [ {
-                "id" : "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
-                "is_active" : false,
-                "is_private_session": true,
-                "is_restricted" : false,
-                "name" : "My fridge",
-                "type" : "Computer",
-                "volume_percent" : 100
-            } ]
-        }
-"#;
-    let payload: DevicePayload = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(payload.devices[0]._type, DeviceType::Computer)
-}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -494,3 +494,82 @@ fn test_audio_features() {
     let duration = Duration::from_millis(255349);
     assert_eq!(audio_features.duration, duration);
 }
+
+#[test]
+fn test_full_track() {
+    let json = r#"
+    {
+  "album": {
+    "album_type": "single",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/6sFIWsNpZYqfjUpaCgueju"
+        },
+        "href": "https://api.spotify.com/v1/artists/6sFIWsNpZYqfjUpaCgueju",
+        "id": "6sFIWsNpZYqfjUpaCgueju",
+        "name": "Carly Rae Jepsen",
+        "type": "artist",
+        "uri": "spotify:artist:6sFIWsNpZYqfjUpaCgueju"
+      }
+    ],
+    "available_markets": [
+      "ZA"
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/0tGPJ0bkWOUmH7MEOR77qc"
+    },
+    "href": "https://api.spotify.com/v1/albums/0tGPJ0bkWOUmH7MEOR77qc",
+    "id": "0tGPJ0bkWOUmH7MEOR77qc",
+    "images": [
+      {
+        "height": 64,
+        "url": "https://i.scdn.co/image/5a73a056d0af707b4119a883d87285feda543fbb",
+        "width": 64
+      }
+    ],
+    "name": "Cut To The Feeling",
+    "release_date": "2017-05-26",
+    "release_date_precision": "day",
+    "type": "album",
+    "uri": "spotify:album:0tGPJ0bkWOUmH7MEOR77qc"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/6sFIWsNpZYqfjUpaCgueju"
+      },
+      "href": "https://api.spotify.com/v1/artists/6sFIWsNpZYqfjUpaCgueju",
+      "id": "6sFIWsNpZYqfjUpaCgueju",
+      "name": "Carly Rae Jepsen",
+      "type": "artist",
+      "uri": "spotify:artist:6sFIWsNpZYqfjUpaCgueju"
+    }
+  ],
+  "available_markets": [
+    "ZA"
+  ],
+  "disc_number": 1,
+  "duration_ms": 207959,
+  "explicit": false,
+  "external_ids": {
+    "isrc": "USUM71703861"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl"
+  },
+  "href": "https://api.spotify.com/v1/tracks/11dFghVXANMlKmJXsNCbNl",
+  "id": "11dFghVXANMlKmJXsNCbNl",
+  "is_local": false,
+  "name": "Cut To The Feeling",
+  "popularity": 63,
+  "preview_url": "https://p.scdn.co/mp3-preview/3eb16018c2a700240e9dfb8817b6f2d041f15eb1?cid=774b29d4f13844c495f206cafdad9c86",
+  "track_number": 1,
+  "type": "track",
+  "uri": "spotify:track:11dFghVXANMlKmJXsNCbNl"
+}
+    "#;
+    let full_track: FullTrack = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(207959);
+    assert_eq!(full_track.duration, duration);
+}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -3,7 +3,7 @@ use rspotify::model::*;
 use std::time::Duration;
 #[test]
 fn test_simplified_track() {
-    let json_str = r#"
+  let json_str = r#"
 {
     "artists": [ {
       "external_urls": {
@@ -33,14 +33,14 @@ fn test_simplified_track() {
   }
 
 "#;
-    let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
-    let duration = Duration::from_millis(276773);
-    assert_eq!(track.duration, duration);
+  let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
+  let duration = Duration::from_millis(276773);
+  assert_eq!(track.duration, duration);
 }
 
 #[test]
 fn test_public_user() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "display_name": "Ronald Pompa",
             "external_urls": {
@@ -63,12 +63,12 @@ fn test_public_user() {
             "uri": "spotify:user:wizzler"
         }
         "#;
-    let user: PublicUser = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(user.id, "wizzler".to_string());
+  let user: PublicUser = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(user.id, "wizzler".to_string());
 }
 #[test]
 fn test_private_user() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "country": "US",
             "display_name": "Sergey",
@@ -92,13 +92,13 @@ fn test_private_user() {
             "uri": "spotify:user:waq5aexykhm6nlv0cnwdieng0"
           } 
         "#;
-    let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
+  let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
 }
 
 #[test]
 fn test_full_artist() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "external_urls": {
                 "spotify": "https://open.spotify.com/artist/0OdUWJ0sBjDrqHygGUXeCF"
@@ -125,14 +125,14 @@ fn test_full_artist() {
             "uri": "spotify:artist:0OdUWJ0sBjDrqHygGUXeCF"
         }
         "#;
-    let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(full_artist.name, "Band of Horses");
-    assert_eq!(full_artist.followers.total, 833247);
+  let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(full_artist.name, "Band of Horses");
+  assert_eq!(full_artist.followers.total, 833247);
 }
 
 #[test]
 fn test_simplified_episode() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "audio_preview_url": "https://p.scdn.co/mp3-preview/d8b916e1872de2bb0285d8c7bfe2b4b57011c85c",
             "description": "En unik barockträdgård från 1600-talet gömmer sig på Södermalm i Stockholm och nu gräver arkeologerna ut parken och kvarteret där Bellman lekte som barn.  Nu grävs Carl Michael Bellmans kvarter fram på Södermalm i Stockholm. Under dagens jordyta döljer sig en rik barockträdgård, men också tunga industrier från en tid då Söder var stockholmarnas sommarnöje. Dessutom om hur arkeologer ska kunna bli bättre att hitta de fattigas kulturarv. För vid sidan av slott, borgar och hallar finns torpen och backstugorna som utgör ett fortfarande okänt kulturarv som angår oss alla. Programledare Tobias Svanelid.",
@@ -167,18 +167,18 @@ fn test_simplified_episode() {
             "uri": "spotify:episode:3brfPv3PaUhspkm1T9ZVl8"
         }
         "#;
-    let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(
-        simplified_episode.release_date_precision,
-        DatePrecision::Day
-    );
-    let duration = Duration::from_millis(2685023);
-    assert_eq!(simplified_episode.duration, duration);
+  let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(
+    simplified_episode.release_date_precision,
+    DatePrecision::Day
+  );
+  let duration = Duration::from_millis(2685023);
+  assert_eq!(simplified_episode.duration, duration);
 }
 
 #[test]
 fn test_full_episode() {
-    let json_str = r#"
+  let json_str = r#"
     {
         "audio_preview_url": "https://p.scdn.co/mp3-preview/566fcc94708f39bcddc09e4ce84a8e5db8f07d4d",
         "description": "En ny tysk ",
@@ -238,28 +238,28 @@ fn test_full_episode() {
         "uri": "spotify:episode:512ojhOuo1ktJprKbVcKyQ"
     }
         "#;
-    let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
-    let duration = Duration::from_millis(1502795);
-    assert_eq!(full_episode.duration, duration);
+  let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
+  let duration = Duration::from_millis(1502795);
+  assert_eq!(full_episode.duration, duration);
 }
 
 #[test]
 fn test_copyright() {
-    let json_str = r#"
+  let json_str = r#"
 	[ {
 	    "text" : "(P) 2000 Sony Music Entertainment Inc.",
 	    "type" : "P"
 	} ]
 
 "#;
-    let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(copyrights[0]._type, CopyrightType::Performance);
+  let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(copyrights[0]._type, CopyrightType::Performance);
 }
 
 #[test]
 fn test_audio_analysis_section() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "start": 237.02356,
             "duration": 18.32542,
@@ -275,12 +275,12 @@ fn test_audio_analysis_section() {
             "time_signature_confidence": 1
         }
         "#;
-    let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(session.time_interval.duration, 18.32542);
+  let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(session.time_interval.duration, 18.32542);
 }
 #[test]
 fn test_audio_analysis_segments() {
-    let json_str = r#"
+  let json_str = r#"
          {
             "start": 252.15601,
             "duration": 3.19297,
@@ -297,26 +297,26 @@ fn test_audio_analysis_segments() {
             ]
             }
             "#;
-    let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(segment.time_interval.start, 252.15601);
+  let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(segment.time_interval.start, 252.15601);
 }
 
 #[test]
 fn test_actions() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "disallows": {
                 "resuming": true
             }
         }
         "#;
-    let actions: Actions = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(actions.disallows[0], DisallowKey::Resuming);
+  let actions: Actions = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(actions.disallows[0], DisallowKey::Resuming);
 }
 
 #[test]
 fn test_recommendations_seed() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "initialPoolSize": 500,
             "afterFilteringSize": 380,
@@ -326,13 +326,13 @@ fn test_recommendations_seed() {
             "type": "artist"
         }        
         "#;
-    let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(seed._type, RecommendationsSeedType::Artist);
+  let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(seed._type, RecommendationsSeedType::Artist);
 }
 
 #[test]
 fn test_full_playlist() {
-    let json_str_images = r#"
+  let json_str_images = r#"
 [
     {
 	"height": null,
@@ -341,7 +341,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-    let json_str_simplified_artists = r#"
+  let json_str_simplified_artists = r#"
 [
     {
 	"external_urls": {
@@ -355,7 +355,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-    let json_str = r#"
+  let json_str = r#"
         {
             "collaborative": false,
             "description": "A playlist for testing pourposes",
@@ -459,17 +459,17 @@ fn test_full_playlist() {
             "uri": "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n"
         }
         "#.replace("json_str_images", json_str_images).replace("json_str_simplified_artists", json_str_simplified_artists);
-    let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(
-        full_playlist.uri,
-        "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
-    );
-    assert_eq!(full_playlist.followers.total, 109);
+  let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(
+    full_playlist.uri,
+    "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
+  );
+  assert_eq!(full_playlist.followers.total, 109);
 }
 
 #[test]
 fn test_audio_features() {
-    let json = r#"
+  let json = r#"
     {
         "duration_ms" : 255349,
         "key" : 5,
@@ -491,14 +491,14 @@ fn test_audio_features() {
         "type" : "audio_features"
     }
     "#;
-    let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
-    let duration = Duration::from_millis(255349);
-    assert_eq!(audio_features.duration, duration);
+  let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
+  let duration = Duration::from_millis(255349);
+  assert_eq!(audio_features.duration, duration);
 }
 
 #[test]
 fn test_full_track() {
-    let json = r#"
+  let json = r#"
     {
   "album": {
     "album_type": "single",
@@ -570,27 +570,27 @@ fn test_full_track() {
   "uri": "spotify:track:11dFghVXANMlKmJXsNCbNl"
 }
     "#;
-    let full_track: FullTrack = serde_json::from_str(&json).unwrap();
-    let duration = Duration::from_millis(207959);
-    assert_eq!(full_track.duration, duration);
+  let full_track: FullTrack = serde_json::from_str(&json).unwrap();
+  let duration = Duration::from_millis(207959);
+  assert_eq!(full_track.duration, duration);
 }
 
 #[test]
 fn test_resume_point() {
-    let json = r#"
+  let json = r#"
     {
         "fully_played": false,
         "resume_position_ms": 423432
     }   
     "#;
-    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
-    let duration = Duration::from_millis(423432);
-    assert_eq!(resume_point.resume_position, duration);
+  let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+  let duration = Duration::from_millis(423432);
+  assert_eq!(resume_point.resume_position, duration);
 }
 
 #[test]
 fn test_currently_playing_context() {
-    let json = r#"
+  let json = r#"
 {
   "timestamp": 1607769168429,
   "context": {
@@ -688,23 +688,23 @@ fn test_currently_playing_context() {
   "is_playing": true
 }
     "#;
-    let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
-    let timestamp = 1607769168429;
-    let second: i64 = (timestamp - timestamp % 1000) / 1000;
-    let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp(second, nanosecond as u32),
-        Utc,
-    );
-    assert_eq!(currently_playing_context.timestamp, dt);
+  let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
+  let timestamp = 1607769168429;
+  let second: i64 = (timestamp - timestamp % 1000) / 1000;
+  let nanosecond = (timestamp % 1000) * 1000000;
+  let dt = DateTime::<Utc>::from_utc(
+    NaiveDateTime::from_timestamp(second, nanosecond as u32),
+    Utc,
+  );
+  assert_eq!(currently_playing_context.timestamp, dt);
 
-    let duration = Duration::from_millis(22270);
-    assert_eq!(currently_playing_context.progress, Some(duration));
+  let duration = Duration::from_millis(22270);
+  assert_eq!(currently_playing_context.progress, Some(duration));
 }
 
 #[test]
 fn test_current_playback_context() {
-    let json = r#"
+  let json = r#"
 {
   "device": {
     "id": "28d0f845293d03a2713392905c6d30b6442719b5",
@@ -726,7 +726,6 @@ fn test_current_playback_context() {
     "type": "album",
     "uri": "spotify:album:2lgOc40hhHqjUGAKMWqGxO"
   },
-  "progress_ms": 137847,
   "item": {
     "album": {
       "album_type": "single",
@@ -804,13 +803,14 @@ fn test_current_playback_context() {
   "is_playing": true
 }
     "#;
-    let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
-    let timestamp = 1607774342714;
-    let second: i64 = (timestamp - timestamp % 1000) / 1000;
-    let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp(second, nanosecond as u32),
-        Utc,
-    );
-    assert_eq!(current_playback_context.timestamp, dt);
+  let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
+  let timestamp = 1607774342714;
+  let second: i64 = (timestamp - timestamp % 1000) / 1000;
+  let nanosecond = (timestamp % 1000) * 1000000;
+  let dt = DateTime::<Utc>::from_utc(
+    NaiveDateTime::from_timestamp(second, nanosecond as u32),
+    Utc,
+  );
+  assert_eq!(current_playback_context.timestamp, dt);
+  assert!(current_playback_context.progress.is_none());
 }

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -411,6 +411,7 @@ fn test_full_playlist() {
     assert_eq!(full_playlist.followers.total, 109);
 }
 
+#[test]
 fn test_devices() {
     let json_str = r#"
         {

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -697,6 +697,9 @@ fn test_currently_playing_context() {
         Utc,
     );
     assert_eq!(currently_playing_context.timestamp, dt);
+
+    let duration = Duration::from_millis(22270);
+    assert_eq!(currently_playing_context.progress, Some(duration));
 }
 
 #[test]

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -33,7 +33,8 @@ fn test_simplified_track() {
 
 "#;
     let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(track.duration_ms, 276773);
+    let duration = Duration::from_millis(276773);
+    assert_eq!(track.duration, duration);
 }
 
 #[test]

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -573,3 +573,16 @@ fn test_full_track() {
     let duration = Duration::from_millis(207959);
     assert_eq!(full_track.duration, duration);
 }
+
+#[test]
+fn test_resume_point() {
+    let json = r#"
+    {
+        "fully_played": false,
+        "resume_position_ms": 423432
+    }   
+    "#;
+    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(423432);
+    assert_eq!(resume_point.resume_position, duration);
+}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -698,3 +698,116 @@ fn test_currently_playing_context() {
     );
     assert_eq!(currently_playing_context.timestamp, dt);
 }
+
+#[test]
+fn test_current_playback_context() {
+    let json = r#"
+{
+  "device": {
+    "id": "28d0f845293d03a2713392905c6d30b6442719b5",
+    "is_active": true,
+    "is_private_session": false,
+    "is_restricted": false,
+    "name": "Web Player (Firefox)",
+    "type": "Computer",
+    "volume_percent": 100
+  },
+  "shuffle_state": false,
+  "repeat_state": "off",
+  "timestamp": 1607774342714,
+  "context": {
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/2lgOc40hhHqjUGAKMWqGxO"
+    },
+    "href": "https://api.spotify.com/v1/albums/2lgOc40hhHqjUGAKMWqGxO",
+    "type": "album",
+    "uri": "spotify:album:2lgOc40hhHqjUGAKMWqGxO"
+  },
+  "progress_ms": 137847,
+  "item": {
+    "album": {
+      "album_type": "single",
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0cGUm45nv7Z6M6qdXYQGTX"
+          },
+          "href": "https://api.spotify.com/v1/artists/0cGUm45nv7Z6M6qdXYQGTX",
+          "id": "0cGUm45nv7Z6M6qdXYQGTX",
+          "name": "Kehlani",
+          "type": "artist",
+          "uri": "spotify:artist:0cGUm45nv7Z6M6qdXYQGTX"
+        }
+      ],
+      "available_markets": [],
+      "external_urls": {
+        "spotify": "https://open.spotify.com/album/2lgOc40hhHqjUGAKMWqGxO"
+      },
+      "href": "https://api.spotify.com/v1/albums/2lgOc40hhHqjUGAKMWqGxO",
+      "id": "2lgOc40hhHqjUGAKMWqGxO",
+      "images": [
+        {
+          "height": 64,
+          "url": "https://i.scdn.co/image/ab67616d00004851fa7b2b60e85950ee93dcdc04",
+          "width": 64
+        }
+      ],
+      "name": "Playinwitme (feat. Kehlani)",
+      "release_date": "2018-03-20",
+      "release_date_precision": "day",
+      "total_tracks": 1,
+      "type": "album",
+      "uri": "spotify:album:2lgOc40hhHqjUGAKMWqGxO"
+    },
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/0cGUm45nv7Z6M6qdXYQGTX"
+        },
+        "href": "https://api.spotify.com/v1/artists/0cGUm45nv7Z6M6qdXYQGTX",
+        "id": "0cGUm45nv7Z6M6qdXYQGTX",
+        "name": "Kehlani",
+        "type": "artist",
+        "uri": "spotify:artist:0cGUm45nv7Z6M6qdXYQGTX"
+      }
+    ],
+    "available_markets": [],
+    "disc_number": 1,
+    "duration_ms": 193093,
+    "explicit": false,
+    "external_ids": {
+      "isrc": "USAT21801141"
+    },
+    "external_urls": {
+      "spotify": "https://open.spotify.com/track/43cFjTTCD9Cni4aSL0sORz"
+    },
+    "href": "https://api.spotify.com/v1/tracks/43cFjTTCD9Cni4aSL0sORz",
+    "id": "43cFjTTCD9Cni4aSL0sORz",
+    "is_local": false,
+    "name": "Playinwitme (feat. Kehlani)",
+    "popularity": 0,
+    "preview_url": null,
+    "track_number": 1,
+    "type": "track",
+    "uri": "spotify:track:43cFjTTCD9Cni4aSL0sORz"
+  },
+  "currently_playing_type": "track",
+  "actions": {
+    "disallows": {
+      "resuming": true,
+      "skipping_prev": true
+    }
+  },
+  "is_playing": true
+}
+    "#;
+    let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607774342714;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(current_playback_context.timestamp, dt);
+}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -3,7 +3,7 @@ use rspotify::model::*;
 use std::time::Duration;
 #[test]
 fn test_simplified_track() {
-  let json_str = r#"
+    let json_str = r#"
 {
     "artists": [ {
       "external_urls": {
@@ -33,14 +33,14 @@ fn test_simplified_track() {
   }
 
 "#;
-  let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
-  let duration = Duration::from_millis(276773);
-  assert_eq!(track.duration, duration);
+    let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
+    let duration = Duration::from_millis(276773);
+    assert_eq!(track.duration, duration);
 }
 
 #[test]
 fn test_public_user() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "display_name": "Ronald Pompa",
             "external_urls": {
@@ -63,12 +63,12 @@ fn test_public_user() {
             "uri": "spotify:user:wizzler"
         }
         "#;
-  let user: PublicUser = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(user.id, "wizzler".to_string());
+    let user: PublicUser = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(user.id, "wizzler".to_string());
 }
 #[test]
 fn test_private_user() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "country": "US",
             "display_name": "Sergey",
@@ -92,13 +92,13 @@ fn test_private_user() {
             "uri": "spotify:user:waq5aexykhm6nlv0cnwdieng0"
           } 
         "#;
-  let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
+    let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
 }
 
 #[test]
 fn test_full_artist() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "external_urls": {
                 "spotify": "https://open.spotify.com/artist/0OdUWJ0sBjDrqHygGUXeCF"
@@ -125,14 +125,14 @@ fn test_full_artist() {
             "uri": "spotify:artist:0OdUWJ0sBjDrqHygGUXeCF"
         }
         "#;
-  let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(full_artist.name, "Band of Horses");
-  assert_eq!(full_artist.followers.total, 833247);
+    let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(full_artist.name, "Band of Horses");
+    assert_eq!(full_artist.followers.total, 833247);
 }
 
 #[test]
 fn test_simplified_episode() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "audio_preview_url": "https://p.scdn.co/mp3-preview/d8b916e1872de2bb0285d8c7bfe2b4b57011c85c",
             "description": "En unik barockträdgård från 1600-talet gömmer sig på Södermalm i Stockholm och nu gräver arkeologerna ut parken och kvarteret där Bellman lekte som barn.  Nu grävs Carl Michael Bellmans kvarter fram på Södermalm i Stockholm. Under dagens jordyta döljer sig en rik barockträdgård, men också tunga industrier från en tid då Söder var stockholmarnas sommarnöje. Dessutom om hur arkeologer ska kunna bli bättre att hitta de fattigas kulturarv. För vid sidan av slott, borgar och hallar finns torpen och backstugorna som utgör ett fortfarande okänt kulturarv som angår oss alla. Programledare Tobias Svanelid.",
@@ -167,18 +167,18 @@ fn test_simplified_episode() {
             "uri": "spotify:episode:3brfPv3PaUhspkm1T9ZVl8"
         }
         "#;
-  let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(
-    simplified_episode.release_date_precision,
-    DatePrecision::Day
-  );
-  let duration = Duration::from_millis(2685023);
-  assert_eq!(simplified_episode.duration, duration);
+    let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(
+        simplified_episode.release_date_precision,
+        DatePrecision::Day
+    );
+    let duration = Duration::from_millis(2685023);
+    assert_eq!(simplified_episode.duration, duration);
 }
 
 #[test]
 fn test_full_episode() {
-  let json_str = r#"
+    let json_str = r#"
     {
         "audio_preview_url": "https://p.scdn.co/mp3-preview/566fcc94708f39bcddc09e4ce84a8e5db8f07d4d",
         "description": "En ny tysk ",
@@ -238,28 +238,28 @@ fn test_full_episode() {
         "uri": "spotify:episode:512ojhOuo1ktJprKbVcKyQ"
     }
         "#;
-  let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
-  let duration = Duration::from_millis(1502795);
-  assert_eq!(full_episode.duration, duration);
+    let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
+    let duration = Duration::from_millis(1502795);
+    assert_eq!(full_episode.duration, duration);
 }
 
 #[test]
 fn test_copyright() {
-  let json_str = r#"
+    let json_str = r#"
 	[ {
 	    "text" : "(P) 2000 Sony Music Entertainment Inc.",
 	    "type" : "P"
 	} ]
 
 "#;
-  let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(copyrights[0]._type, CopyrightType::Performance);
+    let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(copyrights[0]._type, CopyrightType::Performance);
 }
 
 #[test]
 fn test_audio_analysis_section() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "start": 237.02356,
             "duration": 18.32542,
@@ -275,12 +275,12 @@ fn test_audio_analysis_section() {
             "time_signature_confidence": 1
         }
         "#;
-  let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(session.time_interval.duration, 18.32542);
+    let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(session.time_interval.duration, 18.32542);
 }
 #[test]
 fn test_audio_analysis_segments() {
-  let json_str = r#"
+    let json_str = r#"
          {
             "start": 252.15601,
             "duration": 3.19297,
@@ -297,26 +297,26 @@ fn test_audio_analysis_segments() {
             ]
             }
             "#;
-  let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(segment.time_interval.start, 252.15601);
+    let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(segment.time_interval.start, 252.15601);
 }
 
 #[test]
 fn test_actions() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "disallows": {
                 "resuming": true
             }
         }
         "#;
-  let actions: Actions = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(actions.disallows[0], DisallowKey::Resuming);
+    let actions: Actions = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(actions.disallows[0], DisallowKey::Resuming);
 }
 
 #[test]
 fn test_recommendations_seed() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "initialPoolSize": 500,
             "afterFilteringSize": 380,
@@ -326,13 +326,13 @@ fn test_recommendations_seed() {
             "type": "artist"
         }        
         "#;
-  let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(seed._type, RecommendationsSeedType::Artist);
+    let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(seed._type, RecommendationsSeedType::Artist);
 }
 
 #[test]
 fn test_full_playlist() {
-  let json_str_images = r#"
+    let json_str_images = r#"
 [
     {
 	"height": null,
@@ -341,7 +341,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-  let json_str_simplified_artists = r#"
+    let json_str_simplified_artists = r#"
 [
     {
 	"external_urls": {
@@ -355,7 +355,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-  let json_str = r#"
+    let json_str = r#"
         {
             "collaborative": false,
             "description": "A playlist for testing pourposes",
@@ -459,17 +459,17 @@ fn test_full_playlist() {
             "uri": "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n"
         }
         "#.replace("json_str_images", json_str_images).replace("json_str_simplified_artists", json_str_simplified_artists);
-  let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(
-    full_playlist.uri,
-    "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
-  );
-  assert_eq!(full_playlist.followers.total, 109);
+    let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(
+        full_playlist.uri,
+        "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
+    );
+    assert_eq!(full_playlist.followers.total, 109);
 }
 
 #[test]
 fn test_audio_features() {
-  let json = r#"
+    let json = r#"
     {
         "duration_ms" : 255349,
         "key" : 5,
@@ -491,14 +491,14 @@ fn test_audio_features() {
         "type" : "audio_features"
     }
     "#;
-  let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
-  let duration = Duration::from_millis(255349);
-  assert_eq!(audio_features.duration, duration);
+    let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
+    let duration = Duration::from_millis(255349);
+    assert_eq!(audio_features.duration, duration);
 }
 
 #[test]
 fn test_full_track() {
-  let json = r#"
+    let json = r#"
     {
   "album": {
     "album_type": "single",
@@ -570,27 +570,27 @@ fn test_full_track() {
   "uri": "spotify:track:11dFghVXANMlKmJXsNCbNl"
 }
     "#;
-  let full_track: FullTrack = serde_json::from_str(&json).unwrap();
-  let duration = Duration::from_millis(207959);
-  assert_eq!(full_track.duration, duration);
+    let full_track: FullTrack = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(207959);
+    assert_eq!(full_track.duration, duration);
 }
 
 #[test]
 fn test_resume_point() {
-  let json = r#"
+    let json = r#"
     {
         "fully_played": false,
         "resume_position_ms": 423432
     }   
     "#;
-  let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
-  let duration = Duration::from_millis(423432);
-  assert_eq!(resume_point.resume_position, duration);
+    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(423432);
+    assert_eq!(resume_point.resume_position, duration);
 }
 
 #[test]
 fn test_currently_playing_context() {
-  let json = r#"
+    let json = r#"
 {
   "timestamp": 1607769168429,
   "context": {
@@ -688,23 +688,23 @@ fn test_currently_playing_context() {
   "is_playing": true
 }
     "#;
-  let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
-  let timestamp = 1607769168429;
-  let second: i64 = (timestamp - timestamp % 1000) / 1000;
-  let nanosecond = (timestamp % 1000) * 1000000;
-  let dt = DateTime::<Utc>::from_utc(
-    NaiveDateTime::from_timestamp(second, nanosecond as u32),
-    Utc,
-  );
-  assert_eq!(currently_playing_context.timestamp, dt);
+    let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607769168429;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(currently_playing_context.timestamp, dt);
 
-  let duration = Duration::from_millis(22270);
-  assert_eq!(currently_playing_context.progress, Some(duration));
+    let duration = Duration::from_millis(22270);
+    assert_eq!(currently_playing_context.progress, Some(duration));
 }
 
 #[test]
 fn test_current_playback_context() {
-  let json = r#"
+    let json = r#"
 {
   "device": {
     "id": "28d0f845293d03a2713392905c6d30b6442719b5",
@@ -803,14 +803,14 @@ fn test_current_playback_context() {
   "is_playing": true
 }
     "#;
-  let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
-  let timestamp = 1607774342714;
-  let second: i64 = (timestamp - timestamp % 1000) / 1000;
-  let nanosecond = (timestamp % 1000) * 1000000;
-  let dt = DateTime::<Utc>::from_utc(
-    NaiveDateTime::from_timestamp(second, nanosecond as u32),
-    Utc,
-  );
-  assert_eq!(current_playback_context.timestamp, dt);
-  assert!(current_playback_context.progress.is_none());
+    let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607774342714;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(current_playback_context.timestamp, dt);
+    assert!(current_playback_context.progress.is_none());
 }

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -170,6 +170,8 @@ fn test_simplified_episode() {
         simplified_episode.release_date_precision,
         DatePrecision::Day
     );
+    let duration = Duration::from_millis(2685023);
+    assert_eq!(simplified_episode.duration, duration);
 }
 
 #[test]

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -767,3 +767,14 @@ async fn test_add_queue() {
         .await
         .unwrap();
 }
+
+#[maybe_async]
+#[maybe_async_test]
+#[ignore]
+async fn test_get_several_shows() {
+    oauth_client()
+        .await
+        .get_several_shows(vec!["5CfCWKI5pZ28U0uOzXkDHe", "5as3aKmN2k11yfDDDSrvaZ"], None)
+        .await
+        .unwrap();
+}

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -774,7 +774,10 @@ async fn test_add_queue() {
 async fn test_get_several_shows() {
     oauth_client()
         .await
-        .get_several_shows(vec!["5CfCWKI5pZ28U0uOzXkDHe", "5as3aKmN2k11yfDDDSrvaZ"], None)
+        .get_several_shows(
+            vec!["5CfCWKI5pZ28U0uOzXkDHe", "5as3aKmN2k11yfDDDSrvaZ"],
+            None,
+        )
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

Keep polish the models by following the issues:

+ #127 
+ #149 

## Motivation and Context

To make `rspotify`'s API easier to use. 

+ [x] Types like FullAlbums, PageSimplifiedAlbums, etc exist as wrappers. This makes the API more complex. Instead, have that type exist solely in the API function that needs it, and then return a Vec<FullAlbum>. This drastically reduces the number of public API types. The wrapper objects need to be reduced: 
  - [x] `FullTracks`
  - [x] `CursorPageFullArtists`
  - [x] `SeversalSimplifiedShows`
  - [x] `DevicePayload`
  - [x] `AudioFeaturesPayload`
  - [x] `PageCategory`
  - [x] `PageSimpliedAlbums`
  - [x] `FullAlbums`
  - [x] `FullArtists`
+ [ ] `AudioAnalysisSection::mode` and `AudioFeatures::mode` are `f32s` but should be `Option<Mode>s` where `enum Mode { Major, Minor } `as it is more useful.
+ [ ] ~~`CursorBasedPage` should also not include the URLs.~~
+ [x] Rename `AudioFeatures.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+ [x] Rename `FullEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+ [x] Rename `SimplifiedEpisode.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+ [x] Rename `FullTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+ [x] Rename `SimplifiedTrack.duration_ms` to duration, and change its type from `u32` to `std::time::Duration`.
+ [x] `SimplifiedEpisode::duration_ms` should be a `Duration`.
+ [x] `Offset::position` should be a `Duration`
+ [x] `CurrentlyPlayingContext::progress_ms` should be `progress`: `Option<Duration>`.
+ [x] `CurrentPlaybackContext::progress_ms` should be `progress`: `Option<Duration>`.
+ [x] `ResumePoint::resume_position_ms` should be a `Duration`.
+ [x] `CurrentlyPlayingContext::timestamp` should be a `DateTime<Utc>`
+ [x] `CurrentPlaybackContext::timestamp` should be a `DateTime<Utc>`
+ [x] ~~`SimplifiedPlayingContext::timestamp` should be a `DateTime<Utc>`~~(`SimplifiedPlayingContext` is useless, just remove it.)

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] Reduce wrapper object:
  - [x] `FullArtists`: `test_artist_related_artists`, `test_artists`
  - [x] `FullTracks`: `test_artist_top_tracks`, `test_tracks`
  - [x] `CursorPageFullArtists`: `test_current_user_followed_artists`
  - [x] `SeversalSimplifiedShows`: `test_get_seversal_shows`
  - [x] `DevicePayload`: `test_device`
  - [x] `AudioFeaturesPayload`: `test_audios_features`
  - [x] `PageCategory`: `test_categories`
  - [x] `PageSimpliedAlbums`: `test_new_releases`
  - [x] `FullAlbums`: `test_albums`
- [x] Rename `duration_ms` to `duration`, and change its type from `f32` to `std::time::Duration`
  - [x] `AudioFeatures`: `test_audio_features`
  - [x] `FullEpisode`: `test_full_episode`
  - [x] `SimplifiedEpisode`: `simplified_episode`
  - [x] `FullTrack`: `test_full_track` 
  - [x] `SimplifiedTrack`: `test_simplified_track` 
+ [x] `ResumePoint::resume_position_ms` should be a `Duration`: `test_resume_point`
- [x] `CurrentlyPlayingContext/CurrentlyPlaybackContext/SimplifiedPlayingContext::timestamp` should be a `DateTime<Utc>` 
  + [x] `CurrentlyPlayingContext`: `test_currently_playing_context`
  + [x] `CurrentPlaybackContext`: `test_current_playback_context`
+ [x] `Offset::position` should be a `Duration`: `test_offset`

PS: it seems the pull request template doesn't works, I just add the content manually, and I would like to open a new PR to test the pull request template individually 