### PR TITLE
Fix failed CI jobs for cross-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
   cross-compile:
     name: Cross Compile
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+      CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     strategy:
       matrix:
         target:


### PR DESCRIPTION
## Description

Trying to fix failed CI jobs, fixed #183 

## Motivation and Context

It seems the CI has stopped passing suddenly for cross-compilation on all platforms for reqwest, just fix it.

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Check if all jobs pass or not?
