### PR TITLE
Fix not allowing from token as market/country

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -320,14 +320,14 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-artists-top-tracks/)
     #[maybe_async]
-    pub async fn artist_top_tracks<T: Into<Market>>(
+    pub async fn artist_top_tracks(
         &self,
         artist_id: &str,
-        market: T,
+        market: Market,
     ) -> ClientResult<Vec<FullTrack>> {
         let mut params = Query::with_capacity(1);
 
-        params.insert("market".to_owned(), market.into().into());
+        params.insert("market".to_owned(), market.into());
 
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/top-tracks", trid);

--- a/src/client.rs
+++ b/src/client.rs
@@ -229,7 +229,7 @@ impl Spotify {
 
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
 
         let url = format!("tracks/?ids={}", ids.join(","));
@@ -303,7 +303,7 @@ impl Spotify {
             params.insert("offset".to_owned(), offset.to_string());
         }
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/albums", trid);
@@ -327,7 +327,7 @@ impl Spotify {
     ) -> ClientResult<Vec<FullTrack>> {
         let mut params = Query::with_capacity(1);
 
-        params.insert("market".to_owned(), market.into());
+        params.insert("market".to_owned(), market.to_string());
 
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/top-tracks", trid);
@@ -418,7 +418,7 @@ impl Spotify {
         params.insert("q".to_owned(), q.to_owned());
         params.insert("type".to_owned(), _type.to_string());
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         if let Some(include_external) = include_external {
             params.insert("include_external".to_owned(), include_external.to_string());
@@ -484,7 +484,7 @@ impl Spotify {
             params.insert("fields".to_owned(), fields.to_owned());
         }
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
 
         let plid = self.get_id(Type::Playlist, playlist_id);
@@ -594,7 +594,7 @@ impl Spotify {
         params.insert("limit".to_owned(), limit.into().unwrap_or(50).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         if let Some(fields) = fields {
             params.insert("fields".to_owned(), fields.to_owned());
@@ -1370,7 +1370,7 @@ impl Spotify {
             params.insert("locale".to_owned(), locale);
         }
         if let Some(market) = country {
-            params.insert("country".to_owned(), market.into());
+            params.insert("country".to_owned(), market.to_string());
         }
         if let Some(timestamp) = timestamp {
             params.insert("timestamp".to_owned(), timestamp.to_rfc3339());
@@ -1400,7 +1400,7 @@ impl Spotify {
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = country {
-            params.insert("country".to_owned(), market.into());
+            params.insert("country".to_owned(), market.to_string());
         }
 
         let result = self.get("browse/new-releases", None, &params).await?;
@@ -1435,7 +1435,7 @@ impl Spotify {
             params.insert("locale".to_owned(), locale);
         }
         if let Some(market) = country {
-            params.insert("country".to_owned(), market.into());
+            params.insert("country".to_owned(), market.to_string());
         }
         let result = self.get("browse/categories", None, &params).await?;
         self.convert_result::<PageCategory>(&result)
@@ -1465,7 +1465,7 @@ impl Spotify {
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = country {
-            params.insert("country".to_owned(), market.into());
+            params.insert("country".to_owned(), market.to_string());
         }
 
         let url = format!("browse/categories/{}/playlists", category_id);
@@ -1548,7 +1548,7 @@ impl Spotify {
             params.insert("seed_tracks".to_owned(), seed_tracks_ids.join(","));
         }
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let result = self.get("recommendations", None, &params).await?;
         self.convert_result(&result)
@@ -1635,7 +1635,7 @@ impl Spotify {
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.into());
+            params.insert("country".to_owned(), market.to_string());
         }
         if let Some(additional_types) = additional_types {
             params.insert(
@@ -1673,7 +1673,7 @@ impl Spotify {
     ) -> ClientResult<Option<CurrentlyPlayingContext>> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         if let Some(additional_types) = additional_types {
             params.insert(
@@ -1967,7 +1967,7 @@ impl Spotify {
     pub async fn get_a_show(&self, id: String, market: Option<Market>) -> ClientResult<FullShow> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let url = format!("shows/{}", id);
         let result = self.get(&url, None, &params).await?;
@@ -1995,7 +1995,7 @@ impl Spotify {
             ids.into_iter().collect::<Vec<_>>().join(","),
         );
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let result = self.get("shows", None, &params).await?;
         self.convert_result::<SeversalSimplifiedShows>(&result)
@@ -2026,7 +2026,7 @@ impl Spotify {
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let url = format!("shows/{}/episodes", id);
         let result = self.get(&url, None, &params).await?;
@@ -2051,7 +2051,7 @@ impl Spotify {
         let url = format!("episodes/{}", id);
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
 
         let result = self.get(&url, None, &params).await?;
@@ -2077,7 +2077,7 @@ impl Spotify {
             ids.into_iter().collect::<Vec<_>>().join(","),
         );
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.into());
+            params.insert("market".to_owned(), market.to_string());
         }
         let result = self.get("episodes", None, &params).await?;
         self.convert_result(&result)
@@ -2121,8 +2121,7 @@ impl Spotify {
         let url = format!("me/shows?ids={}", joined_ids);
         let mut params = json!({});
         if let Some(market) = market {
-            let market: String = market.into();
-            json_insert!(params, "country", market);
+            json_insert!(params, "country", market.to_string());
         }
         self.delete(&url, None, &params).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -212,14 +212,14 @@ impl Spotify {
     ///
     /// Parameters:
     /// - track_ids - a list of spotify URIs, URLs or IDs
-    /// - market - an ISO 3166-1 alpha-2 country code.
+    /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
     #[maybe_async]
     pub async fn tracks<'a>(
         &self,
         track_ids: impl IntoIterator<Item = &'a str>,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<Vec<FullTrack>> {
         // TODO: this can be improved
         let mut ids: Vec<String> = vec![];
@@ -229,7 +229,7 @@ impl Spotify {
 
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
 
         let url = format!("tracks/?ids={}", ids.join(","));
@@ -278,7 +278,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_id - the artist ID, URI or URL
     /// - album_type - 'album', 'single', 'appears_on', 'compilation'
-    /// - country - limit the response to one particular country.
+    /// - market - limit the response to one particular country.
     /// - limit  - the number of albums to return
     /// - offset - the index of the first album to return
     ///
@@ -288,7 +288,7 @@ impl Spotify {
         &self,
         artist_id: &str,
         album_type: Option<AlbumType>,
-        country: Option<Country>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
@@ -302,8 +302,8 @@ impl Spotify {
         if let Some(offset) = offset {
             params.insert("offset".to_owned(), offset.to_string());
         }
-        if let Some(country) = country {
-            params.insert("country".to_owned(), country.to_string());
+        if let Some(market) = market {
+            params.insert("market".to_owned(), market.into());
         }
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/albums", trid);
@@ -316,20 +316,18 @@ impl Spotify {
     ///
     /// Parameters:
     /// - artist_id - the artist ID, URI or URL
-    /// - country - limit the response to one particular country.
+    /// - market - limit the response to one particular country.
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-artists-top-tracks/)
     #[maybe_async]
-    pub async fn artist_top_tracks<T: Into<Option<Country>>>(
+    pub async fn artist_top_tracks<T: Into<Market>>(
         &self,
         artist_id: &str,
-        country: T,
+        market: T,
     ) -> ClientResult<Vec<FullTrack>> {
         let mut params = Query::with_capacity(1);
-        params.insert(
-            "country".to_owned(),
-            country.into().unwrap_or(Country::UnitedStates).to_string(),
-        );
+
+        params.insert("market".to_owned(), market.into().into());
 
         let trid = self.get_id(Type::Artist, artist_id);
         let url = format!("artists/{}/top-tracks", trid);
@@ -411,7 +409,7 @@ impl Spotify {
         _type: SearchType,
         limit: L,
         offset: O,
-        market: Option<Country>,
+        market: Option<Market>,
         include_external: Option<IncludeExternal>,
     ) -> ClientResult<SearchResult> {
         let mut params = Query::with_capacity(4);
@@ -420,7 +418,7 @@ impl Spotify {
         params.insert("q".to_owned(), q.to_owned());
         params.insert("type".to_owned(), _type.to_string());
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         if let Some(include_external) = include_external {
             params.insert("include_external".to_owned(), include_external.to_string());
@@ -471,7 +469,7 @@ impl Spotify {
     ///
     /// Parameters:
     /// - playlist_id - the id of the playlist
-    /// - market - an ISO 3166-1 alpha-2 country code.
+    /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist/)
     #[maybe_async]
@@ -479,14 +477,14 @@ impl Spotify {
         &self,
         playlist_id: &str,
         fields: Option<&str>,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<FullPlaylist> {
         let mut params = Query::new();
         if let Some(fields) = fields {
             params.insert("fields".to_owned(), fields.to_owned());
         }
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
 
         let plid = self.get_id(Type::Playlist, playlist_id);
@@ -553,14 +551,10 @@ impl Spotify {
         user_id: &str,
         playlist_id: Option<&mut str>,
         fields: Option<&str>,
-        market: Option<Country>,
     ) -> ClientResult<FullPlaylist> {
         let mut params = Query::new();
         if let Some(fields) = fields {
             params.insert("fields".to_owned(), fields.to_string());
-        }
-        if let Some(market) = market {
-            params.insert("market".to_owned(), market.to_string());
         }
         match playlist_id {
             Some(playlist_id) => {
@@ -584,7 +578,7 @@ impl Spotify {
     /// - fields - which fields to return
     /// - limit - the maximum number of tracks to return
     /// - offset - the index of the first track to return
-    /// - market - an ISO 3166-1 alpha-2 country code.
+    /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/web-api/get-playlists-tracks/)
     #[maybe_async]
@@ -594,13 +588,13 @@ impl Spotify {
         fields: Option<&str>,
         limit: L,
         offset: O,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<Page<PlaylistItem>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(50).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = market {
-            params.insert("market".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         if let Some(fields) = fields {
             params.insert("fields".to_owned(), fields.to_owned());
@@ -1349,7 +1343,7 @@ impl Spotify {
     /// - locale - The desired language, consisting of a lowercase ISO 639
     ///   language code and an uppercase ISO 3166-1 alpha-2 country code,
     ///   joined by an underscore.
-    /// - country - An ISO 3166-1 alpha-2 country code.
+    /// - country - An ISO 3166-1 alpha-2 country code or the string from_token.
     /// - timestamp - A timestamp in ISO 8601 format: yyyy-MM-ddTHH:mm:ss. Use
     ///   this parameter to specify the user's local time to get results
     ///   tailored for that specific date and time in the day
@@ -1364,7 +1358,7 @@ impl Spotify {
     pub async fn featured_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
         locale: Option<String>,
-        country: Option<Country>,
+        country: Option<Market>,
         timestamp: Option<DateTime<Utc>>,
         limit: L,
         offset: O,
@@ -1375,8 +1369,8 @@ impl Spotify {
         if let Some(locale) = locale {
             params.insert("locale".to_owned(), locale);
         }
-        if let Some(country) = country {
-            params.insert("country".to_owned(), country.to_string());
+        if let Some(market) = country {
+            params.insert("country".to_owned(), market.into());
         }
         if let Some(timestamp) = timestamp {
             params.insert("timestamp".to_owned(), timestamp.to_rfc3339());
@@ -1388,7 +1382,7 @@ impl Spotify {
     /// Get a list of new album releases featured in Spotify.
     ///
     /// Parameters:
-    /// - country - An ISO 3166-1 alpha-2 country code.
+    /// - country - An ISO 3166-1 alpha-2 country code or string from_token.
     /// - limit - The maximum number of items to return. Default: 20.
     ///   Minimum: 1. Maximum: 50
     /// - offset - The index of the first item to return. Default: 0 (the first
@@ -1398,15 +1392,15 @@ impl Spotify {
     #[maybe_async]
     pub async fn new_releases<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
-        country: Option<Country>,
+        country: Option<Market>,
         limit: L,
         offset: O,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
-        if let Some(country) = country {
-            params.insert("country".to_owned(), country.to_string());
+        if let Some(market) = country {
+            params.insert("country".to_owned(), market.into());
         }
 
         let result = self.get("browse/new-releases", None, &params).await?;
@@ -1417,7 +1411,7 @@ impl Spotify {
     /// Get a list of new album releases featured in Spotify
     ///
     /// Parameters:
-    /// - country - An ISO 3166-1 alpha-2 country code.
+    /// - country - An ISO 3166-1 alpha-2 country code or string from_token.
     /// - locale - The desired language, consisting of an ISO 639 language code
     ///   and an ISO 3166-1 alpha-2 country code, joined by an underscore.
     /// - limit - The maximum number of items to return. Default: 20.
@@ -1430,7 +1424,7 @@ impl Spotify {
     pub async fn categories<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
         locale: Option<String>,
-        country: Option<Country>,
+        country: Option<Market>,
         limit: L,
         offset: O,
     ) -> ClientResult<Page<Category>> {
@@ -1440,8 +1434,8 @@ impl Spotify {
         if let Some(locale) = locale {
             params.insert("locale".to_owned(), locale);
         }
-        if let Some(country) = country {
-            params.insert("country".to_owned(), country.to_string());
+        if let Some(market) = country {
+            params.insert("country".to_owned(), market.into());
         }
         let result = self.get("browse/categories", None, &params).await?;
         self.convert_result::<PageCategory>(&result)
@@ -1452,7 +1446,7 @@ impl Spotify {
     ///
     /// Parameters:
     /// - category_id - The category id to get playlists from.
-    /// - country - An ISO 3166-1 alpha-2 country code.
+    /// - country - An ISO 3166-1 alpha-2 country code or the string from_token.
     /// - limit - The maximum number of items to return. Default: 20.
     ///   Minimum: 1. Maximum: 50
     /// - offset - The index of the first item to return. Default: 0 (the first
@@ -1463,15 +1457,15 @@ impl Spotify {
     pub async fn category_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
         category_id: &str,
-        country: Option<Country>,
+        country: Option<Market>,
         limit: L,
         offset: O,
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
-        if let Some(country) = country {
-            params.insert("country".to_owned(), country.to_string());
+        if let Some(market) = country {
+            params.insert("country".to_owned(), market.into());
         }
 
         let url = format!("browse/categories/{}/playlists", category_id);
@@ -1486,7 +1480,7 @@ impl Spotify {
     /// - seed_artists - a list of artist IDs, URIs or URLs
     /// - seed_tracks - a list of artist IDs, URIs or URLs
     /// - seed_genres - a list of genre names. Available genres for
-    /// - country - An ISO 3166-1 alpha-2 country code. If provided, all
+    /// - market - An ISO 3166-1 alpha-2 country code or the string from_token. If provided, all
     ///   results will be playable in this country.
     /// - limit - The maximum number of items to return. Default: 20.
     ///   Minimum: 1. Maximum: 100
@@ -1502,7 +1496,7 @@ impl Spotify {
         seed_genres: Option<Vec<String>>,
         seed_tracks: Option<Vec<String>>,
         limit: L,
-        country: Option<Country>,
+        market: Option<Market>,
         payload: &Map<String, Value>,
     ) -> ClientResult<Recommendations> {
         let mut params = Query::with_capacity(payload.len() + 1);
@@ -1553,8 +1547,8 @@ impl Spotify {
                 .collect::<Vec<_>>();
             params.insert("seed_tracks".to_owned(), seed_tracks_ids.join(","));
         }
-        if let Some(country) = country {
-            params.insert("market".to_owned(), country.to_string());
+        if let Some(market) = market {
+            params.insert("market".to_owned(), market.into());
         }
         let result = self.get("recommendations", None, &params).await?;
         self.convert_result(&result)
@@ -1627,7 +1621,7 @@ impl Spotify {
     /// Get Information About The User’s Current Playback
     ///
     /// Parameters:
-    /// - market: Optional. an ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. an ISO 3166-1 alpha-2 country code or the string from_token.
     /// - additional_types: Optional. A comma-separated list of item types that
     ///   your client supports besides the default track type. Valid types are:
     ///   `track` and `episode`.
@@ -1636,12 +1630,12 @@ impl Spotify {
     #[maybe_async]
     pub async fn current_playback(
         &self,
-        market: Option<Country>,
+        market: Option<Market>,
         additional_types: Option<Vec<AdditionalType>>,
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("country".to_owned(), market.into());
         }
         if let Some(additional_types) = additional_types {
             params.insert(
@@ -1665,7 +1659,7 @@ impl Spotify {
     /// Get the User’s Currently Playing Track
     ///
     /// Parameters:
-    /// - market: Optional. an ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. an ISO 3166-1 alpha-2 country code or the string from_token.
     /// - additional_types: Optional. A comma-separated list of item types that
     ///   your client supports besides the default track type. Valid types are:
     ///   `track` and `episode`.
@@ -1674,12 +1668,12 @@ impl Spotify {
     #[maybe_async]
     pub async fn current_playing(
         &self,
-        market: Option<Country>,
+        market: Option<Market>,
         additional_types: Option<Vec<AdditionalType>>,
     ) -> ClientResult<Option<CurrentlyPlayingContext>> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         if let Some(additional_types) = additional_types {
             params.insert(
@@ -1966,14 +1960,14 @@ impl Spotify {
     /// - id: The Spotify ID for the show.
     ///
     /// Query Parameters
-    /// - market(Optional): An ISO 3166-1 alpha-2 country code.
+    /// - market(Optional): An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/)
     #[maybe_async]
-    pub async fn get_a_show(&self, id: String, market: Option<Country>) -> ClientResult<FullShow> {
+    pub async fn get_a_show(&self, id: String, market: Option<Market>) -> ClientResult<FullShow> {
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         let url = format!("shows/{}", id);
         let result = self.get(&url, None, &params).await?;
@@ -1985,14 +1979,14 @@ impl Spotify {
     ///
     /// Query Parameters
     /// - ids(Required) A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.
-    /// - market(Optional) An ISO 3166-1 alpha-2 country code.
+    /// - market(Optional) An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/)
     #[maybe_async]
     pub async fn get_several_shows<'a>(
         &self,
         ids: impl IntoIterator<Item = &'a str>,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<Vec<SimplifiedShow>> {
         // TODO: This can probably be better
         let mut params = Query::with_capacity(1);
@@ -2001,7 +1995,7 @@ impl Spotify {
             ids.into_iter().collect::<Vec<_>>().join(","),
         );
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         let result = self.get("shows", None, &params).await?;
         self.convert_result::<SeversalSimplifiedShows>(&result)
@@ -2017,7 +2011,7 @@ impl Spotify {
     /// Query Parameters
     /// - limit: Optional. The maximum number of episodes to return. Default: 20. Minimum: 1. Maximum: 50.
     /// - offset: Optional. The index of the first episode to return. Default: 0 (the first object). Use with limit to get the next set of episodes.
-    /// - market: Optional. An ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/)
     #[maybe_async]
@@ -2026,13 +2020,13 @@ impl Spotify {
         id: String,
         limit: L,
         offset: O,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<Page<SimplifiedEpisode>> {
         let mut params = Query::with_capacity(2);
         params.insert("limit".to_owned(), limit.into().unwrap_or(20).to_string());
         params.insert("offset".to_owned(), offset.into().unwrap_or(0).to_string());
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         let url = format!("shows/{}/episodes", id);
         let result = self.get(&url, None, &params).await?;
@@ -2045,19 +2039,19 @@ impl Spotify {
     /// - id: The Spotify ID for the episode.
     ///
     /// Query Parameters
-    /// - market: Optional. An ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/episodes/get-an-episode/)
     #[maybe_async]
     pub async fn get_an_episode(
         &self,
         id: String,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<FullEpisode> {
         let url = format!("episodes/{}", id);
         let mut params = Query::new();
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
 
         let result = self.get(&url, None, &params).await?;
@@ -2068,14 +2062,14 @@ impl Spotify {
     ///
     /// Query Parameters
     /// - ids: Required. A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.
-    /// - market: Optional. An ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/episodes/get-several-episodes/)
     #[maybe_async]
     pub async fn get_several_episodes<'a>(
         &self,
         ids: impl IntoIterator<Item = &'a str>,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<SeveralEpisodes> {
         let mut params = Query::with_capacity(1);
         params.insert(
@@ -2083,7 +2077,7 @@ impl Spotify {
             ids.into_iter().collect::<Vec<_>>().join(","),
         );
         if let Some(market) = market {
-            params.insert("country".to_owned(), market.to_string());
+            params.insert("market".to_owned(), market.into());
         }
         let result = self.get("episodes", None, &params).await?;
         self.convert_result(&result)
@@ -2114,20 +2108,21 @@ impl Spotify {
     ///
     /// Query Parameters
     /// - ids: Required. A comma-separated list of Spotify IDs for the shows to be deleted from the user’s library.
-    /// - market: Optional. An ISO 3166-1 alpha-2 country code.
+    /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/remove-shows-user/)
     #[maybe_async]
     pub async fn remove_users_saved_shows<'a>(
         &self,
         ids: impl IntoIterator<Item = &'a str>,
-        market: Option<Country>,
+        market: Option<Market>,
     ) -> ClientResult<()> {
         let joined_ids = ids.into_iter().collect::<Vec<_>>().join(",");
         let url = format!("me/shows?ids={}", joined_ids);
         let mut params = json!({});
         if let Some(market) = market {
-            json_insert!(params, "country", market.to_string());
+            let market: String = market.into();
+            json_insert!(params, "country", market);
         }
         self.delete(&url, None, &params).await?;
 

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use strum::ToString;
 
+use super::Country;
+
 /// Disallows object: `interrupting_playback`, `pausing`, `resuming`, `seeking`,
 /// `skipping_next`, `skipping_prev`, `toggling_repeat_context`,
 /// `toggling_shuffle`, `toggling_repeat_track`, `transferring_playback`.
@@ -90,4 +92,21 @@ pub enum Modality {
     Minor = 0,
     Major = 1,
     NoResult = -1,
+}
+/// Limit the response to a particular market
+///
+/// FromToken is the same thing as setting the market parameter to the user's country.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Market {
+    Country(Country),
+    FromToken,
+}
+
+impl Into<String> for Market {
+    fn into(self) -> String {
+        match self {
+            Market::Country(c) => c.to_string(),
+            Market::FromToken => "from_token".to_string(),
+        }
+    }
 }

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -93,6 +93,7 @@ pub enum Modality {
     Major = 1,
     NoResult = -1,
 }
+
 /// Limit the response to a particular market
 ///
 /// FromToken is the same thing as setting the market parameter to the user's country.

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -103,8 +103,8 @@ pub enum Market {
     FromToken,
 }
 
-impl Into<String> for Market {
-    fn into(self) -> String {
+impl ToString for Market {
+    fn to_string(&self) -> String {
         match self {
             Market::Country(c) => c.to_string(),
             Market::FromToken => "from_token".to_string(),

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -1,9 +1,12 @@
 mod common;
 
 use common::maybe_async_test;
-use rspotify::client::{Spotify, SpotifyBuilder};
 use rspotify::model::{AlbumType, Country};
 use rspotify::oauth2::CredentialsBuilder;
+use rspotify::{
+    client::{Spotify, SpotifyBuilder},
+    model::Market,
+};
 
 use maybe_async::maybe_async;
 
@@ -84,7 +87,7 @@ async fn test_artists_albums() {
         .artist_albums(
             birdy_uri,
             Some(AlbumType::Album),
-            Some(Country::UnitedStates),
+            Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,
         )
@@ -107,7 +110,7 @@ async fn test_artist_top_tracks() {
     let birdy_uri = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
     creds_client()
         .await
-        .artist_top_tracks(birdy_uri, Country::UnitedStates)
+        .artist_top_tracks(birdy_uri, Market::Country(Country::UnitedStates))
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -337,6 +337,17 @@ async fn test_new_releases() {
 #[maybe_async]
 #[maybe_async_test]
 #[ignore]
+async fn test_new_releases_with_from_token() {
+    oauth_client()
+        .await
+        .new_releases(Some(Market::FromToken), 10, 0)
+        .await
+        .unwrap();
+}
+
+#[maybe_async]
+#[maybe_async_test]
+#[ignore]
 async fn test_next_playback() {
     let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
     oauth_client()

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -17,10 +17,13 @@
 mod common;
 
 use common::maybe_async_test;
-use rspotify::client::{Spotify, SpotifyBuilder};
 use rspotify::model::offset::for_position;
 use rspotify::model::{Country, RepeatState, SearchType, TimeRange};
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder, TokenBuilder};
+use rspotify::{
+    client::{Spotify, SpotifyBuilder},
+    model::Market,
+};
 
 use std::env;
 
@@ -88,7 +91,7 @@ pub async fn oauth_client() -> Spotify {
 async fn test_categories() {
     oauth_client()
         .await
-        .categories(None, Some(Country::UnitedStates), 10, 0)
+        .categories(None, Some(Market::Country(Country::UnitedStates)), 10, 0)
         .await
         .unwrap();
 }
@@ -99,7 +102,7 @@ async fn test_categories() {
 async fn test_category_playlists() {
     oauth_client()
         .await
-        .category_playlists("pop", Some(Country::UnitedStates), 10, 0)
+        .category_playlists("pop", Some(Market::Country(Country::UnitedStates)), 10, 0)
         .await
         .unwrap();
 }
@@ -326,7 +329,7 @@ async fn test_me() {
 async fn test_new_releases() {
     oauth_client()
         .await
-        .new_releases(Some(Country::Sweden), 10, 0)
+        .new_releases(Some(Market::Country(Country::Sweden)), 10, 0)
         .await
         .unwrap();
 }
@@ -383,7 +386,7 @@ async fn test_recommendations() {
             None,
             Some(seed_tracks),
             10,
-            Some(Country::UnitedStates),
+            Some(Market::Country(Country::UnitedStates)),
             &payload,
         )
         .await
@@ -425,7 +428,7 @@ async fn test_search_artist() {
             SearchType::Artist,
             10,
             0,
-            Some(Country::UnitedStates),
+            Some(Market::Country(Country::UnitedStates)),
             None,
         )
         .await
@@ -444,7 +447,7 @@ async fn test_search_playlist() {
             SearchType::Playlist,
             10,
             0,
-            Some(Country::UnitedStates),
+            Some(Market::Country(Country::UnitedStates)),
             None,
         )
         .await
@@ -463,7 +466,7 @@ async fn test_search_track() {
             SearchType::Track,
             10,
             0,
-            Some(Country::UnitedStates),
+            Some(Market::Country(Country::UnitedStates)),
             None,
         )
         .await
@@ -726,7 +729,7 @@ async fn test_user_playlist() {
     let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
     oauth_client()
         .await
-        .user_playlist(user_id, Some(&mut playlist_id), None, None)
+        .user_playlist(user_id, Some(&mut playlist_id), None)
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

Fixes "from_token" not being a valid option for market/country.

Create Market enum which can be a country or from_token in order to satisfy both conditions.

Update usages of Country to instead use Market enum.

Update mentions and parameters of country/market to be consistent with spotify API docs.

Fixes #28 

## Motivation and Context

To allow market to be automatically selected from the users access-token instead of having to be supplied manually.

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration:
I ran all tests but the most interesting ones would be the following since they used the old Country enum

- [X] ```Market::Country```: test_artist_top_tracks
- [X] ```Market::Country```: test_categories
- [X] ```Market::Country```: test_category_playlists
- [X] ```Market::Country```: test_recommendations
- [X] ```Market::Country```: test_search_artist

I've also added a test that uses Market::FromToken functionality, but since the market supplied is not static and changes with the oauth token credentials, it maybe wouldn't be such a good test?
- [X] ```Market::FromToken```: test_search_artist_with_from_token