### PR TITLE
Serialize enum as number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,7 +179,8 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Change `CurrentPlaybackContext.timestamp`'s type from `u64` to `chrono::DateTime<Utc>`.
   + Change `Offset.position`'s type from `Option<u32>` to `Option<std::time::Duration>`
   + Remove `SimplifiedPlayingContext`, since it's useless.
-
+- ([#177](https://github.com/ramsayleung/rspotify/pull/157)) Change `mode` from `f32` to `enum Modality`:
+  + Change `AudioAnalysisSection::mode`, `AudioAnalysisTrack::mode` and `AudioFeatures::mode` from `f32` to `enum Modality`.
 ## 0.10 (2020/07/01)
 
 - Add `get_access_token_without_cache` and `refresh_access_token_without_cache` to get and refresh access token without caching it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Remove `SimplifiedPlayingContext`, since it's useless.
 - ([#177](https://github.com/ramsayleung/rspotify/pull/157)) Change `mode` from `f32` to `enum Modality`:
   + Change `AudioAnalysisSection::mode`, `AudioAnalysisTrack::mode` and `AudioFeatures::mode` from `f32` to `enum Modality`.
+
 ## 0.10 (2020/07/01)
 
 - Add `get_access_token_without_cache` and `refresh_access_token_without_cache` to get and refresh access token without caching it.

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -1,5 +1,5 @@
 //! All objects related to artist defined by Spotify API
-use crate::model::{enums::Modality, from_duration_ms, modality, to_duration_ms};
+use crate::model::{duration_ms, enums::Modality, modality};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -11,11 +11,7 @@ pub struct AudioFeatures {
     pub acousticness: f32,
     pub analysis_url: String,
     pub danceability: f32,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "duration_ms")]
     pub duration: Duration,
     pub energy: f32,
     pub id: String,

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -1,5 +1,5 @@
 //! All objects related to artist defined by Spotify API
-use crate::model::{from_duration_ms, to_duration_ms};
+use crate::model::{enums::Modality, from_duration_ms, modality, to_duration_ms};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -23,7 +23,8 @@ pub struct AudioFeatures {
     pub key: i32,
     pub liveness: f32,
     pub loudness: f32,
-    pub mode: f32,
+    #[serde(with = "modality")]
+    pub mode: Modality,
     pub speechiness: f32,
     pub tempo: f32,
     pub time_signature: i32,
@@ -77,7 +78,8 @@ pub struct AudioAnalysisSection {
     pub tempo_confidence: f32,
     pub key: i32,
     pub key_confidence: f32,
-    pub mode: f32,
+    #[serde(with = "modality")]
+    pub mode: Modality,
     pub mode_confidence: f32,
     pub time_signature: i32,
     pub time_signature_confidence: f32,
@@ -132,7 +134,8 @@ pub struct AudioAnalysisTrack {
     pub time_signature_confidence: f32,
     pub key: u32,
     pub key_confidence: f32,
-    pub mode: f32,
+    #[serde(with = "modality")]
+    pub mode: Modality,
     pub mode_confidence: f32,
     pub codestring: String,
     pub code_version: f32,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -2,8 +2,8 @@
 use super::device::Device;
 use super::PlayingItem;
 use crate::model::{
-    from_millisecond_timestamp, from_option_duration_ms, to_millisecond_timestamp,
-    to_option_duration_ms, CurrentlyPlayingType, DisallowKey, RepeatState, Type,
+    from_option_duration_ms, millisecond_timestamp, to_option_duration_ms, CurrentlyPlayingType,
+    DisallowKey, RepeatState, Type,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -27,10 +27,7 @@ pub struct Context {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentlyPlayingContext {
     pub context: Option<Context>,
-    #[serde(
-        deserialize_with = "from_millisecond_timestamp",
-        serialize_with = "to_millisecond_timestamp"
-    )]
+    #[serde(with = "millisecond_timestamp")]
     pub timestamp: DateTime<Utc>,
     #[serde(default)]
     #[serde(
@@ -51,10 +48,7 @@ pub struct CurrentPlaybackContext {
     pub repeat_state: RepeatState,
     pub shuffle_state: bool,
     pub context: Option<Context>,
-    #[serde(
-        deserialize_with = "from_millisecond_timestamp",
-        serialize_with = "to_millisecond_timestamp"
-    )]
+    #[serde(with = "millisecond_timestamp")]
     pub timestamp: DateTime<Utc>,
     #[serde(default)]
     #[serde(

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -2,8 +2,7 @@
 use super::device::Device;
 use super::PlayingItem;
 use crate::model::{
-    from_option_duration_ms, millisecond_timestamp, to_option_duration_ms, CurrentlyPlayingType,
-    DisallowKey, RepeatState, Type,
+    millisecond_timestamp, option_duration_ms, CurrentlyPlayingType, DisallowKey, RepeatState, Type,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -30,11 +29,7 @@ pub struct CurrentlyPlayingContext {
     #[serde(with = "millisecond_timestamp")]
     pub timestamp: DateTime<Utc>,
     #[serde(default)]
-    #[serde(
-        deserialize_with = "from_option_duration_ms",
-        serialize_with = "to_option_duration_ms",
-        rename = "progress_ms"
-    )]
+    #[serde(with = "option_duration_ms", rename = "progress_ms")]
     pub progress: Option<Duration>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,
@@ -51,11 +46,7 @@ pub struct CurrentPlaybackContext {
     #[serde(with = "millisecond_timestamp")]
     pub timestamp: DateTime<Utc>,
     #[serde(default)]
-    #[serde(
-        deserialize_with = "from_option_duration_ms",
-        serialize_with = "to_option_duration_ms",
-        rename = "progress_ms"
-    )]
+    #[serde(with = "option_duration_ms", rename = "progress_ms")]
     pub progress: Option<Duration>,
     pub is_playing: bool,
     pub item: Option<PlayingItem>,

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -79,3 +79,15 @@ pub enum RestrictionReason {
     Product,
     Explict,
 }
+
+/// Indicates the modality (major or minor) of a track
+/// This field will contain a 0 for `minor`, a 1 for `major` or
+/// a -1 for `no result`
+/// 
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#section-object)
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, ToString)]
+pub enum Modality {
+    Minor,
+    Major,
+    NoResult,
+}

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -87,7 +87,7 @@ pub enum RestrictionReason {
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#section-object)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, ToString)]
 pub enum Modality {
-    Minor,
-    Major,
-    NoResult,
+    Minor = 0,
+    Major = 1,
+    NoResult = -1,
 }

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -83,7 +83,7 @@ pub enum RestrictionReason {
 /// Indicates the modality (major or minor) of a track
 /// This field will contain a 0 for `minor`, a 1 for `major` or
 /// a -1 for `no result`
-/// 
+///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#section-object)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, ToString)]
 pub enum Modality {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -139,6 +139,38 @@ where
     }
 }
 
+pub(in crate) mod modality {
+    use super::enums::Modality;
+    use serde::{de, Deserialize, Serializer};
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Modality, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let v = i8::deserialize(d)?;
+        match v {
+            0 => Ok(Modality::Minor),
+            1 => Ok(Modality::Major),
+            -1 => Ok(Modality::NoResult),
+            _ => Err(de::Error::invalid_value(
+                de::Unexpected::Signed(v.into()),
+                &"valid value: 0, 1, -1",
+            )),
+        }
+    }
+
+    pub fn serialize<S>(x: &Modality, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match x {
+            Modality::Minor => s.serialize_i8(0),
+            Modality::Major => s.serialize_i8(1),
+            Modality::NoResult => s.serialize_i8(-1),
+        }
+    }
+}
+
 /// Restriction object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-restriction-object)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -139,6 +139,7 @@ where
     }
 }
 
+/// Deserialize/Serialize `Modality` to integer(0, 1, -1).
 pub(in crate) mod modality {
     use super::enums::Modality;
     use serde::{de, Deserialize, Serializer};

--- a/src/model/offset.rs
+++ b/src/model/offset.rs
@@ -1,5 +1,5 @@
 //! Offset object
-use crate::model::{from_option_duration_ms, to_option_duration_ms};
+use crate::model::option_duration_ms;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -9,10 +9,7 @@ use std::time::Duration;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Offset {
     #[serde(default)]
-    #[serde(
-        deserialize_with = "from_option_duration_ms",
-        serialize_with = "to_option_duration_ms"
-    )]
+    #[serde(with = "option_duration_ms")]
     pub position: Option<Duration>,
     pub uri: Option<String>,
 }

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -1,6 +1,6 @@
 use super::image::Image;
 use super::page::Page;
-use crate::model::{from_duration_ms, to_duration_ms, CopyrightType, DatePrecision};
+use crate::model::{duration_ms, CopyrightType, DatePrecision};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -86,11 +86,7 @@ pub struct FullShow {
 pub struct SimplifiedEpisode {
     pub audio_preview_url: Option<String>,
     pub description: String,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "duration_ms")]
     pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
@@ -120,11 +116,7 @@ pub struct SimplifiedEpisode {
 pub struct FullEpisode {
     pub audio_preview_url: Option<String>,
     pub description: String,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "duration_ms")]
     pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
@@ -156,10 +148,6 @@ pub struct SeveralEpisodes {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResumePoint {
     pub fully_played: bool,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "resume_position_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "resume_position_ms")]
     pub resume_position: Duration,
 }

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -7,8 +7,8 @@ use std::{collections::HashMap, time::Duration};
 use super::album::SimplifiedAlbum;
 use super::artist::SimplifiedArtist;
 use super::Restriction;
+use crate::model::duration_ms;
 use crate::model::Type;
-use crate::model::{from_duration_ms, to_duration_ms};
 /// Full track object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full)
@@ -19,11 +19,7 @@ pub struct FullTrack {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub available_markets: Vec<String>,
     pub disc_number: i32,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "duration_ms")]
     pub duration: Duration,
     pub explicit: bool,
     pub external_ids: HashMap<String, String>,
@@ -75,11 +71,7 @@ pub struct SimplifiedTrack {
     pub artists: Vec<SimplifiedArtist>,
     pub available_markets: Option<Vec<String>>,
     pub disc_number: i32,
-    #[serde(
-        deserialize_with = "from_duration_ms",
-        serialize_with = "to_duration_ms",
-        rename = "duration_ms"
-    )]
+    #[serde(with = "duration_ms", rename = "duration_ms")]
     pub duration: Duration,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -3,7 +3,7 @@ use rspotify::model::*;
 use std::time::Duration;
 #[test]
 fn test_simplified_track() {
-  let json_str = r#"
+    let json_str = r#"
 {
     "artists": [ {
       "external_urls": {
@@ -33,14 +33,14 @@ fn test_simplified_track() {
   }
 
 "#;
-  let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
-  let duration = Duration::from_millis(276773);
-  assert_eq!(track.duration, duration);
+    let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
+    let duration = Duration::from_millis(276773);
+    assert_eq!(track.duration, duration);
 }
 
 #[test]
 fn test_public_user() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "display_name": "Ronald Pompa",
             "external_urls": {
@@ -63,12 +63,12 @@ fn test_public_user() {
             "uri": "spotify:user:wizzler"
         }
         "#;
-  let user: PublicUser = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(user.id, "wizzler".to_string());
+    let user: PublicUser = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(user.id, "wizzler".to_string());
 }
 #[test]
 fn test_private_user() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "country": "US",
             "display_name": "Sergey",
@@ -92,13 +92,13 @@ fn test_private_user() {
             "uri": "spotify:user:waq5aexykhm6nlv0cnwdieng0"
           } 
         "#;
-  let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
+    let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
 }
 
 #[test]
 fn test_full_artist() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "external_urls": {
                 "spotify": "https://open.spotify.com/artist/0OdUWJ0sBjDrqHygGUXeCF"
@@ -125,14 +125,14 @@ fn test_full_artist() {
             "uri": "spotify:artist:0OdUWJ0sBjDrqHygGUXeCF"
         }
         "#;
-  let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(full_artist.name, "Band of Horses");
-  assert_eq!(full_artist.followers.total, 833247);
+    let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(full_artist.name, "Band of Horses");
+    assert_eq!(full_artist.followers.total, 833247);
 }
 
 #[test]
 fn test_simplified_episode() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "audio_preview_url": "https://p.scdn.co/mp3-preview/d8b916e1872de2bb0285d8c7bfe2b4b57011c85c",
             "description": "En unik barockträdgård från 1600-talet gömmer sig på Södermalm i Stockholm och nu gräver arkeologerna ut parken och kvarteret där Bellman lekte som barn.  Nu grävs Carl Michael Bellmans kvarter fram på Södermalm i Stockholm. Under dagens jordyta döljer sig en rik barockträdgård, men också tunga industrier från en tid då Söder var stockholmarnas sommarnöje. Dessutom om hur arkeologer ska kunna bli bättre att hitta de fattigas kulturarv. För vid sidan av slott, borgar och hallar finns torpen och backstugorna som utgör ett fortfarande okänt kulturarv som angår oss alla. Programledare Tobias Svanelid.",
@@ -167,18 +167,18 @@ fn test_simplified_episode() {
             "uri": "spotify:episode:3brfPv3PaUhspkm1T9ZVl8"
         }
         "#;
-  let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(
-    simplified_episode.release_date_precision,
-    DatePrecision::Day
-  );
-  let duration = Duration::from_millis(2685023);
-  assert_eq!(simplified_episode.duration, duration);
+    let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(
+        simplified_episode.release_date_precision,
+        DatePrecision::Day
+    );
+    let duration = Duration::from_millis(2685023);
+    assert_eq!(simplified_episode.duration, duration);
 }
 
 #[test]
 fn test_full_episode() {
-  let json_str = r#"
+    let json_str = r#"
     {
         "audio_preview_url": "https://p.scdn.co/mp3-preview/566fcc94708f39bcddc09e4ce84a8e5db8f07d4d",
         "description": "En ny tysk ",
@@ -238,28 +238,28 @@ fn test_full_episode() {
         "uri": "spotify:episode:512ojhOuo1ktJprKbVcKyQ"
     }
         "#;
-  let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
-  let duration = Duration::from_millis(1502795);
-  assert_eq!(full_episode.duration, duration);
+    let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
+    let duration = Duration::from_millis(1502795);
+    assert_eq!(full_episode.duration, duration);
 }
 
 #[test]
 fn test_copyright() {
-  let json_str = r#"
+    let json_str = r#"
 	[ {
 	    "text" : "(P) 2000 Sony Music Entertainment Inc.",
 	    "type" : "P"
 	} ]
 
 "#;
-  let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(copyrights[0]._type, CopyrightType::Performance);
+    let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(copyrights[0]._type, CopyrightType::Performance);
 }
 
 #[test]
 fn test_audio_analysis_section() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "start": 237.02356,
             "duration": 18.32542,
@@ -275,12 +275,12 @@ fn test_audio_analysis_section() {
             "time_signature_confidence": 1
         }
         "#;
-  let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(session.time_interval.duration, 18.32542);
+    let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(session.time_interval.duration, 18.32542);
 }
 #[test]
 fn test_audio_analysis_segments() {
-  let json_str = r#"
+    let json_str = r#"
          {
             "start": 252.15601,
             "duration": 3.19297,
@@ -297,26 +297,26 @@ fn test_audio_analysis_segments() {
             ]
             }
             "#;
-  let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(segment.time_interval.start, 252.15601);
+    let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(segment.time_interval.start, 252.15601);
 }
 
 #[test]
 fn test_actions() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "disallows": {
                 "resuming": true
             }
         }
         "#;
-  let actions: Actions = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(actions.disallows[0], DisallowKey::Resuming);
+    let actions: Actions = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(actions.disallows[0], DisallowKey::Resuming);
 }
 
 #[test]
 fn test_recommendations_seed() {
-  let json_str = r#"
+    let json_str = r#"
         {
             "initialPoolSize": 500,
             "afterFilteringSize": 380,
@@ -326,13 +326,13 @@ fn test_recommendations_seed() {
             "type": "artist"
         }        
         "#;
-  let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(seed._type, RecommendationsSeedType::Artist);
+    let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(seed._type, RecommendationsSeedType::Artist);
 }
 
 #[test]
 fn test_full_playlist() {
-  let json_str_images = r#"
+    let json_str_images = r#"
 [
     {
 	"height": null,
@@ -341,7 +341,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-  let json_str_simplified_artists = r#"
+    let json_str_simplified_artists = r#"
 [
     {
 	"external_urls": {
@@ -355,7 +355,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-  let json_str = r#"
+    let json_str = r#"
         {
             "collaborative": false,
             "description": "A playlist for testing pourposes",
@@ -459,17 +459,17 @@ fn test_full_playlist() {
             "uri": "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n"
         }
         "#.replace("json_str_images", json_str_images).replace("json_str_simplified_artists", json_str_simplified_artists);
-  let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
-  assert_eq!(
-    full_playlist.uri,
-    "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
-  );
-  assert_eq!(full_playlist.followers.total, 109);
+    let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(
+        full_playlist.uri,
+        "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
+    );
+    assert_eq!(full_playlist.followers.total, 109);
 }
 
 #[test]
 fn test_audio_features() {
-  let json = r#"
+    let json = r#"
     {
         "duration_ms" : 255349,
         "key" : 5,
@@ -491,14 +491,14 @@ fn test_audio_features() {
         "type" : "audio_features"
     }
     "#;
-  let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
-  let duration = Duration::from_millis(255349);
-  assert_eq!(audio_features.duration, duration);
+    let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
+    let duration = Duration::from_millis(255349);
+    assert_eq!(audio_features.duration, duration);
 }
 
 #[test]
 fn test_full_track() {
-  let json = r#"
+    let json = r#"
     {
   "album": {
     "album_type": "single",
@@ -570,27 +570,27 @@ fn test_full_track() {
   "uri": "spotify:track:11dFghVXANMlKmJXsNCbNl"
 }
     "#;
-  let full_track: FullTrack = serde_json::from_str(&json).unwrap();
-  let duration = Duration::from_millis(207959);
-  assert_eq!(full_track.duration, duration);
+    let full_track: FullTrack = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(207959);
+    assert_eq!(full_track.duration, duration);
 }
 
 #[test]
 fn test_resume_point() {
-  let json = r#"
+    let json = r#"
     {
         "fully_played": false,
         "resume_position_ms": 423432
     }   
     "#;
-  let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
-  let duration = Duration::from_millis(423432);
-  assert_eq!(resume_point.resume_position, duration);
+    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(423432);
+    assert_eq!(resume_point.resume_position, duration);
 }
 
 #[test]
 fn test_currently_playing_context() {
-  let json = r#"
+    let json = r#"
 {
   "timestamp": 1607769168429,
   "context": {
@@ -688,23 +688,23 @@ fn test_currently_playing_context() {
   "is_playing": true
 }
     "#;
-  let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
-  let timestamp = 1607769168429;
-  let second: i64 = (timestamp - timestamp % 1000) / 1000;
-  let nanosecond = (timestamp % 1000) * 1000000;
-  let dt = DateTime::<Utc>::from_utc(
-    NaiveDateTime::from_timestamp(second, nanosecond as u32),
-    Utc,
-  );
-  assert_eq!(currently_playing_context.timestamp, dt);
+    let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607769168429;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(currently_playing_context.timestamp, dt);
 
-  let duration = Duration::from_millis(22270);
-  assert_eq!(currently_playing_context.progress, Some(duration));
+    let duration = Duration::from_millis(22270);
+    assert_eq!(currently_playing_context.progress, Some(duration));
 }
 
 #[test]
 fn test_current_playback_context() {
-  let json = r#"
+    let json = r#"
 {
   "device": {
     "id": "28d0f845293d03a2713392905c6d30b6442719b5",
@@ -803,42 +803,42 @@ fn test_current_playback_context() {
   "is_playing": true
 }
     "#;
-  let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
-  let timestamp = 1607774342714;
-  let second: i64 = (timestamp - timestamp % 1000) / 1000;
-  let nanosecond = (timestamp % 1000) * 1000000;
-  let dt = DateTime::<Utc>::from_utc(
-    NaiveDateTime::from_timestamp(second, nanosecond as u32),
-    Utc,
-  );
-  assert_eq!(current_playback_context.timestamp, dt);
-  assert!(current_playback_context.progress.is_none());
+    let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
+    let timestamp = 1607774342714;
+    let second: i64 = (timestamp - timestamp % 1000) / 1000;
+    let nanosecond = (timestamp % 1000) * 1000000;
+    let dt = DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp(second, nanosecond as u32),
+        Utc,
+    );
+    assert_eq!(current_playback_context.timestamp, dt);
+    assert!(current_playback_context.progress.is_none());
 }
 
 #[test]
 fn test_offset() {
-  let json = r#"
+    let json = r#"
   {
     "position": 5,
     "uri": "spotify:track:1301WleyT98MSxVHPZCA6M"
   }
   "#;
-  let offset: Offset = serde_json::from_str(&json).unwrap();
-  let duration = Duration::from_millis(5);
-  assert_eq!(offset.position, Some(duration));
+    let offset: Offset = serde_json::from_str(&json).unwrap();
+    let duration = Duration::from_millis(5);
+    assert_eq!(offset.position, Some(duration));
 
-  let empty_json = r#"
+    let empty_json = r#"
   {
 
   }
   "#;
-  let empty_offset: Offset = serde_json::from_str(&empty_json).unwrap();
-  assert!(empty_offset.position.is_none());
+    let empty_offset: Offset = serde_json::from_str(&empty_json).unwrap();
+    assert!(empty_offset.position.is_none());
 }
 
 #[test]
 fn test_audio_analysis_track() {
-  let json = r#"
+    let json = r#"
   {
     "num_samples": 5630445,
     "duration": 255.34898,
@@ -868,6 +868,6 @@ fn test_audio_analysis_track() {
     "rhythm_version": 1
   }
   "#;
-  let audio_analysis_track: AudioAnalysisTrack = serde_json::from_str(&json).unwrap();
-  assert_eq!(audio_analysis_track.mode, Modality::Minor);
+    let audio_analysis_track: AudioAnalysisTrack = serde_json::from_str(&json).unwrap();
+    assert_eq!(audio_analysis_track.mode, Modality::Minor);
 }

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -3,7 +3,7 @@ use rspotify::model::*;
 use std::time::Duration;
 #[test]
 fn test_simplified_track() {
-    let json_str = r#"
+  let json_str = r#"
 {
     "artists": [ {
       "external_urls": {
@@ -33,14 +33,14 @@ fn test_simplified_track() {
   }
 
 "#;
-    let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
-    let duration = Duration::from_millis(276773);
-    assert_eq!(track.duration, duration);
+  let track: SimplifiedTrack = serde_json::from_str(&json_str).unwrap();
+  let duration = Duration::from_millis(276773);
+  assert_eq!(track.duration, duration);
 }
 
 #[test]
 fn test_public_user() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "display_name": "Ronald Pompa",
             "external_urls": {
@@ -63,12 +63,12 @@ fn test_public_user() {
             "uri": "spotify:user:wizzler"
         }
         "#;
-    let user: PublicUser = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(user.id, "wizzler".to_string());
+  let user: PublicUser = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(user.id, "wizzler".to_string());
 }
 #[test]
 fn test_private_user() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "country": "US",
             "display_name": "Sergey",
@@ -92,13 +92,13 @@ fn test_private_user() {
             "uri": "spotify:user:waq5aexykhm6nlv0cnwdieng0"
           } 
         "#;
-    let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
+  let private_user: PrivateUser = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(private_user.country.unwrap(), Country::UnitedStates);
 }
 
 #[test]
 fn test_full_artist() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "external_urls": {
                 "spotify": "https://open.spotify.com/artist/0OdUWJ0sBjDrqHygGUXeCF"
@@ -125,14 +125,14 @@ fn test_full_artist() {
             "uri": "spotify:artist:0OdUWJ0sBjDrqHygGUXeCF"
         }
         "#;
-    let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(full_artist.name, "Band of Horses");
-    assert_eq!(full_artist.followers.total, 833247);
+  let full_artist: FullArtist = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(full_artist.name, "Band of Horses");
+  assert_eq!(full_artist.followers.total, 833247);
 }
 
 #[test]
 fn test_simplified_episode() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "audio_preview_url": "https://p.scdn.co/mp3-preview/d8b916e1872de2bb0285d8c7bfe2b4b57011c85c",
             "description": "En unik barockträdgård från 1600-talet gömmer sig på Södermalm i Stockholm och nu gräver arkeologerna ut parken och kvarteret där Bellman lekte som barn.  Nu grävs Carl Michael Bellmans kvarter fram på Södermalm i Stockholm. Under dagens jordyta döljer sig en rik barockträdgård, men också tunga industrier från en tid då Söder var stockholmarnas sommarnöje. Dessutom om hur arkeologer ska kunna bli bättre att hitta de fattigas kulturarv. För vid sidan av slott, borgar och hallar finns torpen och backstugorna som utgör ett fortfarande okänt kulturarv som angår oss alla. Programledare Tobias Svanelid.",
@@ -167,18 +167,18 @@ fn test_simplified_episode() {
             "uri": "spotify:episode:3brfPv3PaUhspkm1T9ZVl8"
         }
         "#;
-    let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(
-        simplified_episode.release_date_precision,
-        DatePrecision::Day
-    );
-    let duration = Duration::from_millis(2685023);
-    assert_eq!(simplified_episode.duration, duration);
+  let simplified_episode: SimplifiedEpisode = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(
+    simplified_episode.release_date_precision,
+    DatePrecision::Day
+  );
+  let duration = Duration::from_millis(2685023);
+  assert_eq!(simplified_episode.duration, duration);
 }
 
 #[test]
 fn test_full_episode() {
-    let json_str = r#"
+  let json_str = r#"
     {
         "audio_preview_url": "https://p.scdn.co/mp3-preview/566fcc94708f39bcddc09e4ce84a8e5db8f07d4d",
         "description": "En ny tysk ",
@@ -238,28 +238,28 @@ fn test_full_episode() {
         "uri": "spotify:episode:512ojhOuo1ktJprKbVcKyQ"
     }
         "#;
-    let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
-    let duration = Duration::from_millis(1502795);
-    assert_eq!(full_episode.duration, duration);
+  let full_episode: FullEpisode = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(full_episode.release_date_precision, DatePrecision::Day);
+  let duration = Duration::from_millis(1502795);
+  assert_eq!(full_episode.duration, duration);
 }
 
 #[test]
 fn test_copyright() {
-    let json_str = r#"
+  let json_str = r#"
 	[ {
 	    "text" : "(P) 2000 Sony Music Entertainment Inc.",
 	    "type" : "P"
 	} ]
 
 "#;
-    let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(copyrights[0]._type, CopyrightType::Performance);
+  let copyrights: Vec<Copyright> = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(copyrights[0]._type, CopyrightType::Performance);
 }
 
 #[test]
 fn test_audio_analysis_section() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "start": 237.02356,
             "duration": 18.32542,
@@ -275,12 +275,12 @@ fn test_audio_analysis_section() {
             "time_signature_confidence": 1
         }
         "#;
-    let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(session.time_interval.duration, 18.32542);
+  let session: AudioAnalysisSection = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(session.time_interval.duration, 18.32542);
 }
 #[test]
 fn test_audio_analysis_segments() {
-    let json_str = r#"
+  let json_str = r#"
          {
             "start": 252.15601,
             "duration": 3.19297,
@@ -297,26 +297,26 @@ fn test_audio_analysis_segments() {
             ]
             }
             "#;
-    let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(segment.time_interval.start, 252.15601);
+  let segment: AudioAnalysisSegment = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(segment.time_interval.start, 252.15601);
 }
 
 #[test]
 fn test_actions() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "disallows": {
                 "resuming": true
             }
         }
         "#;
-    let actions: Actions = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(actions.disallows[0], DisallowKey::Resuming);
+  let actions: Actions = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(actions.disallows[0], DisallowKey::Resuming);
 }
 
 #[test]
 fn test_recommendations_seed() {
-    let json_str = r#"
+  let json_str = r#"
         {
             "initialPoolSize": 500,
             "afterFilteringSize": 380,
@@ -326,13 +326,13 @@ fn test_recommendations_seed() {
             "type": "artist"
         }        
         "#;
-    let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(seed._type, RecommendationsSeedType::Artist);
+  let seed: RecommendationsSeed = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(seed._type, RecommendationsSeedType::Artist);
 }
 
 #[test]
 fn test_full_playlist() {
-    let json_str_images = r#"
+  let json_str_images = r#"
 [
     {
 	"height": null,
@@ -341,7 +341,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-    let json_str_simplified_artists = r#"
+  let json_str_simplified_artists = r#"
 [
     {
 	"external_urls": {
@@ -355,7 +355,7 @@ fn test_full_playlist() {
     }
 ]
 "#;
-    let json_str = r#"
+  let json_str = r#"
         {
             "collaborative": false,
             "description": "A playlist for testing pourposes",
@@ -459,17 +459,17 @@ fn test_full_playlist() {
             "uri": "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n"
         }
         "#.replace("json_str_images", json_str_images).replace("json_str_simplified_artists", json_str_simplified_artists);
-    let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(
-        full_playlist.uri,
-        "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
-    );
-    assert_eq!(full_playlist.followers.total, 109);
+  let full_playlist: FullPlaylist = serde_json::from_str(&json_str).unwrap();
+  assert_eq!(
+    full_playlist.uri,
+    "spotify:playlist:3cEYpjA9oz9GiPac4AsH4n".to_string()
+  );
+  assert_eq!(full_playlist.followers.total, 109);
 }
 
 #[test]
 fn test_audio_features() {
-    let json = r#"
+  let json = r#"
     {
         "duration_ms" : 255349,
         "key" : 5,
@@ -491,14 +491,14 @@ fn test_audio_features() {
         "type" : "audio_features"
     }
     "#;
-    let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
-    let duration = Duration::from_millis(255349);
-    assert_eq!(audio_features.duration, duration);
+  let audio_features: AudioFeatures = serde_json::from_str(json).unwrap();
+  let duration = Duration::from_millis(255349);
+  assert_eq!(audio_features.duration, duration);
 }
 
 #[test]
 fn test_full_track() {
-    let json = r#"
+  let json = r#"
     {
   "album": {
     "album_type": "single",
@@ -570,27 +570,27 @@ fn test_full_track() {
   "uri": "spotify:track:11dFghVXANMlKmJXsNCbNl"
 }
     "#;
-    let full_track: FullTrack = serde_json::from_str(&json).unwrap();
-    let duration = Duration::from_millis(207959);
-    assert_eq!(full_track.duration, duration);
+  let full_track: FullTrack = serde_json::from_str(&json).unwrap();
+  let duration = Duration::from_millis(207959);
+  assert_eq!(full_track.duration, duration);
 }
 
 #[test]
 fn test_resume_point() {
-    let json = r#"
+  let json = r#"
     {
         "fully_played": false,
         "resume_position_ms": 423432
     }   
     "#;
-    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
-    let duration = Duration::from_millis(423432);
-    assert_eq!(resume_point.resume_position, duration);
+  let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+  let duration = Duration::from_millis(423432);
+  assert_eq!(resume_point.resume_position, duration);
 }
 
 #[test]
 fn test_currently_playing_context() {
-    let json = r#"
+  let json = r#"
 {
   "timestamp": 1607769168429,
   "context": {
@@ -688,23 +688,23 @@ fn test_currently_playing_context() {
   "is_playing": true
 }
     "#;
-    let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
-    let timestamp = 1607769168429;
-    let second: i64 = (timestamp - timestamp % 1000) / 1000;
-    let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp(second, nanosecond as u32),
-        Utc,
-    );
-    assert_eq!(currently_playing_context.timestamp, dt);
+  let currently_playing_context: CurrentlyPlayingContext = serde_json::from_str(&json).unwrap();
+  let timestamp = 1607769168429;
+  let second: i64 = (timestamp - timestamp % 1000) / 1000;
+  let nanosecond = (timestamp % 1000) * 1000000;
+  let dt = DateTime::<Utc>::from_utc(
+    NaiveDateTime::from_timestamp(second, nanosecond as u32),
+    Utc,
+  );
+  assert_eq!(currently_playing_context.timestamp, dt);
 
-    let duration = Duration::from_millis(22270);
-    assert_eq!(currently_playing_context.progress, Some(duration));
+  let duration = Duration::from_millis(22270);
+  assert_eq!(currently_playing_context.progress, Some(duration));
 }
 
 #[test]
 fn test_current_playback_context() {
-    let json = r#"
+  let json = r#"
 {
   "device": {
     "id": "28d0f845293d03a2713392905c6d30b6442719b5",
@@ -803,35 +803,71 @@ fn test_current_playback_context() {
   "is_playing": true
 }
     "#;
-    let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
-    let timestamp = 1607774342714;
-    let second: i64 = (timestamp - timestamp % 1000) / 1000;
-    let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp(second, nanosecond as u32),
-        Utc,
-    );
-    assert_eq!(current_playback_context.timestamp, dt);
-    assert!(current_playback_context.progress.is_none());
+  let current_playback_context: CurrentPlaybackContext = serde_json::from_str(&json).unwrap();
+  let timestamp = 1607774342714;
+  let second: i64 = (timestamp - timestamp % 1000) / 1000;
+  let nanosecond = (timestamp % 1000) * 1000000;
+  let dt = DateTime::<Utc>::from_utc(
+    NaiveDateTime::from_timestamp(second, nanosecond as u32),
+    Utc,
+  );
+  assert_eq!(current_playback_context.timestamp, dt);
+  assert!(current_playback_context.progress.is_none());
 }
 
 #[test]
 fn test_offset() {
-    let json = r#"
+  let json = r#"
   {
     "position": 5,
     "uri": "spotify:track:1301WleyT98MSxVHPZCA6M"
   }
   "#;
-    let offset: Offset = serde_json::from_str(&json).unwrap();
-    let duration = Duration::from_millis(5);
-    assert_eq!(offset.position, Some(duration));
+  let offset: Offset = serde_json::from_str(&json).unwrap();
+  let duration = Duration::from_millis(5);
+  assert_eq!(offset.position, Some(duration));
 
-    let empty_json = r#"
+  let empty_json = r#"
   {
 
   }
   "#;
-    let empty_offset: Offset = serde_json::from_str(&empty_json).unwrap();
-    assert!(empty_offset.position.is_none());
+  let empty_offset: Offset = serde_json::from_str(&empty_json).unwrap();
+  assert!(empty_offset.position.is_none());
+}
+
+#[test]
+fn test_audio_analysis_track() {
+  let json = r#"
+  {
+    "num_samples": 5630445,
+    "duration": 255.34898,
+    "sample_md5": "",
+    "offset_seconds": 0,
+    "window_seconds": 0,
+    "analysis_sample_rate": 22050,
+    "analysis_channels": 1,
+    "end_of_fade_in": 0,
+    "start_of_fade_out": 251.73334,
+    "loudness": -11.84,
+    "tempo": 98.002,
+    "tempo_confidence": 0.423,
+    "time_signature": 4,
+    "time_signature_confidence": 1,
+    "key": 5,
+    "key_confidence": 0.36,
+    "mode": 0,
+    "mode_confidence": 0.414,
+    "codestring": "e",
+    "code_version": 3.15,
+    "echoprintstring": "e",
+    "echoprint_version": 4.12,
+    "synchstring": "eJ",
+    "synch_version": 1,
+    "rhythmstring": "e",
+    "rhythm_version": 1
+  }
+  "#;
+  let audio_analysis_track: AudioAnalysisTrack = serde_json::from_str(&json).unwrap();
+  assert_eq!(audio_analysis_track.mode, Modality::Minor);
 }


### PR DESCRIPTION
## Description

+ `AudioAnalysisSection::mode`, `AudioAnalysisTrack::mode` and `AudioFeatures::mode` are f32s but should be `Modality` where `enum Modality { Major, Minor, NoResult }`
+ Move `from(to)_millisecond_timestamp` into its module `millisecond_timestamp` and rename them to `deserialize` & `serialize`
+ Move `from(to)_duration_ms` into its module `duration_ms` and rename them to `deserialize` & `serialize`
+ Move `from(to)_option_duration_ms` into its module `option_duration_ms` and rename them to `deserialize` & `serialize`

## Motivation and Context

To make the API more ergonomic and easier to use.

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] `AudioAnalysisSection`: `test_audio_analysis_section`
- [x] `AudioFeatures`: `test_audio_features`
- [x] `AudioAnalysisTrack`: `test_audio_analysis_track`