### PR TITLE
Make cache file a optional feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Remove `SimplifiedPlayingContext`, since it's useless.
 - ([#177](https://github.com/ramsayleung/rspotify/pull/157)) Change `mode` from `f32` to `enum Modality`:
   + Change `AudioAnalysisSection::mode`, `AudioAnalysisTrack::mode` and `AudioFeatures::mode` from `f32` to `enum Modality`.
+- ([#178](https://github.com/ramsayleung/rspotify/pull/178)) Make cache file as a feature:
+  + Mark `refresh_user_token_without_cache`, `request_client_token_without_cache`, `request_user_token_without_cache` from public to private.
+  + Remove `prompt_for_user_token_without_cache`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,8 @@ If we missed any change or there's something you'd like to discuss about this ve
 - ([#177](https://github.com/ramsayleung/rspotify/pull/157)) Change `mode` from `f32` to `enum Modality`:
   + Change `AudioAnalysisSection::mode`, `AudioAnalysisTrack::mode` and `AudioFeatures::mode` from `f32` to `enum Modality`.
 - ([#178](https://github.com/ramsayleung/rspotify/pull/178)) Make cache file as a feature:
-  + Mark `refresh_user_token_without_cache`, `request_client_token_without_cache`, `request_user_token_without_cache` from public to private.
-  + Remove `prompt_for_user_token_without_cache`.
+  + Change `refresh_user_token_without_cache`, `request_client_token_without_cache`, `request_user_token_without_cache` functions from public to private.
+  + Remove `prompt_for_user_token_without_cache` function.
 
 ## 0.10 (2020/07/01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 futures = "0.3.5"
 
 [features]
-default = ["client-reqwest", "reqwest-default-tls"]
+default = ["client-reqwest", "reqwest-default-tls", "cache_file"]
 cli = ["webbrowser"]
 env-file = ["dotenv"]
+cache_file = []
 
 # Available clients. By default they don't include a TLS so that it can be
 # configured.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 futures = "0.3.5"
 
 [features]
-default = ["client-reqwest", "reqwest-default-tls", "cache_file"]
+default = ["client-reqwest", "reqwest-default-tls", "cache-file"]
 cli = ["webbrowser"]
 env-file = ["dotenv"]
-cache_file = []
+cache-file = []
 
 # Available clients. By default they don't include a TLS so that it can be
 # configured.

--- a/examples/webapp/src/main.rs
+++ b/examples/webapp/src/main.rs
@@ -1,7 +1,6 @@
 //! In this example, the token is saved into a cache file. If you are building a
 //! real-world web app, you should store it in a database instead. In that case
-//! you can use `Spotify::request_user_token_without_cache` and
-//! `Spotify::refresh_user_token_without_cache` to avoid creating cache files.
+//! you can disable `cache-file` feature to avoid creating cache files.
 
 #![feature(proc_macro_hygiene, decl_macro)]
 

--- a/examples/with_refresh_token.rs
+++ b/examples/with_refresh_token.rs
@@ -70,7 +70,7 @@ async fn main() {
     // refresh token. We can also do some requests here.
     println!(">>> Session one, obtaining refresh token and running some requests:");
     spotify
-        .prompt_for_user_token_without_cache()
+        .prompt_for_user_token()
         .await
         .expect("couldn't authenticate successfully");
     let refresh_token = spotify

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use serde_json::map::Map;
 use serde_json::{json, Value};
 use thiserror::Error;
 
-#[cfg(feature = "cache_file")]
+#[cfg(feature = "cache-file")]
 use std::path::PathBuf;
 
 use super::http::{BaseClient, Query};
@@ -52,7 +52,7 @@ pub enum ClientError {
     #[error("cli error: {0}")]
     CLI(String),
 
-    #[cfg(feature = "cache_file")]
+    #[cfg(feature = "cache-file")]
     #[error("cache file error: {0}")]
     CacheFile(String),
 }
@@ -111,7 +111,7 @@ pub struct Spotify {
 
     /// The cache file path, in case it's used. By default it's
     /// [`DEFAULT_CACHE_PATH`](constant.DEFAULT_API_PREFIX.html).
-    #[cfg(feature = "cache_file")]
+    #[cfg(feature = "cache-file")]
     #[builder(default = r#"PathBuf::from(DEFAULT_CACHE_PATH)"#)]
     pub cache_path: PathBuf,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use serde_json::map::Map;
 use serde_json::{json, Value};
 use thiserror::Error;
 
+#[cfg(feature = "cache_file")]
 use std::path::PathBuf;
 
 use super::http::{BaseClient, Query};
@@ -51,6 +52,7 @@ pub enum ClientError {
     #[error("cli error: {0}")]
     CLI(String),
 
+    #[cfg(feature = "cache_file")]
     #[error("cache file error: {0}")]
     CacheFile(String),
 }
@@ -109,6 +111,7 @@ pub struct Spotify {
 
     /// The cache file path, in case it's used. By default it's
     /// [`DEFAULT_CACHE_PATH`](constant.DEFAULT_API_PREFIX.html).
+    #[cfg(feature = "cache_file")]
     #[builder(default = r#"PathBuf::from(DEFAULT_CACHE_PATH)"#)]
     pub cache_path: PathBuf,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,16 +103,12 @@
 //!    ](client/struct.Spotify.html#method.parse_response_code).
 //! 3. The code is sent to Spotify in order to obtain an access token with
 //!    [`Spotify::request_user_token`
-//!    ](client/struct.Spotify.html#method.request_user_token) or
-//!    [`Spotify::request_user_token_without_cache`
-//!    ](client/struct.Spotify.html#method.prompt_for_user_token_without_cache).
+//!    ](client/struct.Spotify.html#method.request_user_token)
 //! 4. Finally, this access token can be used internally for the requests.
 //!    This access token may expire relatively soon, so it can be refreshed
 //!    with the refresh token (obtained in the third step as well) using
 //!    [`Spotify::refresh_user_token`
-//!    ](client/struct.Spotify.html#method.refresh_user_token) or
-//!    [`Spotify::refresh_user_token_without_cache`
-//!    ](client/struct.Spotify.html#method.refresh_user_token_without_cache).
+//!    ](client/struct.Spotify.html#method.refresh_user_token).
 //!    Otherwise, a new access token may be generated from scratch by repeating
 //!    these steps, but the advantage of refreshing it is that this doesn't
 //!    require the user to log in, and that it's a simpler procedure.

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -6,13 +6,14 @@ use maybe_async::maybe_async;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
-use std::iter::FromIterator;
 #[cfg(feature = "cache_file")]
 use std::{
+    collections::HashSet,
     fs,
     io::{Read, Write},
+    iter::FromIterator,
     path::Path,
 };
 
@@ -27,6 +28,7 @@ mod auth_urls {
 
 // TODO this should be removed after making a custom type for scopes
 // or handling them as a vector of strings.
+#[cfg(feature = "cache_file")]
 fn is_scope_subset(needle_scope: &str, haystack_scope: &str) -> bool {
     let needle_vec: Vec<&str> = needle_scope.split_whitespace().collect();
     let haystack_vec: Vec<&str> = haystack_scope.split_whitespace().collect();
@@ -415,6 +417,7 @@ mod tests {
     use std::{fs, io::Read};
 
     #[test]
+    #[cfg(feature = "cache_file")]
     fn test_is_scope_subset() {
         let mut needle_scope = String::from("1 2 3");
         let mut haystack_scope = String::from("1 2 3 4");

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -234,10 +234,7 @@ impl Spotify {
     ///
     /// The obtained token will be saved internally.
     #[maybe_async]
-    pub async fn refresh_user_token_without_cache(
-        &mut self,
-        refresh_token: &str,
-    ) -> ClientResult<()> {
+    async fn refresh_user_token_without_cache(&mut self, refresh_token: &str) -> ClientResult<()> {
         let mut data = Form::new();
         data.insert(headers::REFRESH_TOKEN.to_owned(), refresh_token.to_owned());
         data.insert(
@@ -252,8 +249,13 @@ impl Spotify {
         Ok(())
     }
 
-    /// The same as `refresh_user_token_without_cache`, but saves the token
-    /// into the cache file if possible.
+    /// Refreshes the access token with the refresh token provided by the
+    /// [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow),
+    /// without saving it into the cache file.
+    ///
+    /// The obtained token will be saved internally.
+    /// The token will be saved into the cache file if `cache_file` feature is
+    /// enabled.
     #[maybe_async]
     pub async fn refresh_user_token(&mut self, refresh_token: &str) -> ClientResult<()> {
         self.refresh_user_token_without_cache(refresh_token).await?;
@@ -264,7 +266,7 @@ impl Spotify {
     /// Obtains the client access token for the app without saving it into the
     /// cache file. The resulting token is saved internally.
     #[maybe_async]
-    pub async fn request_client_token_without_cache(&mut self) -> ClientResult<()> {
+    async fn request_client_token_without_cache(&mut self) -> ClientResult<()> {
         let mut data = Form::new();
         data.insert(
             headers::GRANT_TYPE.to_owned(),
@@ -276,8 +278,10 @@ impl Spotify {
         Ok(())
     }
 
-    /// The same as `request_client_token_without_cache`, but saves the token
-    /// into the cache file if possible.
+    /// Obtains the client access token for the app without saving it into the
+    /// cache file. The resulting token is saved internally.
+    /// The token will be saved into the cache file if `cache_file` feature is
+    /// enabled.
     #[maybe_async]
     pub async fn request_client_token(&mut self) -> ClientResult<()> {
         #[cfg(not(feature = "cache_file"))]
@@ -309,7 +313,7 @@ impl Spotify {
     ///
     /// Step 3 of the [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow).
     #[maybe_async]
-    pub async fn request_user_token_without_cache(&mut self, code: &str) -> ClientResult<()> {
+    async fn request_user_token_without_cache(&mut self, code: &str) -> ClientResult<()> {
         let oauth = self.get_oauth()?;
         let mut data = Form::new();
         data.insert(
@@ -326,8 +330,13 @@ impl Spotify {
         Ok(())
     }
 
-    /// The same as `request_user_token_without_cache`, but saves the token into
-    /// the cache file if possible.
+    /// Obtains the user access token for the app with the given code without
+    /// saving it into the cache file, as part of the OAuth authentication.
+    /// The access token will be saved inside the Spotify instance.
+    ///
+    /// Step 3 of the [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow)
+    /// The token will be saved into the cache file if `cache_file` feature is
+    /// enabled.
     #[maybe_async]
     pub async fn request_user_token(&mut self, code: &str) -> ClientResult<()> {
         #[cfg(not(feature = "cache_file"))]
@@ -347,19 +356,8 @@ impl Spotify {
     /// in order to obtain the access token information. The resulting access
     /// token will be saved internally once the operation is successful.
     ///
-    /// Note: this method requires the `cli` feature.
-    #[cfg(feature = "cli")]
-    #[maybe_async]
-    pub async fn prompt_for_user_token_without_cache(&mut self) -> ClientResult<()> {
-        let code = self.get_code_from_user()?;
-        self.request_user_token_without_cache(&code).await?;
-
-        Ok(())
-    }
-
-    /// The same as the `prompt_for_user_token_without_cache` method, but it
-    /// will try to use the user token into the cache file, and save it in
-    /// case it didn't exist/was invalid.
+    /// It will try to use the user token into the cache file, and save it if
+    /// `cache_file` feature is enabled.
     ///
     /// Note: this method requires the `cli` feature.
     #[cfg(feature = "cli")]

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -10,7 +10,11 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::iter::FromIterator;
 #[cfg(feature = "cache_file")]
-use std::{fs, io::{Read, Write}, path::Path};
+use std::{
+    fs,
+    io::{Read, Write},
+    path::Path,
+};
 
 use super::client::{ClientResult, Spotify};
 use super::http::{headers, BaseClient, Form, Headers};
@@ -23,7 +27,6 @@ mod auth_urls {
 
 // TODO this should be removed after making a custom type for scopes
 // or handling them as a vector of strings.
-#[cfg(feature = "cache_file")]
 fn is_scope_subset(needle_scope: &str, haystack_scope: &str) -> bool {
     let needle_vec: Vec<&str> = needle_scope.split_whitespace().collect();
     let haystack_vec: Vec<&str> = haystack_scope.split_whitespace().collect();
@@ -410,8 +413,8 @@ mod tests {
     use super::*;
     use crate::client::SpotifyBuilder;
 
-    use std::fs;
-    use std::io::Read;
+    #[cfg(feature = "cache_file")]
+    use std::{fs, io::Read};
 
     #[test]
     fn test_is_scope_subset() {
@@ -423,6 +426,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cache_file")]
     fn test_write_token() {
         let tok = TokenBuilder::default()
             .access_token("test-access_token")

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -192,22 +192,16 @@ impl Spotify {
 
     /// Tries to read the cache file's token, which may not exist.
     #[maybe_async]
+    #[cfg(feature = "cache-file")]
     pub async fn read_token_cache(&mut self) -> Option<Token> {
-        #[cfg(feature = "cache_file")]
-        {
-            let tok = TokenBuilder::from_cache(&self.cache_path).build().ok()?;
+        let tok = TokenBuilder::from_cache(&self.cache_path).build().ok()?;
 
-            if !is_scope_subset(&self.get_oauth().ok()?.scope, &tok.scope) || tok.is_expired() {
-                // Invalid token, since it doesn't have at least the currently
-                // required scopes or it's expired.
-                None
-            } else {
-                Some(tok)
-            }
-        }
-        #[cfg(not(feature = "cache_file"))]
-        {
+        if !is_scope_subset(&self.get_oauth().ok()?.scope, &tok.scope) || tok.is_expired() {
+            // Invalid token, since it doesn't have at least the currently
+            // required scopes or it's expired.
             None
+        } else {
+            Some(tok)
         }
     }
 


### PR DESCRIPTION
## Description

Trying to fix #135 #96, make cache file as a optional feature.

## Motivation and Context

The cache file feature is useful, but the API surface is some kind of verbose, like `do_something` and `do_something_without_cache`. The developers have to explicitly choose `cache` function or `without_cache` function to control the way of how does the cache file work? It would be more ergonomic to make cache file as a feature to offer the right to developers to control how does it work ?

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

Test `cache-file` feature by hand:

+ `request_client_token`:

```rust
# Check if cache file is generated, expect to be nothing
cargo run --example track --no-default-feature --features="env-file cli client-reqwest request-default-tls" 

# Check if cache file is generated, expect that `.spotify_token_cache.json` is saved
cargo run --example track --no-default-feature --features="env-file cache-file cli client-reqwest request-default-tls"
```

+ `request_user_token`:

```rust
# Check if cache file is generated, expect to be nothing
cargo run --example me --features="env-file cli client-ureq ureq-rustls-tls" --no-default-features

# Check if cache file is generated, expect that `.spotify_token_cache.json` is saved
cargo run --example me --features="env-file cli client-ureq ureq-rustls-tls cache-file" --no-default-features
```
