### PR TITLE
Improved test error messages and small CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features=cli,env-file,${{ matrix.client }}
+          args: --no-default-features --features=env-file,${{ matrix.client }}
 
   lints:
     name: Lints

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -10,9 +10,14 @@ use maybe_async::maybe_async;
 /// Generating a new basic client for the requests.
 #[maybe_async]
 pub async fn creds_client() -> Spotify {
-    // The credentials must be available in the environment. Enable
-    // `env-file` in order to read them from an `.env` file.
-    let creds = CredentialsBuilder::from_env().build().unwrap();
+    // The credentials must be available in the environment.
+    let creds = CredentialsBuilder::from_env().build().unwrap_or_else(|_| {
+        panic!(
+            "No credentials configured. Make sure that either the `env-file` \
+            feature is enabled, or that the required environment variables are \
+            exported (`RSPOTIFY_CLIENT_ID`, `RSPOTIFY_CLIENT_SECRET`)"
+        )
+    });
 
     let mut spotify = SpotifyBuilder::default()
         .credentials(creds)

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -41,7 +41,13 @@ pub async fn oauth_client() -> Spotify {
     } else if let Ok(refresh_token) = env::var("RSPOTIFY_REFRESH_TOKEN") {
         // The credentials must be available in the environment. Enable
         // `env-file` in order to read them from an `.env` file.
-        let creds = CredentialsBuilder::from_env().build().unwrap();
+        let creds = CredentialsBuilder::from_env().build().unwrap_or_else(|_| {
+            panic!(
+                "No credentials configured. Make sure that the required \
+                environment variables are exported (`RSPOTIFY_CLIENT_ID`, \
+                `RSPOTIFY_CLIENT_SECRET`)"
+            )
+        });
 
         // Using every possible scope
         let oauth = OAuthBuilder::from_env()

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -43,9 +43,10 @@ pub async fn oauth_client() -> Spotify {
         // `env-file` in order to read them from an `.env` file.
         let creds = CredentialsBuilder::from_env().build().unwrap_or_else(|_| {
             panic!(
-                "No credentials configured. Make sure that the required \
+                "No credentials configured. Make sure that either the \
+                `env-file` feature is enabled, or that the required \
                 environment variables are exported (`RSPOTIFY_CLIENT_ID`, \
-                `RSPOTIFY_CLIENT_SECRET`)"
+                `RSPOTIFY_CLIENT_SECRET`)."
             )
         });
 


### PR DESCRIPTION
## Description

If you ran `cargo test` without the `env-file` feature by mistake or no credentials set, you'd get a somewhat weird error. This should provide more context for both `test_with_credential` and `test_with_oauth`. I also removed the `cli` feature from the CI tests as it's not really needed for now (CI can't interact with the user anyway).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've just ran the tests a couple times expecting these errors