### PR TITLE
Update async-trait crate to 0.1.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 # Temporary until https://github.com/rust-lang/rfcs/issues/2739, for
 # `maybe_async`.
-async-trait = { version = "0.1.40", optional = true }
+async-trait = { version = "0.1.48", optional = true }
 base64 = "0.13.0"
 chrono = { version = "0.4.13", features = ["serde", "rustc-serialize"] }
 derive_builder = "0.10.0"


### PR DESCRIPTION
## Description

Update async-trait crate to 0.1.48. Only the version number in Cargo.toml was changed, no other fixes required.

## Motivation and Context

derive_builder_core 0.10.0 requires quote 1.0.8 or superior, which conflicts with some other packages like async-trait and some others.

Example bellow of me trying to run ```cargo check``` in one of my projects:
```
error: failed to select a version for `quote`.
    ... required by package `derive_builder_core v0.10.0`
    ... which is depended on by `derive_builder v0.10.0`
    ... which is depended on by `rspotify v0.10.0 (https://github.com/ramsayleung/rspotify.git#7130835a)`
    ... which is depended on by `constantinus v0.1.0 (/mnt/c/Users/rodrigo.mauricio/Documents/Pessoal/constantinus)`
versions that meet the requirements `^1.0.8` are: 1.0.9, 1.0.8

all possible versions conflict with previously selected packages.

  previously selected package `quote v1.0.7`
    ... which is depended on by `async-trait v0.1.42`
    ... which is depended on by `rspotify v0.10.0 (https://github.com/ramsayleung/rspotify.git#7130835a)`
    ... which is depended on by `constantinus v0.1.0 (/mnt/c/Users/rodrigo.mauricio/Documents/Pessoal/constantinus)`

failed to select a version for `quote` which could resolve this conflict
```

## Dependencies 

async-trait = 0.1.48
quote = ^1.0.8
derive_builder_core = 0.10.0

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

No tests required?
