### PR TITLE
explicitly forbid having both client features enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,8 +154,9 @@
 //! ](https://github.com/ramsayleung/rspotify/tree/master/examples)
 //! which can serve as a learning tool.
 
-// disable all modules when both client features are enabled, this way only the compile error below gets
-// show instead of showing a whole list of confusing errors
+// disable all modules when both client features are enabled,
+// this way only the compile error below gets show
+// instead of showing a whole list of confusing errors
 #[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 pub mod client;
 #[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
@@ -168,7 +169,10 @@ pub mod oauth2;
 pub mod util;
 
 #[cfg(all(feature = "client-reqwest", feature = "client-ureq"))]
-compile_error!("`client-reqwest` and `client-ureq` features cannot be both enabled at the same time, if you want to use `client-ureq` you need to set `default-features = false`");
+compile_error!(
+    "`client-reqwest` and `client-ureq` features cannot both be enabled at the same time, \
+  if you want to use `client-ureq` you need to set `default-features = false`"
+);
 
 #[doc(hidden)]
 mod macros {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,11 +154,21 @@
 //! ](https://github.com/ramsayleung/rspotify/tree/master/examples)
 //! which can serve as a learning tool.
 
+// disable all modules when both client features are enabled, this way only the compile error below gets
+// show instead of showing a whole list of confusing errors
+#[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 pub mod client;
+#[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 mod http;
+#[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 pub mod model;
+#[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 pub mod oauth2;
+#[cfg(not(all(feature = "client-reqwest", feature = "client-ureq")))]
 pub mod util;
+
+#[cfg(all(feature = "client-reqwest", feature = "client-ureq"))]
+compile_error!("`client-reqwest` and `client-ureq` features cannot be both enabled at the same time, if you want to use `client-ureq` you need to set `default-features = false`");
 
 #[doc(hidden)]
 mod macros {


### PR DESCRIPTION
## Description

Instead of showing various `duplicate definition` errors when a user tries to compile the library with both client features, provide a meaningful error message explaining that both features can't be enabled at the same time.