### PR TITLE
Fix auth CI issue

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -87,8 +87,8 @@ pub struct Token {
     pub refresh_token: Option<String>,
     /// A list of [scopes](https://developer.spotify.com/documentation/general/guides/scopes/)
     /// which have been granted for this `access_token`
-    #[builder(default = "HashSet::new()")]
-    #[serde(with = "space_separated_scope")]
+    #[builder(default)]
+    #[serde(default, with = "space_separated_scope")]
     pub scope: HashSet<String>,
 }
 


### PR DESCRIPTION
This fixes the CI issue mentioned in #161. The Spotify API now returns no `scope` field when using the client credentials (as opposed to an empty array), so adding a default value when deserializing via `serde` is enough.