### PR TITLE
Fix broken reference link in documentation.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -61,12 +61,12 @@ pub type ClientResult<T> = Result<T, ClientError>;
 /// API as part of the JSON response object.
 #[derive(Debug, Error, Deserialize)]
 pub enum APIError {
-    /// See https://developer.spotify.com/documentation/web-api/reference/object-model/#error-object
+    /// See https://developer.spotify.com/documentation/web-api/reference/#object-errorobject
     #[error("{status}: {message}")]
     #[serde(alias = "error")]
     Regular { status: u16, message: String },
 
-    /// See https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-object
+    /// See https://developer.spotify.com/documentation/web-api/reference/#object-playererrorobject
     #[error("{status} ({reason}): {message}")]
     #[serde(alias = "error")]
     Player {
@@ -199,7 +199,7 @@ impl Spotify {
     /// Parameters:
     /// - track_id - a spotify URI, URL or ID
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-track)
     #[maybe_async]
     pub async fn track(&self, track_id: &str) -> ClientResult<FullTrack> {
         let trid = self.get_id(Type::Track, track_id);
@@ -214,7 +214,7 @@ impl Spotify {
     /// - track_ids - a list of spotify URIs, URLs or IDs
     /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
     #[maybe_async]
     pub async fn tracks<'a>(
         &self,
@@ -242,7 +242,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_id - an artist ID, URI or URL
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-artist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artist)
     #[maybe_async]
     pub async fn artist(&self, artist_id: &str) -> ClientResult<FullArtist> {
         let trid = self.get_id(Type::Artist, artist_id);
@@ -256,7 +256,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_ids - a list of artist IDs, URIs or URLs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-several-artists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
     #[maybe_async]
     pub async fn artists<'a>(
         &self,
@@ -282,7 +282,7 @@ impl Spotify {
     /// - limit  - the number of albums to return
     /// - offset - the index of the first album to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-artists-albums/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artists-albums)
     #[maybe_async]
     pub async fn artist_albums(
         &self,
@@ -318,7 +318,7 @@ impl Spotify {
     /// - artist_id - the artist ID, URI or URL
     /// - market - limit the response to one particular country.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-artists-top-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artists-top-tracks)
     #[maybe_async]
     pub async fn artist_top_tracks(
         &self,
@@ -342,7 +342,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_id - the artist ID, URI or URL
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-related-artists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artists-related-artists)
     #[maybe_async]
     pub async fn artist_related_artists(&self, artist_id: &str) -> ClientResult<Vec<FullArtist>> {
         let trid = self.get_id(Type::Artist, artist_id);
@@ -357,7 +357,7 @@ impl Spotify {
     /// Parameters:
     /// - album_id - the album ID, URI or URL
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-album/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-album)
     #[maybe_async]
     pub async fn album(&self, album_id: &str) -> ClientResult<FullAlbum> {
         let trid = self.get_id(Type::Album, album_id);
@@ -372,7 +372,7 @@ impl Spotify {
     /// Parameters:
     /// - albums_ids - a list of album IDs, URIs or URLs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-several-albums/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
     #[maybe_async]
     pub async fn albums<'a>(
         &self,
@@ -401,7 +401,7 @@ impl Spotify {
     ///   include_external=audio is specified the response will include any
     ///   relevant audio content that is hosted externally.  
     ///
-    /// [Reference](https://developer.spotify.com/web-api/search-item/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
     #[maybe_async]
     pub async fn search<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -435,7 +435,7 @@ impl Spotify {
     /// - limit  - the number of items to return
     /// - offset - the index of the first item to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-albums-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-albums-tracks)
     #[maybe_async]
     pub async fn album_track<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -457,7 +457,7 @@ impl Spotify {
     /// Parameters:
     /// - user - the id of the usr
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-users-profile/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-profile)
     #[maybe_async]
     pub async fn user(&self, user_id: &str) -> ClientResult<PublicUser> {
         let url = format!("users/{}", user_id);
@@ -471,7 +471,7 @@ impl Spotify {
     /// - playlist_id - the id of the playlist
     /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-playlist)
     #[maybe_async]
     pub async fn playlist(
         &self,
@@ -499,7 +499,7 @@ impl Spotify {
     /// - limit  - the number of items to return
     /// - offset - the index of the first item to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-a-list-of-current-users-playlists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-list-of-current-users-playlists)
     #[maybe_async]
     pub async fn current_user_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -521,7 +521,7 @@ impl Spotify {
     /// - limit  - the number of items to return
     /// - offset - the index of the first item to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-list-users-playlists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-list-users-playlists)
     #[maybe_async]
     pub async fn user_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -544,7 +544,7 @@ impl Spotify {
     /// - playlist_id - the id of the playlist
     /// - fields - which fields to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-list-users-playlists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-list-users-playlists)
     #[maybe_async]
     pub async fn user_playlist(
         &self,
@@ -580,7 +580,7 @@ impl Spotify {
     /// - offset - the index of the first track to return
     /// - market - an ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-playlists-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-playlists-tracks)
     #[maybe_async]
     pub async fn playlist_tracks<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -613,7 +613,7 @@ impl Spotify {
     /// - public - is the created playlist public
     /// - description - the description of the playlist
     ///
-    /// [Reference](https://developer.spotify.com/web-api/create-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-create-playlist)
     #[maybe_async]
     pub async fn user_playlist_create<P: Into<Option<bool>>, D: Into<Option<String>>>(
         &self,
@@ -643,7 +643,7 @@ impl Spotify {
     /// - collaborative - optional is the playlist collaborative
     /// - description - optional description of the playlist
     ///
-    /// [Reference](https://developer.spotify.com/web-api/change-playlist-details/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-change-playlist-details)
     #[maybe_async]
     pub async fn playlist_change_detail(
         &self,
@@ -675,7 +675,7 @@ impl Spotify {
     /// Parameters:
     /// - playlist_id - the id of the playlist
     ///
-    /// [Reference](https://developer.spotify.com/web-api/unfollow-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-unfollow-playlist)
     #[maybe_async]
     pub async fn playlist_unfollow(&self, playlist_id: &str) -> ClientResult<String> {
         let url = format!("playlists/{}/followers", playlist_id);
@@ -689,7 +689,7 @@ impl Spotify {
     /// - track_ids - a list of track URIs, URLs or IDs
     /// - position - the position to add the tracks
     ///
-    /// [Reference](https://developer.spotify.com/web-api/add-tracks-to-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist)
     #[maybe_async]
     pub async fn playlist_add_tracks<'a>(
         &self,
@@ -718,7 +718,7 @@ impl Spotify {
     /// - playlist_id - the id of the playlist
     /// - tracks - the list of track ids to add to the playlist
     ///
-    /// [Reference](https://developer.spotify.com/web-api/replace-playlists-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-reorder-or-replace-playlists-tracks)
     #[maybe_async]
     pub async fn playlist_replace_tracks<'a>(
         &self,
@@ -749,7 +749,7 @@ impl Spotify {
     /// - insert_before - the position where the tracks should be inserted
     /// - snapshot_id - optional playlist's snapshot ID
     ///
-    /// [Reference](https://developer.spotify.com/web-api/reorder-playlists-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-reorder-or-replace-playlists-tracks)
     #[maybe_async]
     pub async fn playlist_reorder_tracks<R: Into<Option<u32>>>(
         &self,
@@ -781,7 +781,7 @@ impl Spotify {
     /// - track_ids - the list of track ids to add to the playlist
     /// - snapshot_id - optional id of the playlist snapshot
     ///
-    /// [Reference](https://developer.spotify.com/web-api/remove-tracks-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-tracks-playlist)
     #[maybe_async]
     pub async fn playlist_remove_all_occurrences_of_tracks<'a>(
         &self,
@@ -839,7 +839,7 @@ impl Spotify {
     /// ```
     /// - snapshot_id: optional id of the playlist snapshot
     ///
-    /// [Reference](https://developer.spotify.com/web-api/remove-tracks-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-tracks-playlist)
     #[maybe_async]
     pub async fn playlist_remove_specific_occurrences_of_tracks(
         &self,
@@ -876,7 +876,7 @@ impl Spotify {
     /// Parameters:
     /// - playlist_id - the id of the playlist
     ///
-    /// [Reference](https://developer.spotify.com/web-api/follow-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-follow-playlist)
     #[maybe_async]
     pub async fn playlist_follow<P: Into<Option<bool>>>(
         &self,
@@ -904,7 +904,7 @@ impl Spotify {
     /// - user_ids - the ids of the users that you want to
     /// check to see if they follow the playlist. Maximum: 5 ids.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/check-user-following-playlist/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-if-user-follows-playlist)
     #[maybe_async]
     pub async fn playlist_check_follow(
         &self,
@@ -926,7 +926,7 @@ impl Spotify {
     /// Get detailed profile information about the current user.
     /// An alias for the 'current_user' method.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-current-users-profile/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-current-users-profile)
     #[maybe_async]
     pub async fn me(&self) -> ClientResult<PrivateUser> {
         let result = self.get("me/", None, &Query::new()).await?;
@@ -936,7 +936,7 @@ impl Spotify {
     /// Get detailed profile information about the current user.
     /// An alias for the 'me' method.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-current-users-profile/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-current-users-profile)
     #[maybe_async]
     pub async fn current_user(&self) -> ClientResult<PrivateUser> {
         self.me().await
@@ -944,7 +944,7 @@ impl Spotify {
 
     /// Get information about the current users currently playing track.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
     #[maybe_async]
     pub async fn current_user_playing_track(
         &self,
@@ -967,7 +967,7 @@ impl Spotify {
     /// - offset - the index of the first album to return
     /// - market - Provide this parameter if you want to apply Track Relinking.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-users-saved-albums/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-albums)
     #[maybe_async]
     pub async fn current_user_saved_albums<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -989,7 +989,7 @@ impl Spotify {
     /// - offset - the index of the first track to return
     /// - market - Provide this parameter if you want to apply Track Relinking.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-users-saved-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-tracks)
     #[maybe_async]
     pub async fn current_user_saved_tracks<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1009,7 +1009,7 @@ impl Spotify {
     /// - limit - the number of tracks to return
     /// - after - the last artist ID retrieved from the previous request
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-followed-artists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-followed)
     #[maybe_async]
     pub async fn current_user_followed_artists<L: Into<Option<u32>>>(
         &self,
@@ -1033,7 +1033,7 @@ impl Spotify {
     /// Parameters:
     /// - track_ids - a list of track URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/remove-tracks-user/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-tracks-user)
     #[maybe_async]
     pub async fn current_user_saved_tracks_delete<'a>(
         &self,
@@ -1055,7 +1055,7 @@ impl Spotify {
     /// Parameters:
     /// - track_ids - a list of track URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/check-users-saved-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-users-saved-tracks)
     #[maybe_async]
     pub async fn current_user_saved_tracks_contains<'a>(
         &self,
@@ -1075,7 +1075,7 @@ impl Spotify {
     /// Parameters:
     /// - track_ids - a list of track URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/save-tracks-user/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-save-tracks-user)
     #[maybe_async]
     pub async fn current_user_saved_tracks_add<'a>(
         &self,
@@ -1098,7 +1098,7 @@ impl Spotify {
     /// - offset - the index of the first entity to return
     /// - time_range - Over what time frame are the affinities computed
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-users-top-artists-and-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-top-artists-and-tracks)
     #[maybe_async]
     pub async fn current_user_top_artists<
         L: Into<Option<u32>>,
@@ -1131,7 +1131,7 @@ impl Spotify {
     /// - offset - the index of the first entity to return
     /// - time_range - Over what time frame are the affinities computed
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-users-top-artists-and-tracks/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-top-artists-and-tracks)
     #[maybe_async]
     pub async fn current_user_top_tracks<
         L: Into<Option<u32>>,
@@ -1162,7 +1162,7 @@ impl Spotify {
     /// Parameters:
     /// - limit - the number of entities to return
     ///
-    /// [Reference](https://developer.spotify.com/web-api/web-api-personalization-endpoints/get-recently-played/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track)
     #[maybe_async]
     pub async fn current_user_recently_played<L: Into<Option<u32>>>(
         &self,
@@ -1179,7 +1179,7 @@ impl Spotify {
     /// Parameters:
     /// - album_ids - a list of album URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/save-albums-user/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-save-albums-user)
     #[maybe_async]
     pub async fn current_user_saved_albums_add<'a>(
         &self,
@@ -1200,7 +1200,7 @@ impl Spotify {
     /// Parameters:
     /// - album_ids - a list of album URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/remove-albums-user/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-albums-user)
     #[maybe_async]
     pub async fn current_user_saved_albums_delete<'a>(
         &self,
@@ -1222,7 +1222,7 @@ impl Spotify {
     /// Parameters:
     /// - album_ids - a list of album URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-albums/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-users-saved-albums)
     #[maybe_async]
     pub async fn current_user_saved_albums_contains<'a>(
         &self,
@@ -1242,7 +1242,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_ids - a list of artist IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/follow-artists-users/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-follow-artists-users)
     #[maybe_async]
     pub async fn user_follow_artists<'a>(
         &self,
@@ -1262,7 +1262,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_ids - a list of artist IDs
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-artists-users/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-unfollow-artists-users)
     #[maybe_async]
     pub async fn user_unfollow_artists<'a>(
         &self,
@@ -1283,7 +1283,7 @@ impl Spotify {
     /// Parameters:
     /// - artist_ids - the ids of the users that you want to
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/check-current-user-follows/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-current-user-follows)
     #[maybe_async]
     pub async fn user_artist_check_follow<'a>(
         &self,
@@ -1302,7 +1302,7 @@ impl Spotify {
     /// Parameters:
     /// - user_ids - a list of artist IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/follow-artists-users/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-follow-artists-users)
     #[maybe_async]
     pub async fn user_follow_users<'a>(
         &self,
@@ -1322,7 +1322,7 @@ impl Spotify {
     /// Parameters:
     /// - user_ids - a list of artist IDs
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-artists-users/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-unfollow-artists-users)
     #[maybe_async]
     pub async fn user_unfollow_users<'a>(
         &self,
@@ -1353,7 +1353,7 @@ impl Spotify {
     ///   (the first object). Use with limit to get the next set of
     ///   items.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-list-featured-playlists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-featured-playlists)
     #[maybe_async]
     pub async fn featured_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1388,7 +1388,7 @@ impl Spotify {
     /// - offset - The index of the first item to return. Default: 0 (the first
     ///   object). Use with limit to get the next set of items.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-list-new-releases/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-new-releases)
     #[maybe_async]
     pub async fn new_releases<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1419,7 +1419,7 @@ impl Spotify {
     /// - offset - The index of the first item to return. Default: 0 (the first
     ///   object). Use with limit to get the next set of items.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-list-categories/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
     #[maybe_async]
     pub async fn categories<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1452,7 +1452,7 @@ impl Spotify {
     /// - offset - The index of the first item to return. Default: 0 (the first
     ///   object). Use with limit to get the next set of items.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/browse/get-categorys-playlists/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-categories-playlists)
     #[maybe_async]
     pub async fn category_playlists<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1488,7 +1488,7 @@ impl Spotify {
     ///   in the documentation, these values provide filters and targeting on
     ///   results.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-recommendations/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations)
     #[maybe_async]
     pub async fn recommendations<L: Into<Option<u32>>>(
         &self,
@@ -1559,7 +1559,7 @@ impl Spotify {
     /// Parameters:
     /// - track - track URI, URL or ID
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-audio-features/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-features)
     #[maybe_async]
     pub async fn track_features(&self, track: &str) -> ClientResult<AudioFeatures> {
         let track_id = self.get_id(Type::Track, track);
@@ -1573,7 +1573,7 @@ impl Spotify {
     /// Parameters:
     /// - tracks a list of track URIs, URLs or IDs
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-several-audio-features/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features)
     #[maybe_async]
     pub async fn tracks_features<'a>(
         &self,
@@ -1599,7 +1599,7 @@ impl Spotify {
     /// Parameters:
     /// - track_id - a track URI, URL or ID
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
     #[maybe_async]
     pub async fn track_analysis(&self, track: &str) -> ClientResult<AudioAnalysis> {
         let trid = self.get_id(Type::Track, track);
@@ -1610,7 +1610,7 @@ impl Spotify {
 
     /// Get a User’s Available Devices
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-a-users-available-devices/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
     #[maybe_async]
     pub async fn device(&self) -> ClientResult<Vec<Device>> {
         let result = self.get("me/player/devices", None, &Query::new()).await?;
@@ -1626,7 +1626,7 @@ impl Spotify {
     ///   your client supports besides the default track type. Valid types are:
     ///   `track` and `episode`.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-information-about-the-users-current-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
     #[maybe_async]
     pub async fn current_playback(
         &self,
@@ -1664,7 +1664,7 @@ impl Spotify {
     ///   your client supports besides the default track type. Valid types are:
     ///   `track` and `episode`.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
     #[maybe_async]
     pub async fn current_playing(
         &self,
@@ -1706,7 +1706,7 @@ impl Spotify {
     /// - force_play - true: after transfer, play. false:
     ///   keep current state.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/transfer-a-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-transfer-a-users-playback)
     #[maybe_async]
     pub async fn transfer_playback<T: Into<Option<bool>>>(
         &self,
@@ -1740,7 +1740,7 @@ impl Spotify {
     /// - offset - offset into context by index or track
     /// - position_ms - Indicates from what position to start playback.
     ///
-    /// [Reference](https://developer.spotify.com/web-api/start-a-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-start-a-users-playback)
     #[maybe_async]
     pub async fn start_playback(
         &self,
@@ -1781,7 +1781,7 @@ impl Spotify {
     /// Parameters:
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/pause-a-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-pause-a-users-playback)
     #[maybe_async]
     pub async fn pause_playback(&self, device_id: Option<String>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/pause", device_id);
@@ -1795,7 +1795,7 @@ impl Spotify {
     /// Parameters:
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/skip-users-playback-to-next-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-skip-users-playback-to-next-track)
     #[maybe_async]
     pub async fn next_track(&self, device_id: Option<String>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/next", device_id);
@@ -1809,7 +1809,7 @@ impl Spotify {
     /// Parameters:
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/skip-users-playback-to-previous-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-skip-users-playback-to-previous-track)
     #[maybe_async]
     pub async fn previous_track(&self, device_id: Option<String>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/previous", device_id);
@@ -1824,7 +1824,7 @@ impl Spotify {
     /// - position_ms - position in milliseconds to seek to
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/seek-to-position-in-currently-playing-track/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-seek-to-position-in-currently-playing-track)
     #[maybe_async]
     pub async fn seek_track(
         &self,
@@ -1846,7 +1846,7 @@ impl Spotify {
     /// - state - `track`, `context`, or `off`
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/set-repeat-mode-on-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-set-repeat-mode-on-users-playback)
     #[maybe_async]
     pub async fn repeat(&self, state: RepeatState, device_id: Option<String>) -> ClientResult<()> {
         let url = self.append_device_id(
@@ -1864,7 +1864,7 @@ impl Spotify {
     /// - volume_percent - volume between 0 and 100
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/set-volume-for-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-set-volume-for-users-playback)
     #[maybe_async]
     pub async fn volume(&self, volume_percent: u8, device_id: Option<String>) -> ClientResult<()> {
         if volume_percent > 100u8 {
@@ -1885,7 +1885,7 @@ impl Spotify {
     /// - state - true or false
     /// - device_id - device target for playback
     ///
-    /// [Reference](https://developer.spotify.com/web-api/toggle-shuffle-for-users-playback/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-toggle-shuffle-for-users-playback)
     #[maybe_async]
     pub async fn shuffle(&self, state: bool, device_id: Option<String>) -> ClientResult<()> {
         let url = self.append_device_id(&format!("me/player/shuffle?state={}", state), device_id);
@@ -1902,7 +1902,7 @@ impl Spotify {
     /// - If no device ID provided the user's currently active device is
     ///   targeted
     ///
-    /// [Reference](https://developer.spotify.com/console/post-queue/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-to-queue)
     #[maybe_async]
     pub async fn add_item_to_queue(
         &self,
@@ -1921,7 +1921,7 @@ impl Spotify {
     /// - ids(Required) A comma-separated list of Spotify IDs for the shows to
     ///   be added to the user’s library.
     ///
-    /// [Reference](https://developer.spotify.com/console/put-current-user-saved-shows)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-save-shows-user)
     #[maybe_async]
     pub async fn save_shows<'a>(&self, ids: impl IntoIterator<Item = &'a str>) -> ClientResult<()> {
         let joined_ids = ids.into_iter().collect::<Vec<_>>().join(",");
@@ -1940,7 +1940,7 @@ impl Spotify {
     /// - offset(Optional). The index of the first show to return. Default: 0
     ///   (the first object). Use with limit to get the next set of shows.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-shows/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-shows)
     #[maybe_async]
     pub async fn get_saved_show<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -1962,7 +1962,7 @@ impl Spotify {
     /// Query Parameters
     /// - market(Optional): An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-show)
     #[maybe_async]
     pub async fn get_a_show(&self, id: String, market: Option<Market>) -> ClientResult<FullShow> {
         let mut params = Query::new();
@@ -1981,7 +1981,7 @@ impl Spotify {
     /// - ids(Required) A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.
     /// - market(Optional) An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-shows)
     #[maybe_async]
     pub async fn get_several_shows<'a>(
         &self,
@@ -2013,7 +2013,7 @@ impl Spotify {
     /// - offset: Optional. The index of the first episode to return. Default: 0 (the first object). Use with limit to get the next set of episodes.
     /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-shows-episodes)
     #[maybe_async]
     pub async fn get_shows_episodes<L: Into<Option<u32>>, O: Into<Option<u32>>>(
         &self,
@@ -2041,7 +2041,7 @@ impl Spotify {
     /// Query Parameters
     /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/episodes/get-an-episode/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-episode)
     #[maybe_async]
     pub async fn get_an_episode(
         &self,
@@ -2064,7 +2064,7 @@ impl Spotify {
     /// - ids: Required. A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.
     /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/episodes/get-several-episodes/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-episodes)
     #[maybe_async]
     pub async fn get_several_episodes<'a>(
         &self,
@@ -2088,7 +2088,7 @@ impl Spotify {
     /// Query Parameters
     /// - ids: Required. A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-shows/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-check-users-saved-shows)
     #[maybe_async]
     pub async fn check_users_saved_shows<'a>(
         &self,
@@ -2110,7 +2110,7 @@ impl Spotify {
     /// - ids: Required. A comma-separated list of Spotify IDs for the shows to be deleted from the user’s library.
     /// - market: Optional. An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/library/remove-shows-user/)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-shows-user)
     #[maybe_async]
     pub async fn remove_users_saved_shows<'a>(
         &self,

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -13,7 +13,7 @@ use crate::model::{AlbumType, Copyright, DatePrecision, Type};
 
 /// Simplified Album Object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#album-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedalbumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedAlbum {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,7 +40,7 @@ pub struct SimplifiedAlbum {
 
 /// Full Album Object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#album-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-albumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullAlbum {
     pub artists: Vec<SimplifiedArtist>,
@@ -65,7 +65,7 @@ pub struct FullAlbum {
 
 /// Full Albums wrapped by Vec object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/albums/get-several-albums/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
 #[derive(Deserialize)]
 pub(in crate) struct FullAlbums {
     pub albums: Vec<FullAlbum>,
@@ -73,7 +73,7 @@ pub(in crate) struct FullAlbums {
 
 /// Simplified Albums wrapped by Page object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-list-new-releases/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-new-releases)
 #[derive(Deserialize)]
 pub(in crate) struct PageSimpliedAlbums {
     pub albums: Page<SimplifiedAlbum>,
@@ -81,7 +81,7 @@ pub(in crate) struct PageSimpliedAlbums {
 
 /// Saved Album object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#save-album-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedalbumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SavedAlbum {
     pub added_at: DateTime<Utc>,

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -7,7 +7,7 @@ use crate::model::{Followers, Type};
 use std::collections::HashMap;
 /// Simplified Artist Object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#artist-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedartistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedArtist {
     pub external_urls: HashMap<String, String>,
@@ -21,7 +21,7 @@ pub struct SimplifiedArtist {
 
 /// Full Artist Object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#artist-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-artistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullArtist {
     pub external_urls: HashMap<String, String>,
@@ -39,7 +39,7 @@ pub struct FullArtist {
 
 /// Full artist object wrapped by `Vec`
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/artists/get-several-artists/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
 #[derive(Deserialize)]
 pub(in crate) struct FullArtists {
     pub artists: Vec<FullArtist>,
@@ -47,7 +47,7 @@ pub(in crate) struct FullArtists {
 
 /// Full Artists vector wrapped by cursor-based-page object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-followed)
 #[derive(Deserialize)]
 pub(in crate) struct CursorPageFullArtists {
     pub artists: CursorBasedPage<FullArtist>,

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 /// Audio Feature Object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#audio-features-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-audiofeaturesobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioFeatures {
     pub acousticness: f32,
@@ -33,7 +33,7 @@ pub struct AudioFeatures {
 
 /// Audio feature object wrapped by `Vec`
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features)
 #[derive(Deserialize)]
 pub(in crate) struct AudioFeaturesPayload {
     pub audio_features: Vec<AudioFeatures>,
@@ -41,7 +41,7 @@ pub(in crate) struct AudioFeaturesPayload {
 
 /// Audio analysis object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysis {
     pub bars: Vec<TimeInterval>,
@@ -54,7 +54,7 @@ pub struct AudioAnalysis {
 }
 
 /// Time interval object
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#time-interval-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct TimeInterval {
     pub start: f32,
@@ -64,7 +64,7 @@ pub struct TimeInterval {
 
 /// Audio analysis section object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#section-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisSection {
     #[serde(flatten)]
@@ -83,7 +83,7 @@ pub struct AudioAnalysisSection {
 
 /// Audio analysis meta object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisMeta {
     pub analyzer_version: String,
@@ -96,7 +96,7 @@ pub struct AudioAnalysisMeta {
 }
 /// Audio analysis segment object
 ///
-///[Reference](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/#segment-object)
+///[Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisSegment {
     #[serde(flatten)]
@@ -111,7 +111,7 @@ pub struct AudioAnalysisSegment {
 
 /// Audio analysis track object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-audio-analysis/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisTrack {
     pub num_samples: u32,

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -4,7 +4,7 @@ use super::page::Page;
 use serde::{Deserialize, Serialize};
 /// Category object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-list-categories/#categoryobject)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Category {
     pub href: String,
@@ -15,7 +15,7 @@ pub struct Category {
 
 /// Categories wrapped by page object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-list-categories/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
 #[derive(Deserialize)]
 pub(in crate) struct PageCategory {
     pub categories: Page<Category>,

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 /// Context object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-the-users-currently-playing-track/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Context {
     pub uri: String,
@@ -22,7 +22,7 @@ pub struct Context {
 
 /// Currently playing object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentlyPlayingContext {
     pub context: Option<Context>,
@@ -36,7 +36,7 @@ pub struct CurrentlyPlayingContext {
     pub currently_playing_type: CurrentlyPlayingType,
     pub actions: Actions,
 }
-/// [Currently Playback Context](https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentPlaybackContext {
     pub device: Device,
@@ -56,7 +56,7 @@ pub struct CurrentPlaybackContext {
 
 /// Actions object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct Actions {
     pub disallows: Vec<DisallowKey>,

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Device object
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-a-users-available-devices/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Device {
     pub id: Option<String>,
@@ -18,7 +18,7 @@ pub struct Device {
 
 /// Device payload object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 #[derive(Deserialize)]
 pub(in crate) struct DevicePayload {
     pub devices: Vec<Device>,

--- a/src/model/enums/types.rs
+++ b/src/model/enums/types.rs
@@ -70,7 +70,7 @@ pub enum CurrentlyPlayingType {
 
 /// Type for search: `artist`, `album`, `track`, `playlist`, `show`, `episode`
 ///
-/// [Reference](https://developer.spotify.com/web-api/search-item/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, ToString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Image object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#image-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-imageobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Image {
     pub height: Option<u32>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -193,7 +193,7 @@ pub(in crate) mod modality {
 
 /// Restriction object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-restriction-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-albumrestrictionobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Restriction {
     pub reason: RestrictionReason,
@@ -201,7 +201,7 @@ pub struct Restriction {
 
 /// Followers object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#followers-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-followersobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Followers {
     // This field will always set to null, as the Web API does not support it at the moment.
@@ -211,8 +211,8 @@ pub struct Followers {
 
 /// A full track object or a full episode object
 ///
-/// + [Reference to full track](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full)
-/// + [Reference to full episode](https://developer.spotify.com/documentation/web-api/reference/object-model/#episode-object-full)
+/// + [Reference to full track](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)
+/// + [Reference to full episode](https://developer.spotify.com/documentation/web-api/reference/#object-episodeobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum PlayingItem {

--- a/src/model/offset.rs
+++ b/src/model/offset.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 /// Offset object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-start-a-users-playback)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Offset {
     #[serde(default)]

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Paging object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-pagingobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Page<T> {
     pub href: String,
@@ -16,7 +16,7 @@ pub struct Page<T> {
 }
 /// Cursor-based paging object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#cursor-based-paging-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorpagingobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CursorBasedPage<T> {
     pub href: String,
@@ -30,7 +30,7 @@ pub struct CursorBasedPage<T> {
 }
 /// Cursor object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#cursor-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Cursor {
     pub after: Option<String>,

--- a/src/model/playing.rs
+++ b/src/model/playing.rs
@@ -7,7 +7,7 @@ use super::track::FullTrack;
 
 /// Playing history object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#play-history-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playhistoryobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlayHistory {
     pub track: FullTrack,

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -12,7 +12,7 @@ use crate::model::{Followers, Type};
 
 /// Playlist result object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlaylistResult {
     pub snapshot_id: String,
@@ -20,7 +20,7 @@ pub struct PlaylistResult {
 
 /// Simplified playlist object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#playlist-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedplaylistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedPlaylist {
     pub collaborative: bool,
@@ -40,7 +40,7 @@ pub struct SimplifiedPlaylist {
 
 /// Full playlist object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#playlist-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullPlaylist {
     pub collaborative: bool,
@@ -62,7 +62,7 @@ pub struct FullPlaylist {
 
 /// Playlist track object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#playlist-track-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlaylistItem {
     pub added_at: Option<DateTime<Utc>>,
@@ -71,7 +71,7 @@ pub struct PlaylistItem {
     pub track: Option<FullTrack>,
 }
 /// Featured playlists object
-/// [Reference](https://developer.spotify.com/web-api/get-list-featured-playlists/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-featured-playlists)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FeaturedPlaylists {
     pub message: String,
@@ -80,7 +80,7 @@ pub struct FeaturedPlaylists {
 
 /// Category playlists object wrapped by `Page`
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/browse/get-categorys-playlists/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-categories-playlists)
 #[derive(Deserialize)]
 pub(in crate) struct CategoryPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,

--- a/src/model/recommend.rs
+++ b/src/model/recommend.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Recommendations object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#recommendations-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Recommendations {
     pub seeds: Vec<RecommendationsSeed>,
@@ -14,7 +14,7 @@ pub struct Recommendations {
 
 /// Recommendations seed object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#recommendations-seed-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RecommendationsSeed {
     #[serde(rename = "afterFilteringSize")]

--- a/src/model/search.rs
+++ b/src/model/search.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Search for playlists
 ///
-///[Reference](https://developer.spotify.com/web-api/search-item/);
+///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search);
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,
@@ -17,7 +17,7 @@ pub struct SearchPlaylists {
 
 /// Search for albums
 ///
-///[Reference](https://developer.spotify.com/web-api/search-item/)
+///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchAlbums {
     pub albums: Page<SimplifiedAlbum>,
@@ -25,12 +25,12 @@ pub struct SearchAlbums {
 
 /// Search for artists
 ///
-///[Reference](https://developer.spotify.com/web-api/search-item/)
+///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchArtists {
     pub artists: Page<FullArtist>,
 }
-///[Search item](https://developer.spotify.com/web-api/search-item/)
+///[Search item](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchTracks {
     pub tracks: Page<FullTrack>,
@@ -38,7 +38,7 @@ pub struct SearchTracks {
 
 /// Search for shows
 ///
-/// [Reference](https://developer.spotify.com/web-api/search-item/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchShows {
     pub shows: Page<SimplifiedShow>,
@@ -46,7 +46,7 @@ pub struct SearchShows {
 
 /// Search for episodes
 ///
-/// [Reference](https://developer.spotify.com/web-api/search-item/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchEpisodes {
     pub episodes: Page<SimplifiedEpisode>,

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 /// Copyright object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#copyright-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-copyrightobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Copyright {
     pub text: String,
@@ -17,7 +17,7 @@ pub struct Copyright {
 
 /// Simplified show object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#show-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedshowobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedShow {
     pub available_markets: Vec<String>,
@@ -40,7 +40,7 @@ pub struct SimplifiedShow {
 
 /// SimplifiedShows wrapped by `Vec`
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-shows)
 #[derive(Deserialize)]
 pub(in crate) struct SeversalSimplifiedShows {
     pub shows: Vec<SimplifiedShow>,
@@ -48,7 +48,7 @@ pub(in crate) struct SeversalSimplifiedShows {
 
 /// Saved show object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#saved-show-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedshowobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Show {
     pub added_at: String,
@@ -57,7 +57,7 @@ pub struct Show {
 
 /// Full show object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#show-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-showobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullShow {
     pub available_markets: Vec<String>,
@@ -81,7 +81,7 @@ pub struct FullShow {
 
 /// Simplified episode object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#episode-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedepisodeobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedEpisode {
     pub audio_preview_url: Option<String>,
@@ -111,7 +111,7 @@ pub struct SimplifiedEpisode {
 
 /// Full episode object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#episode-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-episodeobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullEpisode {
     pub audio_preview_url: Option<String>,
@@ -145,7 +145,7 @@ pub struct SeveralEpisodes {
 
 /// Resume point object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#resume-point-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-resumepointobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResumePoint {
     pub fully_played: bool,

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -12,7 +12,7 @@ use crate::model::Type;
 
 /// Full track object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullTrack {
     pub album: SimplifiedAlbum,
@@ -45,7 +45,7 @@ pub struct FullTrack {
 
 /// Track link object
 ///
-/// [Reference] https://developer.spotify.com/documentation/web-api/reference/object-model/#track-link
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-linkedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrackLink {
     pub external_urls: HashMap<String, String>,
@@ -58,7 +58,7 @@ pub struct TrackLink {
 
 /// Full track wrapped by `Vec`
 ///
-/// [Reference](https://developer.spotify.com/web-api/get-several-tracks/)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
 #[derive(Deserialize)]
 pub(in crate) struct FullTracks {
     pub tracks: Vec<FullTrack>,
@@ -69,7 +69,7 @@ pub(in crate) struct FullTracks {
 /// `is_playable`, `linked_from` and `restrictions` will only be present when
 /// relinking is applied.
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedTrack {
     pub artists: Vec<SimplifiedArtist>,
@@ -96,7 +96,7 @@ pub struct SimplifiedTrack {
 
 /// Saved track object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#saved-track-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SavedTrack {
     pub added_at: DateTime<Utc>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -8,7 +8,7 @@ use crate::model::{Country, Followers, SubscriptionLevel, Type};
 
 /// Public user object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#user-object-public)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-publicuserobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PublicUser {
     pub display_name: Option<String>,
@@ -25,7 +25,7 @@ pub struct PublicUser {
 
 /// Private user object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#user-object-private)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-privateuserobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrivateUser {
     pub country: Option<Country>,
@@ -45,7 +45,7 @@ pub struct PrivateUser {
 
 /// Explicit content setting object
 ///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/#explicit-content-settings-object)
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-explicitcontentsettingsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExplicitContent {
     pub filter_enabled: bool,


### PR DESCRIPTION
## Description

Update documentation links, fixed #180 

## Motivation and Context

Some links used in the docs are broken, and some links are redirect to new url, so just update them to the latest one.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Open updated links with browser, then check if these links are ok.
