### PR TITLE
Mention line lengths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please see the [changelog](./CHANGELOG.md) for a release history and indications
 
 If you find any problems or have suggestions about this crate, please submit an issue. Moreover, any pull request, code review and feedback are welcome.
 
+We use GitHub Actions to make sure the codebase is consistent (`cargo fmt`) and continuously tested (`cargo test`). We try to keep comments at a maximum of 80 characters of length (which isn't automatically checked by `cargo fmt`) and code at 120.
+
 ## Building
 
 Rspotify uses [`maybe_async`](https://docs.rs/maybe-async/0.2.0/maybe_async/) to switch between async and blocking clients, which is triggered inside `Cargo.toml`. So that must be taken into account when building `rspotify`. Read the Configuration section in the docs for more information about how to build with custom TLS implementations, and more.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please see the [changelog](./CHANGELOG.md) for a release history and indications
 
 If you find any problems or have suggestions about this crate, please submit an issue. Moreover, any pull request, code review and feedback are welcome.
 
+### Code Guide
+
 We use GitHub Actions to make sure the codebase is consistent (`cargo fmt`) and continuously tested (`cargo test`). We try to keep comments at a maximum of 80 characters of length (which isn't automatically checked by `cargo fmt`) and code at 120.
 
 ## Building


### PR DESCRIPTION
## Description

This should fix what we discussed at #167 regarding line lengths that aren't checked automatically by `cargo fmt`. Let me know if you think it could be worded differently.
