### PR TITLE
Allow `PlaylistItem` to contain episodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + `Device`
   + `DevicePayload`
   + `Image`
-  + `PlayingItem` 
+  + `PlayableItem`
   + `Offset`
   + `Page`
   + `CursorBasedPage`
@@ -198,6 +198,7 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Change `Token.scope` from `String` to `HashSet`.
   + Change `OAuth.scope` from `String` to `HashSet`.
   + Change `SimplifiedPlaylist::tracks` from `HashMap` to `PlaylistTracksRef`
+- ([#194](https://github.com/ramsayleung/rspotify/pull/194)) Rename `PlayingItem` to `PlayableItem`, `PlaylistItem::track` type changed to `Option<PlayableItem>`, so playlists can contain episodes as well
 
 ## 0.10 (2020/07/01)
 

--- a/src/model/context.rs
+++ b/src/model/context.rs
@@ -1,6 +1,6 @@
 //! All objects related to context
 use super::device::Device;
-use super::PlayingItem;
+use super::PlayableItem;
 use crate::model::{
     millisecond_timestamp, option_duration_ms, CurrentlyPlayingType, DisallowKey, RepeatState, Type,
 };
@@ -32,7 +32,7 @@ pub struct CurrentlyPlayingContext {
     #[serde(with = "option_duration_ms", rename = "progress_ms")]
     pub progress: Option<Duration>,
     pub is_playing: bool,
-    pub item: Option<PlayingItem>,
+    pub item: Option<PlayableItem>,
     pub currently_playing_type: CurrentlyPlayingType,
     pub actions: Actions,
 }
@@ -49,7 +49,7 @@ pub struct CurrentPlaybackContext {
     #[serde(with = "option_duration_ms", rename = "progress_ms")]
     pub progress: Option<Duration>,
     pub is_playing: bool,
-    pub item: Option<PlayingItem>,
+    pub item: Option<PlayableItem>,
     pub currently_playing_type: CurrentlyPlayingType,
     pub actions: Actions,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -216,7 +216,7 @@ pub struct Followers {
 /// + [Reference to full episode](https://developer.spotify.com/documentation/web-api/reference/#object-episodeobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
-pub enum PlayingItem {
+pub enum PlayableItem {
     Track(track::FullTrack),
     Episode(show::FullEpisode),
 }

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use super::image::Image;
 use super::page::Page;
 use super::user::PublicUser;
-use crate::model::{Followers, PlayingItem, Type};
+use crate::model::{Followers, PlayableItem, Type};
 
 /// Playlist result object
 ///
@@ -75,7 +75,7 @@ pub struct PlaylistItem {
     pub added_at: Option<DateTime<Utc>>,
     pub added_by: Option<PublicUser>,
     pub is_local: bool,
-    pub track: Option<PlayingItem>,
+    pub track: Option<PlayableItem>,
 }
 /// Featured playlists object
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-featured-playlists)

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use super::image::Image;
 use super::page::Page;
 use super::user::PublicUser;
-use crate::model::{Followers, Type, PlayingItem};
+use crate::model::{Followers, PlayingItem, Type};
 
 /// Playlist result object
 ///

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 
 use super::image::Image;
 use super::page::Page;
-use super::track::FullTrack;
 use super::user::PublicUser;
-use crate::model::{Followers, Type};
+use crate::model::{Followers, Type, PlayingItem};
 
 /// Playlist result object
 ///
@@ -76,7 +75,7 @@ pub struct PlaylistItem {
     pub added_at: Option<DateTime<Utc>>,
     pub added_by: Option<PublicUser>,
     pub is_local: bool,
-    pub track: Option<FullTrack>,
+    pub track: Option<PlayingItem>,
 }
 /// Featured playlists object
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-featured-playlists)


### PR DESCRIPTION
## Description

It's a change for meta-issue #127: "Allow `PlaylistTrack`/`PlaylistItem` to contain episodes."

## Motivation and Context

According to meta-issue #127 and [official docs](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttrackobject), `PlaylistItem` object can have either `FullTrack` or `FullEpisode` object as a value of the `track` field.
Hence the fix.

## Dependencies 

Update docs and changelog.

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

Run a full test suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramsayleung/rspotify/194)
<!-- Reviewable:end -->
