### PR TITLE
Remove Rspotify default parameters and add parameter macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ If we missed any change or there's something you'd like to discuss about this ve
 
 - Rewritten documentation in hopes that it's easier to get started with Rspotify.
 - Reduced the number of examples. Instead of having an example for each endpoint, which is repetitive and unhelpful for newcomers, some real-life examples are now included. If you'd like to add your own example, please do! ([#113](https://github.com/ramsayleung/rspotify/pull/113))
+- Rspotify now uses macros internally to make the endpoints as concise as possible and nice to read.
 - Add `add_item_to_queue` endpoint.
 - Add `category_playlists` endpoint ([#153](https://github.com/ramsayleung/rspotify/pull/153)).
 - Fix race condition when using a single client from multiple threads ([#114](https://github.com/ramsayleung/rspotify/pull/114)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,9 @@ If we missed any change or there's something you'd like to discuss about this ve
   As a side effect, some methods now take references instead of values (so that they can be used multiple times when querying), and the parameters have been reordered so that the `limit` and `offset` are consistently the last two.
 
   The pagination chunk size can be configured with the `Spotify::pagination_chunks` field, which is set to 50 items by default.
+- No default values are set from Rspotify now, they will be left to the Spotify API.
+- []() Add a `collaborative` parameter to `user_playlist_create`.
+- []() Add a `uris` parameter to `playlist_reorder_tracks`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ If we missed any change or there's something you'd like to discuss about this ve
 - ([#189](https://github.com/ramsayleung/rspotify/pull/189)) Add `scopes!` macro to generate scope for `Token` from string literal
 
 **Breaking changes:**
+- ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Rspotify now consistently uses `Option<T>` for optional parameters. Those generic over `Into<Option<T>>` have been changed, which makes calling endpoints a bit ugiler but more consistent and simpler.
 - `SpotifyClientCredentials` has been renamed to `Credentials` ([#129](https://github.com/ramsayleung/rspotify/pull/129)), and its members `client_id` and `client_secret` to `id` and `secret`, respectively.
 - `TokenInfo` has been renamed to `Token`. It no longer has the `token_type` member, as it's always `Bearer` for now ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
 - `SpotifyOAuth` has been renamed to `OAuth`. It only contains the necessary parameters for OAuth authorization instead of repeating the items from `Credentials` and `Spotify`, so `client_id`, `client_secret` and `cache_path` are no longer in `OAuth` ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
@@ -206,14 +207,14 @@ If we missed any change or there's something you'd like to discuss about this ve
   + Rename `ClientError::IO` to `ClientError::Io`
   + Rename `ClientError::CLI` to `ClientError::Cli`
   + Rename `BaseHTTPClient` to `BaseHttpClient`
-- [#166](https://github.com/ramsayleung/rspotify/pull/166) [#201](https://github.com/ramsayleung/rspotify/pull/201) Add automatic pagination, which is now enabled by default. You can still use the methods with the `_manual` suffix to have access to manual pagination. There are three new examples for this, check out `examples/pagination*` to learn more!
+- ([#166](https://github.com/ramsayleung/rspotify/pull/166) [#201](https://github.com/ramsayleung/rspotify/pull/201)) Add automatic pagination, which is now enabled by default. You can still use the methods with the `_manual` suffix to have access to manual pagination. There are three new examples for this, check out `examples/pagination*` to learn more!
 
   As a side effect, some methods now take references instead of values (so that they can be used multiple times when querying), and the parameters have been reordered so that the `limit` and `offset` are consistently the last two.
 
   The pagination chunk size can be configured with the `Spotify::pagination_chunks` field, which is set to 50 items by default.
 - No default values are set from Rspotify now, they will be left to the Spotify API.
-- [#202](https://github.com/ramsayleung/rspotify/pull/202) Add a `collaborative` parameter to `user_playlist_create`.
-- [#202](https://github.com/ramsayleung/rspotify/pull/202) Add a `uris` parameter to `playlist_reorder_tracks`.
+- ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `collaborative` parameter to `user_playlist_create`.
+- ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `uris` parameter to `playlist_reorder_tracks`.
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,8 +211,8 @@ If we missed any change or there's something you'd like to discuss about this ve
 
   The pagination chunk size can be configured with the `Spotify::pagination_chunks` field, which is set to 50 items by default.
 - No default values are set from Rspotify now, they will be left to the Spotify API.
-- []() Add a `collaborative` parameter to `user_playlist_create`.
-- []() Add a `uris` parameter to `playlist_reorder_tracks`.
+- [#202](https://github.com/ramsayleung/rspotify/pull/202) Add a `collaborative` parameter to `user_playlist_create`.
+- [#202](https://github.com/ramsayleung/rspotify/pull/202) Add a `uris` parameter to `playlist_reorder_tracks`.
 
 ## 0.10 (2020/07/01)
 

--- a/examples/current_user_recently_played.rs
+++ b/examples/current_user_recently_played.rs
@@ -45,7 +45,7 @@ async fn main() {
     spotify.prompt_for_user_token().await.unwrap();
 
     // Running the requests
-    let history = spotify.current_user_recently_played(10).await;
+    let history = spotify.current_user_recently_played(Some(10)).await;
 
     println!("Response: {:?}", history);
 }

--- a/examples/pagination_manual.rs
+++ b/examples/pagination_manual.rs
@@ -54,7 +54,7 @@ async fn main() {
     println!("Items:");
     loop {
         let page = spotify
-            .current_user_saved_tracks_manual(limit, offset)
+            .current_user_saved_tracks_manual(Some(limit), Some(offset))
             .await
             .unwrap();
         for item in page.items {

--- a/examples/ureq/device.rs
+++ b/examples/ureq/device.rs
@@ -1,8 +1,6 @@
 use rspotify::client::SpotifyBuilder;
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder};
-use rspotify::scope;
-
-use std::collections::HashSet;
+use rspotify::scopes;
 
 fn main() {
     // You can use any logger for debugging.

--- a/examples/ureq/me.rs
+++ b/examples/ureq/me.rs
@@ -1,8 +1,6 @@
 use rspotify::client::SpotifyBuilder;
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder};
-use rspotify::scope;
-
-use std::collections::HashSet;
+use rspotify::scopes;
 
 fn main() {
     // You can use any logger for debugging.

--- a/examples/ureq/search.rs
+++ b/examples/ureq/search.rs
@@ -101,7 +101,14 @@ fn main() {
     }
 
     let episode_query = "love";
-    let result = spotify.search(episode_query, SearchType::Episode, None, None, Some(10), None);
+    let result = spotify.search(
+        episode_query,
+        SearchType::Episode,
+        None,
+        None,
+        Some(10),
+        None,
+    );
     match result {
         Ok(episode) => println!("searched episode:{:?}", episode),
         Err(err) => println!("search error!{:?}", err),

--- a/examples/ureq/search.rs
+++ b/examples/ureq/search.rs
@@ -1,9 +1,7 @@
 use rspotify::client::SpotifyBuilder;
 use rspotify::model::{Country, Market, SearchType};
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder};
-use rspotify::scope;
-
-use std::collections::HashSet;
+use rspotify::scopes;
 
 fn main() {
     // You can use any logger for debugging.
@@ -47,7 +45,7 @@ fn main() {
     spotify.request_client_token().unwrap();
 
     let album_query = "album:arrival artist:abba";
-    let result = spotify.search(album_query, SearchType::Album, 10, 0, None, None);
+    let result = spotify.search(album_query, SearchType::Album, None, None, Some(10), None);
     match result {
         Ok(album) => println!("searched album:{:?}", album),
         Err(err) => println!("search error!{:?}", err),
@@ -57,9 +55,9 @@ fn main() {
     let result = spotify.search(
         artist_query,
         SearchType::Artist,
-        10,
-        0,
         Some(Market::Country(Country::UnitedStates)),
+        None,
+        Some(10),
         None,
     );
     match result {
@@ -71,9 +69,9 @@ fn main() {
     let result = spotify.search(
         playlist_query,
         SearchType::Playlist,
-        10,
-        0,
         Some(Market::Country(Country::UnitedStates)),
+        None,
+        Some(10),
         None,
     );
     match result {
@@ -85,9 +83,9 @@ fn main() {
     let result = spotify.search(
         track_query,
         SearchType::Track,
-        10,
-        0,
         Some(Market::Country(Country::UnitedStates)),
+        None,
+        Some(10),
         None,
     );
     match result {
@@ -96,14 +94,14 @@ fn main() {
     }
 
     let show_query = "love";
-    let result = spotify.search(show_query, SearchType::Show, 10, 0, None, None);
+    let result = spotify.search(show_query, SearchType::Show, None, None, Some(10), None);
     match result {
         Ok(show) => println!("searched show:{:?}", show),
         Err(err) => println!("search error!{:?}", err),
     }
 
     let episode_query = "love";
-    let result = spotify.search(episode_query, SearchType::Episode, 10, 0, None, None);
+    let result = spotify.search(episode_query, SearchType::Episode, None, None, Some(10), None);
     match result {
         Ok(episode) => println!("searched episode:{:?}", episode),
         Err(err) => println!("search error!{:?}", err),

--- a/src/client.rs
+++ b/src/client.rs
@@ -621,9 +621,9 @@ impl Spotify {
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
             opt fields,
+            opt market => market.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
-            opt market => market.as_ref(),
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -745,10 +745,10 @@ impl Spotify {
         track_ids: impl IntoIterator<Item = &'a TrackId>,
     ) -> ClientResult<()> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
-
         let params = build_json! {
-            req uris => uris
+            req uris
         };
+
         let url = format!("playlists/{}/tracks", playlist_id.id());
         self.endpoint_put(&url, &params).await?;
 
@@ -1063,8 +1063,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let params = build_map! {
             req r#type => Type::Artist.as_ref(),
-            opt after => &after,
-            opt limit => &limit,
+            opt after,
+            opt limit,
         };
 
         let result = self.endpoint_get("me/following", &params).await?;
@@ -1447,9 +1447,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
+            opt market => market.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
-            opt market => market.as_ref(),
         };
 
         let result = self.endpoint_get("browse/new-releases", &params).await?;
@@ -1809,7 +1809,7 @@ impl Spotify {
                 Offset::Position(position) => json!({ "position": position }),
                 Offset::Uri(uri) => json!({ "uri": uri.uri() }),
             },
-            opt position_ms => position_ms
+            opt position_ms,
 
         };
 
@@ -2120,9 +2120,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
+            opt market => market.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
-            opt market => market.as_ref(),
         };
 
         let url = format!("shows/{}/episodes", id.id());
@@ -2191,7 +2191,7 @@ impl Spotify {
     ) -> ClientResult<Vec<bool>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => ids.as_str(),
+            req ids => &ids,
         };
         let result = self.endpoint_get("me/shows/contains", &params).await?;
         self.convert_result(&result)

--- a/src/client.rs
+++ b/src/client.rs
@@ -721,7 +721,7 @@ impl Spotify {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = build_json! {
             "uris": uris,
-            "position": position,
+            optional "position": position,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,7 +194,7 @@ impl Spotify {
     ) -> ClientResult<Vec<FullTrack>> {
         let ids = join_ids(track_ids);
         let params = build_map! {
-            opt market => market.as_ref(),
+            optional market => market.as_ref(),
         };
 
         let url = format!("tracks/?ids={}", ids);
@@ -274,10 +274,10 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt album_type => album_type.as_ref(),
-            opt market => market.as_ref(),
-            opt limit,
-            opt offset,
+            optional album_type => album_type.as_ref(),
+            optional market => market.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let url = format!("artists/{}/albums", artist_id.id());
@@ -300,7 +300,7 @@ impl Spotify {
         market: Market,
     ) -> ClientResult<Vec<FullTrack>> {
         let params = build_map! {
-            req market => market.as_ref()
+            required market => market.as_ref()
         };
 
         let url = format!("artists/{}/top-tracks", artist_id.id());
@@ -386,12 +386,12 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            req q,
-            req r#type => r#type.as_ref(),
-            opt market => market.as_ref(),
-            opt include_external => include_external.as_ref(),
-            opt limit,
-            opt offset,
+            required q,
+            required r#type => r#type.as_ref(),
+            optional market => market.as_ref(),
+            optional include_external => include_external.as_ref(),
+            optional limit,
+            optional offset,
         };
         println!("params: {:#?}", params);
 
@@ -431,8 +431,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let url = format!("albums/{}/tracks", album_id.id());
@@ -468,8 +468,8 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<FullPlaylist> {
         let params = build_map! {
-            opt fields,
-            opt market => market.as_ref(),
+            optional fields,
+            optional market => market.as_ref(),
         };
 
         let url = format!("playlists/{}", playlist_id.id());
@@ -504,8 +504,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("me/playlists", &params).await?;
@@ -544,8 +544,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let url = format!("users/{}/playlists", user_id.id());
@@ -569,7 +569,7 @@ impl Spotify {
         fields: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
         let params = build_map! {
-            opt fields,
+            optional fields,
         };
 
         let url = match playlist_id {
@@ -620,10 +620,10 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt fields,
-            opt market => market.as_ref(),
-            opt limit,
-            opt offset,
+            optional fields,
+            optional market => market.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -651,10 +651,10 @@ impl Spotify {
         description: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
         let params = build_json! {
-            req name,
-            opt public,
-            opt collaborative,
-            opt description,
+            required name,
+            optional public,
+            optional collaborative,
+            optional description,
         };
 
         let url = format!("users/{}/playlists", user_id.id());
@@ -682,10 +682,10 @@ impl Spotify {
         collaborative: Option<bool>,
     ) -> ClientResult<String> {
         let params = build_json! {
-            opt name,
-            opt public,
-            opt collaborative,
-            opt description,
+            optional name,
+            optional public,
+            optional collaborative,
+            optional description,
         };
 
         let url = format!("playlists/{}", playlist_id);
@@ -721,8 +721,8 @@ impl Spotify {
     ) -> ClientResult<PlaylistResult> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = build_json! {
-            req uris,
-            req position,
+            required uris,
+            required position,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -746,7 +746,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = build_json! {
-            req uris
+            required uris
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -779,12 +779,12 @@ impl Spotify {
     ) -> ClientResult<PlaylistResult> {
         let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
         let params = build_json! {
-            req playlist_id,
-            opt uris,
-            opt range_start,
-            opt insert_before,
-            opt range_length,
-            opt snapshot_id,
+            required playlist_id,
+            optional uris,
+            optional range_start,
+            optional insert_before,
+            optional range_length,
+            optional snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -817,8 +817,8 @@ impl Spotify {
             .collect::<Vec<_>>();
 
         let params = build_json! {
-            req tracks,
-            opt snapshot_id,
+            required tracks,
+            optional snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -873,8 +873,8 @@ impl Spotify {
             .collect::<Vec<_>>();
 
         let params = build_json! {
-            req tracks,
-            opt snapshot_id,
+            required tracks,
+            optional snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -897,7 +897,7 @@ impl Spotify {
         let url = format!("playlists/{}/followers", playlist_id.id());
 
         let params = build_json! {
-            opt public,
+            optional public,
         };
 
         self.endpoint_put(&url, &params).await?;
@@ -1001,8 +1001,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("me/albums", &params).await?;
@@ -1039,8 +1039,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("me/tracks", &params).await?;
@@ -1062,9 +1062,9 @@ impl Spotify {
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let params = build_map! {
-            req r#type => Type::Artist.as_ref(),
-            opt after,
-            opt limit,
+            required r#type => Type::Artist.as_ref(),
+            optional after,
+            optional limit,
         };
 
         let result = self.endpoint_get("me/following", &params).await?;
@@ -1157,9 +1157,9 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt time_range => time_range.as_ref(),
-            opt limit,
-            opt offset,
+            optional time_range => time_range.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get(&"me/top/artists", &params).await?;
@@ -1200,9 +1200,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt time_range => time_range.as_ref(),
-            opt limit,
-            opt offset,
+            optional time_range => time_range.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("me/top/tracks", &params).await?;
@@ -1222,7 +1222,7 @@ impl Spotify {
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
         let params = build_map! {
-            opt limit,
+            optional limit,
         };
 
         let result = self
@@ -1400,11 +1400,11 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let timestamp = timestamp.map(|x| x.to_rfc3339());
         let params = build_map! {
-            opt locale,
-            opt country => country.as_ref(),
-            opt timestamp,
-            opt limit,
-            opt offset,
+            optional locale,
+            optional country => country.as_ref(),
+            optional timestamp,
+            optional limit,
+            optional offset,
         };
 
         let result = self
@@ -1447,9 +1447,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt country => country.as_ref(),
-            opt limit,
-            opt offset,
+            optional country => country.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("browse/new-releases", &params).await?;
@@ -1495,10 +1495,10 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt locale,
-            opt country => country.as_ref(),
-            opt limit,
-            opt offset,
+            optional locale,
+            optional country => country.as_ref(),
+            optional limit,
+            optional offset,
         };
         let result = self.endpoint_get("browse/categories", &params).await?;
         self.convert_result::<PageCategory>(&result)
@@ -1544,9 +1544,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt country => country.as_ref(),
-            opt limit,
-            opt offset,
+            optional country => country.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let url = format!("browse/categories/{}/playlists", category_id);
@@ -1585,11 +1585,11 @@ impl Spotify {
         let seed_tracks = seed_tracks.map(join_ids);
         let limit = limit.map(|x| x.to_string());
         let mut params = build_map! {
-            opt seed_artists,
-            opt seed_genres,
-            opt seed_tracks,
-            opt market => market.as_ref(),
-            opt limit,
+            optional seed_artists,
+            optional seed_genres,
+            optional seed_tracks,
+            optional market => market.as_ref(),
+            optional limit,
         };
 
         // TODO: this probably can be improved.
@@ -1708,8 +1708,8 @@ impl Spotify {
         let additional_types =
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = build_map! {
-            opt country => country.as_ref(),
-            opt additional_types,
+            optional country => country.as_ref(),
+            optional additional_types,
         };
 
         let result = self.endpoint_get("me/player", &params).await?;
@@ -1738,8 +1738,8 @@ impl Spotify {
         let additional_types =
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = build_map! {
-            opt market => market.as_ref(),
-            opt additional_types,
+            optional market => market.as_ref(),
+            optional additional_types,
         };
 
         let result = self
@@ -1770,8 +1770,8 @@ impl Spotify {
         force_play: Option<bool>,
     ) -> ClientResult<()> {
         let params = build_json! {
-            req device_ids => [device_id],
-            opt force_play,
+            required device_ids => [device_id],
+            optional force_play,
         };
 
         self.endpoint_put("me/player", &params).await?;
@@ -1804,12 +1804,12 @@ impl Spotify {
         use super::model::Offset;
 
         let params = build_json! {
-            req context_uri => context_uri.uri(),
-            opt offset => match offset {
+            required context_uri => context_uri.uri(),
+            optional offset => match offset {
                 Offset::Position(position) => json!({ "position": position }),
                 Offset::Uri(uri) => json!({ "uri": uri.uri() }),
             },
-            opt position_ms,
+            optional position_ms,
 
         };
 
@@ -1830,9 +1830,9 @@ impl Spotify {
         use super::model::Offset;
 
         let params = build_json! {
-            req uris => uris.iter().map(|id| id.uri()).collect::<Vec<_>>(),
-            opt position_ms,
-            opt offset => match offset {
+            required uris => uris.iter().map(|id| id.uri()).collect::<Vec<_>>(),
+            optional position_ms,
+            optional offset => match offset {
                 Offset::Position(position) => json!({ "position": position }),
                 Offset::Uri(uri) => json!({ "uri": uri.uri() }),
             },
@@ -2027,8 +2027,8 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt limit,
-            opt offset,
+            optional limit,
+            optional offset,
         };
 
         let result = self.endpoint_get("me/shows", &params).await?;
@@ -2047,7 +2047,7 @@ impl Spotify {
     #[maybe_async]
     pub async fn get_a_show(&self, id: &ShowId, market: Option<Market>) -> ClientResult<FullShow> {
         let params = build_map! {
-            opt market => market.as_ref(),
+            optional market => market.as_ref(),
         };
 
         let url = format!("shows/{}", id.id());
@@ -2071,8 +2071,8 @@ impl Spotify {
     ) -> ClientResult<Vec<SimplifiedShow>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => &ids,
-            opt market => market.as_ref(),
+            required ids => &ids,
+            optional market => market.as_ref(),
         };
 
         let result = self.endpoint_get("shows", &params).await?;
@@ -2120,9 +2120,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt market => market.as_ref(),
-            opt limit,
-            opt offset,
+            optional market => market.as_ref(),
+            optional limit,
+            optional offset,
         };
 
         let url = format!("shows/{}/episodes", id.id());
@@ -2147,7 +2147,7 @@ impl Spotify {
     ) -> ClientResult<FullEpisode> {
         let url = format!("episodes/{}", id.id());
         let params = build_map! {
-            opt market => market.as_ref(),
+            optional market => market.as_ref(),
         };
 
         let result = self.endpoint_get(&url, &params).await?;
@@ -2169,8 +2169,8 @@ impl Spotify {
     ) -> ClientResult<Vec<FullEpisode>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => &ids,
-            opt market => market.as_ref(),
+            required ids => &ids,
+            optional market => market.as_ref(),
         };
 
         let result = self.endpoint_get("episodes", &params).await?;
@@ -2191,7 +2191,7 @@ impl Spotify {
     ) -> ClientResult<Vec<bool>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => &ids,
+            required ids => &ids,
         };
         let result = self.endpoint_get("me/shows/contains", &params).await?;
         self.convert_result(&result)
@@ -2213,7 +2213,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         let url = format!("me/shows?ids={}", join_ids(show_ids));
         let params = build_json! {
-            opt country => country.as_ref()
+            optional country => country.as_ref()
         };
         self.endpoint_delete(&url, &params).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1698,13 +1698,17 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
     #[maybe_async]
-    pub async fn current_playback<'a>(
+    pub async fn current_playback<'a, A: IntoIterator<Item = &'a AdditionalType>>(
         &self,
         country: Option<&Market>,
-        additional_types: Option<impl IntoIterator<Item = &'a AdditionalType>>,
+        additional_types: Option<A>,
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
-        let additional_types =
-            additional_types.map(|x| x.into_iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
+        let additional_types = additional_types.map(|x| {
+            x.into_iter()
+                .map(|x| x.as_ref())
+                .collect::<Vec<_>>()
+                .join(",")
+        });
         let params = build_map! {
             optional "country": country.map(|x| x.as_ref()),
             optional "additional_types": additional_types.as_ref(),
@@ -1761,11 +1765,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-transfer-a-users-playback)
     #[maybe_async]
-    pub async fn transfer_playback(
-        &self,
-        device_id: &str,
-        play: Option<bool>,
-    ) -> ClientResult<()> {
+    pub async fn transfer_playback(&self, device_id: &str, play: Option<bool>) -> ClientResult<()> {
         let params = build_json! {
             "device_ids": [device_id],
             optional "play": play,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1399,11 +1399,11 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let timestamp = timestamp.map(|x| x.to_rfc3339());
         let params = map_query! {
-            opt limit => &limit,
-            opt offset => &offset,
             opt locale,
             opt market => market.as_ref(),
             opt timestamp,
+            opt limit => &limit,
+            opt offset => &offset,
         };
 
         let result = self
@@ -1494,10 +1494,10 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = map_query! {
-            opt limit => &limit,
-            opt offset => &offset,
             opt locale,
             opt market => market.as_ref(),
+            opt limit => &limit,
+            opt offset => &offset,
         };
         let result = self.endpoint_get("browse/categories", &params).await?;
         self.convert_result::<PageCategory>(&result)
@@ -1543,9 +1543,9 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = map_query! {
+            opt market => market.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
-            opt market => market.as_ref(),
         };
 
         let url = format!("browse/categories/{}/playlists", category_id);

--- a/src/client.rs
+++ b/src/client.rs
@@ -778,7 +778,6 @@ impl Spotify {
     ) -> ClientResult<PlaylistResult> {
         let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
         let params = build_json! {
-            "playlist_id": playlist_id,
             optional "uris": uris,
             optional "range_start": range_start,
             optional "insert_before": insert_before,
@@ -1061,7 +1060,7 @@ impl Spotify {
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let params = build_map! {
-            "r#type": Type::Artist.as_ref(),
+            "type": Type::Artist.as_ref(),
             optional "after": after,
             optional "limit": limit.as_deref(),
         };
@@ -1576,8 +1575,8 @@ impl Spotify {
         seed_artists: Option<Vec<&ArtistId>>,
         seed_genres: Option<Vec<&str>>,
         seed_tracks: Option<Vec<&TrackId>>,
-        limit: Option<u32>,
         market: Option<&Market>,
+        limit: Option<u32>,
     ) -> ClientResult<Recommendations> {
         let seed_artists = seed_artists.map(join_ids);
         let seed_genres = seed_genres.map(|x| x.join(","));
@@ -1758,19 +1757,18 @@ impl Spotify {
     ///
     /// Parameters:
     /// - device_id - transfer playback to this device
-    /// - force_play - true: after transfer, play. false:
-    ///   keep current state.
+    /// - force_play - true: after transfer, play. false: keep current state.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-transfer-a-users-playback)
     #[maybe_async]
     pub async fn transfer_playback(
         &self,
         device_id: &str,
-        force_play: Option<bool>,
+        play: Option<bool>,
     ) -> ClientResult<()> {
         let params = build_json! {
             "device_ids": [device_id],
-            optional "force_play": force_play,
+            optional "play": play,
         };
 
         self.endpoint_put("me/player", &params).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,9 +187,9 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
     #[maybe_async]
-    pub async fn tracks(
+    pub async fn tracks<'a>(
         &self,
-        track_ids: impl IntoIterator<Item = &TrackId>,
+        track_ids: impl IntoIterator<Item = &'a TrackId>,
         market: Option<&Market>,
     ) -> ClientResult<Vec<FullTrack>> {
         let ids = join_ids(track_ids);
@@ -222,9 +222,9 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
     #[maybe_async]
-    pub async fn artists(
+    pub async fn artists<'a>(
         &self,
-        artist_ids: impl IntoIterator<Item = &ArtistId>,
+        artist_ids: impl IntoIterator<Item = &'a ArtistId>,
     ) -> ClientResult<Vec<FullArtist>> {
         let ids = join_ids(artist_ids);
         let url = format!("artists/?ids={}", ids);
@@ -348,9 +348,9 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
     #[maybe_async]
-    pub async fn albums(
+    pub async fn albums<'a>(
         &self,
-        album_ids: impl IntoIterator<Item = &AlbumId>,
+        album_ids: impl IntoIterator<Item = &'a AlbumId>,
     ) -> ClientResult<Vec<FullAlbum>> {
         let ids = join_ids(album_ids);
         let url = format!("albums/?ids={}", ids);
@@ -712,10 +712,10 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist)
     #[maybe_async]
-    pub async fn playlist_add_tracks(
+    pub async fn playlist_add_tracks<'a>(
         &self,
         playlist_id: &PlaylistId,
-        track_ids: impl IntoIterator<Item = &TrackId>,
+        track_ids: impl IntoIterator<Item = &'a TrackId>,
         position: Option<i32>,
     ) -> ClientResult<PlaylistResult> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
@@ -738,10 +738,10 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-reorder-or-replace-playlists-tracks)
     #[maybe_async]
-    pub async fn playlist_replace_tracks(
+    pub async fn playlist_replace_tracks<'a>(
         &self,
         playlist_id: &PlaylistId,
-        track_ids: impl IntoIterator<Item = &TrackId>,
+        track_ids: impl IntoIterator<Item = &'a TrackId>,
     ) -> ClientResult<()> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = build_json! {
@@ -800,10 +800,10 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-tracks-playlist)
     #[maybe_async]
-    pub async fn playlist_remove_all_occurrences_of_tracks(
+    pub async fn playlist_remove_all_occurrences_of_tracks<'a>(
         &self,
         playlist_id: &PlaylistId,
-        track_ids: impl IntoIterator<Item = &TrackId>,
+        track_ids: impl IntoIterator<Item = &'a TrackId>,
         snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
         let tracks = track_ids
@@ -1078,9 +1078,9 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-tracks-user)
     #[maybe_async]
-    pub async fn current_user_saved_tracks_delete(
+    pub async fn current_user_saved_tracks_delete<'a>(
         &self,
-        track_ids: impl IntoIterator<Item = &TrackId>,
+        track_ids: impl IntoIterator<Item = &'a TrackId>,
     ) -> ClientResult<()> {
         let url = format!("me/tracks/?ids={}", join_ids(track_ids));
         self.endpoint_delete(&url, &json!({})).await?;
@@ -2205,9 +2205,9 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-remove-shows-user)
     #[maybe_async]
-    pub async fn remove_users_saved_shows(
+    pub async fn remove_users_saved_shows<'a>(
         &self,
-        show_ids: impl IntoIterator<Item = &ShowId>,
+        show_ids: impl IntoIterator<Item = &'a ShowId>,
         country: Option<&Market>,
     ) -> ClientResult<()> {
         let url = format!("me/shows?ids={}", join_ids(show_ids));

--- a/src/client.rs
+++ b/src/client.rs
@@ -1391,7 +1391,7 @@ impl Spotify {
     pub async fn featured_playlists(
         &self,
         locale: Option<&str>,
-        market: Option<Market>,
+        country: Option<Market>,
         timestamp: Option<DateTime<Utc>>,
         limit: Option<u32>,
         offset: Option<u32>,
@@ -1401,7 +1401,7 @@ impl Spotify {
         let timestamp = timestamp.map(|x| x.to_rfc3339());
         let params = build_map! {
             opt locale,
-            opt market => market.as_ref(),
+            opt country => country.as_ref(),
             opt timestamp,
             opt limit,
             opt offset,
@@ -1428,10 +1428,10 @@ impl Spotify {
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-new-releases)
     pub fn new_releases<'a>(
         &'a self,
-        market: Option<&'a Market>,
+        country: Option<&'a Market>,
     ) -> impl Paginator<ClientResult<SimplifiedAlbum>> + 'a {
         paginate(
-            move |limit, offset| self.new_releases_manual(market, Some(limit), Some(offset)),
+            move |limit, offset| self.new_releases_manual(country, Some(limit), Some(offset)),
             self.pagination_chunks,
         )
     }
@@ -1440,14 +1440,14 @@ impl Spotify {
     #[maybe_async]
     pub async fn new_releases_manual(
         &self,
-        market: Option<&Market>,
+        country: Option<&Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt market => market.as_ref(),
+            opt country => country.as_ref(),
             opt limit,
             opt offset,
         };
@@ -1475,10 +1475,10 @@ impl Spotify {
     pub fn categories<'a>(
         &'a self,
         locale: Option<&'a str>,
-        market: Option<&'a Market>,
+        country: Option<&'a Market>,
     ) -> impl Paginator<ClientResult<Category>> + 'a {
         paginate(
-            move |limit, offset| self.categories_manual(locale, market, Some(limit), Some(offset)),
+            move |limit, offset| self.categories_manual(locale, country, Some(limit), Some(offset)),
             self.pagination_chunks,
         )
     }
@@ -1488,7 +1488,7 @@ impl Spotify {
     pub async fn categories_manual(
         &self,
         locale: Option<&str>,
-        market: Option<&Market>,
+        country: Option<&Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<Category>> {
@@ -1496,7 +1496,7 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt locale,
-            opt market => market.as_ref(),
+            opt country => country.as_ref(),
             opt limit,
             opt offset,
         };
@@ -1522,11 +1522,11 @@ impl Spotify {
     pub fn category_playlists<'a>(
         &'a self,
         category_id: &'a str,
-        market: Option<&'a Market>,
+        country: Option<&'a Market>,
     ) -> impl Paginator<ClientResult<SimplifiedPlaylist>> + 'a {
         paginate(
             move |limit, offset| {
-                self.category_playlists_manual(category_id, market, Some(limit), Some(offset))
+                self.category_playlists_manual(category_id, country, Some(limit), Some(offset))
             },
             self.pagination_chunks,
         )
@@ -1537,14 +1537,14 @@ impl Spotify {
     pub async fn category_playlists_manual(
         &self,
         category_id: &str,
-        market: Option<&Market>,
+        country: Option<&Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt market => market.as_ref(),
+            opt country => country.as_ref(),
             opt limit,
             opt offset,
         };
@@ -1702,13 +1702,13 @@ impl Spotify {
     #[maybe_async]
     pub async fn current_playback(
         &self,
-        market: Option<Market>,
+        country: Option<Market>,
         additional_types: Option<Vec<AdditionalType>>,
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let additional_types =
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = build_map! {
-            opt market => market.as_ref(),
+            opt country => country.as_ref(),
             opt additional_types,
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,7 +154,7 @@ impl Spotify {
     }
 
     /// Append device ID to an API path.
-    fn append_device_id(&self, path: &str, device_id: Option<String>) -> String {
+    fn append_device_id(&self, path: &str, device_id: Option<&str>) -> String {
         let mut new_path = path.to_string();
         if let Some(_device_id) = device_id {
             if path.contains('?') {
@@ -677,7 +677,7 @@ impl Spotify {
         playlist_id: &str,
         name: Option<&str>,
         public: Option<bool>,
-        description: Option<String>,
+        description: Option<&str>,
         collaborative: Option<bool>,
     ) -> ClientResult<String> {
         let params = map_json! {
@@ -774,7 +774,7 @@ impl Spotify {
         range_start: Option<i32>,
         insert_before: Option<i32>,
         range_length: Option<u32>,
-        snapshot_id: Option<String>,
+        snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
         let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
         let params = map_json! {
@@ -804,7 +804,7 @@ impl Spotify {
         &self,
         playlist_id: &PlaylistId,
         track_ids: impl IntoIterator<Item = &'a TrackId>,
-        snapshot_id: Option<String>,
+        snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
         let tracks = track_ids
             .into_iter()
@@ -859,7 +859,7 @@ impl Spotify {
         &self,
         playlist_id: &PlaylistId,
         tracks: Vec<TrackPositions<'_>>,
-        snapshot_id: Option<String>,
+        snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
         let tracks = tracks
             .into_iter()
@@ -1056,7 +1056,7 @@ impl Spotify {
     #[maybe_async]
     pub async fn current_user_followed_artists(
         &self,
-        after: Option<String>,
+        after: Option<&str>,
         limit: Option<u32>,
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
@@ -1389,7 +1389,7 @@ impl Spotify {
     #[maybe_async]
     pub async fn featured_playlists(
         &self,
-        locale: Option<String>,
+        locale: Option<&str>,
         market: Option<Market>,
         timestamp: Option<DateTime<Utc>>,
         limit: Option<u32>,
@@ -1572,12 +1572,12 @@ impl Spotify {
     #[maybe_async]
     pub async fn recommendations(
         &self,
+        payload: &Map<String, Value>,
         seed_artists: Option<Vec<&ArtistId>>,
         seed_genres: Option<Vec<String>>,
         seed_tracks: Option<Vec<&TrackId>>,
         limit: Option<u32>,
         market: Option<Market>,
-        payload: &Map<String, Value>,
     ) -> ClientResult<Recommendations> {
         let seed_artists = seed_artists.map(join_ids);
         let seed_genres = seed_genres.map(|x| x.join(","));
@@ -1796,7 +1796,7 @@ impl Spotify {
     pub async fn start_context_playback(
         &self,
         context_uri: &Id<impl PlayContextIdType>,
-        device_id: Option<String>,
+        device_id: Option<&str>,
         offset: Option<super::model::Offset<impl PlayableIdType>>,
         position_ms: Option<std::time::Duration>,
     ) -> ClientResult<()> {
@@ -1822,7 +1822,7 @@ impl Spotify {
     pub async fn start_uris_playback<T: PlayableIdType>(
         &self,
         uris: &[&Id<T>],
-        device_id: Option<String>,
+        device_id: Option<&str>,
         offset: Option<super::model::Offset<T>>,
         position_ms: Option<u32>,
     ) -> ClientResult<()> {
@@ -1850,7 +1850,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-pause-a-users-playback)
     #[maybe_async]
-    pub async fn pause_playback(&self, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn pause_playback(&self, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/pause", device_id);
         self.endpoint_put(&url, &json!({})).await?;
 
@@ -1864,7 +1864,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-skip-users-playback-to-next-track)
     #[maybe_async]
-    pub async fn next_track(&self, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn next_track(&self, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/next", device_id);
         self.endpoint_post(&url, &json!({})).await?;
 
@@ -1878,7 +1878,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-skip-users-playback-to-previous-track)
     #[maybe_async]
-    pub async fn previous_track(&self, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn previous_track(&self, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id("me/player/previous", device_id);
         self.endpoint_post(&url, &json!({})).await?;
 
@@ -1893,11 +1893,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-seek-to-position-in-currently-playing-track)
     #[maybe_async]
-    pub async fn seek_track(
-        &self,
-        position_ms: u32,
-        device_id: Option<String>,
-    ) -> ClientResult<()> {
+    pub async fn seek_track(&self, position_ms: u32, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id(
             &format!("me/player/seek?position_ms={}", position_ms),
             device_id,
@@ -1915,7 +1911,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-set-repeat-mode-on-users-playback)
     #[maybe_async]
-    pub async fn repeat(&self, state: RepeatState, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn repeat(&self, state: RepeatState, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id(
             &format!("me/player/repeat?state={}", state.as_ref()),
             device_id,
@@ -1933,7 +1929,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-set-volume-for-users-playback)
     #[maybe_async]
-    pub async fn volume(&self, volume_percent: u8, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn volume(&self, volume_percent: u8, device_id: Option<&str>) -> ClientResult<()> {
         if volume_percent > 100u8 {
             error!("volume must be between 0 and 100, inclusive");
         }
@@ -1954,7 +1950,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-toggle-shuffle-for-users-playback)
     #[maybe_async]
-    pub async fn shuffle(&self, state: bool, device_id: Option<String>) -> ClientResult<()> {
+    pub async fn shuffle(&self, state: bool, device_id: Option<&str>) -> ClientResult<()> {
         let url = self.append_device_id(&format!("me/player/shuffle?state={}", state), device_id);
         self.endpoint_put(&url, &json!({})).await?;
 
@@ -1974,7 +1970,7 @@ impl Spotify {
     pub async fn add_item_to_queue(
         &self,
         item: &Id<impl PlayableIdType>,
-        device_id: Option<String>,
+        device_id: Option<&str>,
     ) -> ClientResult<()> {
         let url = self.append_device_id(&format!("me/player/queue?uri={}", item), device_id);
         self.endpoint_post(&url, &json!({})).await?;
@@ -2244,7 +2240,7 @@ mod test {
     #[test]
     fn test_append_device_id_without_question_mark() {
         let path = "me/player/play";
-        let device_id = Some("fdafdsadfa".to_owned());
+        let device_id = Some("fdafdsadfa");
         let spotify = SpotifyBuilder::default().build().unwrap();
         let new_path = spotify.append_device_id(path, device_id);
         assert_eq!(new_path, "me/player/play?device_id=fdafdsadfa");
@@ -2253,7 +2249,7 @@ mod test {
     #[test]
     fn test_append_device_id_with_question_mark() {
         let path = "me/player/shuffle?state=true";
-        let device_id = Some("fdafdsadfa".to_owned());
+        let device_id = Some("fdafdsadfa");
         let spotify = SpotifyBuilder::default().build().unwrap();
         let new_path = spotify.append_device_id(path, device_id);
         assert_eq!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1770,7 +1770,7 @@ impl Spotify {
         force_play: Option<bool>,
     ) -> ClientResult<()> {
         let params = build_json! {
-            req device_ids => vec![device_id.to_owned()],
+            req device_ids => [device_id],
             opt force_play,
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use super::http::{HTTPClient, Query};
 use super::model::*;
 use super::oauth2::{Credentials, OAuth, Token};
 use super::pagination::{paginate, Paginator};
-use super::{map_json, map_query};
+use super::{build_json, build_map};
 use crate::model::idtypes::{IdType, PlayContextIdType};
 use std::collections::HashMap;
 
@@ -193,7 +193,7 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<Vec<FullTrack>> {
         let ids = join_ids(track_ids);
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
         };
 
@@ -273,7 +273,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt album_type => album_type.as_ref(),
             opt market => &market.as_ref(),
             opt limit => &limit,
@@ -299,7 +299,7 @@ impl Spotify {
         artist_id: &ArtistId,
         market: Market,
     ) -> ClientResult<Vec<FullTrack>> {
-        let params = map_query! {
+        let params = build_map! {
             req market => market.as_ref()
         };
 
@@ -385,7 +385,7 @@ impl Spotify {
     ) -> ClientResult<SearchResult> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             req q,
             req r#type => r#type.as_ref(),
             opt market => market.as_ref(),
@@ -430,7 +430,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -467,7 +467,7 @@ impl Spotify {
         fields: Option<&str>,
         market: Option<Market>,
     ) -> ClientResult<FullPlaylist> {
-        let params = map_query! {
+        let params = build_map! {
             opt fields,
             opt market => market.as_ref(),
         };
@@ -503,7 +503,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -543,7 +543,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -568,7 +568,7 @@ impl Spotify {
         playlist_id: Option<&PlaylistId>,
         fields: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
-        let params = map_query! {
+        let params = build_map! {
             opt fields,
         };
 
@@ -619,7 +619,7 @@ impl Spotify {
     ) -> ClientResult<Page<PlaylistItem>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt fields,
             opt limit => &limit,
             opt offset => &offset,
@@ -650,7 +650,7 @@ impl Spotify {
         collaborative: Option<bool>,
         description: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
-        let params = map_json! {
+        let params = build_json! {
             req name,
             opt public,
             opt collaborative,
@@ -681,7 +681,7 @@ impl Spotify {
         description: Option<&str>,
         collaborative: Option<bool>,
     ) -> ClientResult<String> {
-        let params = map_json! {
+        let params = build_json! {
             opt name,
             opt public,
             opt collaborative,
@@ -720,7 +720,7 @@ impl Spotify {
         position: Option<i32>,
     ) -> ClientResult<PlaylistResult> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
-        let params = map_json! {
+        let params = build_json! {
             req uris,
             req position,
         };
@@ -746,7 +746,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
 
-        let params = map_json! {
+        let params = build_json! {
             req uris => uris
         };
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -778,7 +778,7 @@ impl Spotify {
         snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
         let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
-        let params = map_json! {
+        let params = build_json! {
             req playlist_id,
             opt uris,
             opt range_start,
@@ -816,7 +816,7 @@ impl Spotify {
             })
             .collect::<Vec<_>>();
 
-        let params = map_json! {
+        let params = build_json! {
             req tracks,
             opt snapshot_id,
         };
@@ -872,7 +872,7 @@ impl Spotify {
             })
             .collect::<Vec<_>>();
 
-        let params = map_json! {
+        let params = build_json! {
             req tracks,
             opt snapshot_id,
         };
@@ -896,7 +896,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         let url = format!("playlists/{}/followers", playlist_id.id());
 
-        let params = map_json! {
+        let params = build_json! {
             opt public,
         };
 
@@ -1000,7 +1000,7 @@ impl Spotify {
     ) -> ClientResult<Page<SavedAlbum>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -1038,7 +1038,7 @@ impl Spotify {
     ) -> ClientResult<Page<SavedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -1061,7 +1061,7 @@ impl Spotify {
         limit: Option<u32>,
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             req r#type => Type::Artist.as_ref(),
             opt after => &after,
             opt limit => &limit,
@@ -1156,7 +1156,7 @@ impl Spotify {
     ) -> ClientResult<Page<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt time_range => time_range.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
@@ -1199,7 +1199,7 @@ impl Spotify {
     ) -> ClientResult<Page<FullTrack>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt time_range => time_range.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
@@ -1221,7 +1221,7 @@ impl Spotify {
         limit: Option<u32>,
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
         };
 
@@ -1399,7 +1399,7 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let timestamp = timestamp.map(|x| x.to_rfc3339());
-        let params = map_query! {
+        let params = build_map! {
             opt locale,
             opt market => market.as_ref(),
             opt timestamp,
@@ -1446,7 +1446,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
             opt market => market.as_ref(),
@@ -1494,7 +1494,7 @@ impl Spotify {
     ) -> ClientResult<Page<Category>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt locale,
             opt market => market.as_ref(),
             opt limit => &limit,
@@ -1543,7 +1543,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
             opt limit => &limit,
             opt offset => &offset,
@@ -1584,7 +1584,7 @@ impl Spotify {
         let seed_genres = seed_genres.map(|x| x.join(","));
         let seed_tracks = seed_tracks.map(join_ids);
         let limit = limit.map(|x| x.to_string());
-        let mut params = map_query! {
+        let mut params = build_map! {
             opt seed_artists,
             opt seed_genres,
             opt seed_tracks,
@@ -1707,7 +1707,7 @@ impl Spotify {
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let additional_types =
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
             opt additional_types,
         };
@@ -1737,7 +1737,7 @@ impl Spotify {
     ) -> ClientResult<Option<CurrentlyPlayingContext>> {
         let additional_types =
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
             opt additional_types,
         };
@@ -1769,7 +1769,7 @@ impl Spotify {
         device_id: &str,
         force_play: Option<bool>,
     ) -> ClientResult<()> {
-        let params = map_json! {
+        let params = build_json! {
             req device_ids => vec![device_id.to_owned()],
             opt force_play,
         };
@@ -1803,7 +1803,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         use super::model::Offset;
 
-        let params = map_json! {
+        let params = build_json! {
             req context_uri => context_uri.uri(),
             opt offset => match offset {
                 Offset::Position(position) => json!({ "position": position }),
@@ -1829,7 +1829,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         use super::model::Offset;
 
-        let params = map_json! {
+        let params = build_json! {
             req uris => uris.iter().map(|id| id.uri()).collect::<Vec<_>>(),
             opt position_ms,
             opt offset => match offset {
@@ -2026,7 +2026,7 @@ impl Spotify {
     ) -> ClientResult<Page<Show>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
         };
@@ -2046,7 +2046,7 @@ impl Spotify {
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-show)
     #[maybe_async]
     pub async fn get_a_show(&self, id: &ShowId, market: Option<Market>) -> ClientResult<FullShow> {
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
         };
 
@@ -2070,7 +2070,7 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<Vec<SimplifiedShow>> {
         let ids = join_ids(ids);
-        let params = map_query! {
+        let params = build_map! {
             req ids => ids.as_ref(),
             opt market => market.as_ref(),
         };
@@ -2119,7 +2119,7 @@ impl Spotify {
     ) -> ClientResult<Page<SimplifiedEpisode>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = map_query! {
+        let params = build_map! {
             opt limit => &limit,
             opt offset => &offset,
             opt market => market.as_ref(),
@@ -2146,7 +2146,7 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<FullEpisode> {
         let url = format!("episodes/{}", id.id());
-        let params = map_query! {
+        let params = build_map! {
             opt market => market.as_ref(),
         };
 
@@ -2168,7 +2168,7 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<Vec<FullEpisode>> {
         let ids = join_ids(ids);
-        let params = map_query! {
+        let params = build_map! {
             req ids => ids.as_ref(),
             opt market => market.as_ref(),
         };
@@ -2190,7 +2190,7 @@ impl Spotify {
         ids: impl IntoIterator<Item = &'a ShowId>,
     ) -> ClientResult<Vec<bool>> {
         let ids = join_ids(ids);
-        let params = map_query! {
+        let params = build_map! {
             req ids => ids.as_str(),
         };
         let result = self.endpoint_get("me/shows/contains", &params).await?;
@@ -2212,7 +2212,7 @@ impl Spotify {
         country: Option<Market>,
     ) -> ClientResult<()> {
         let url = format!("me/shows?ids={}", join_ids(show_ids));
-        let params = map_json! {
+        let params = build_json! {
             opt country => country.as_ref()
         };
         self.endpoint_delete(&url, &params).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1711,7 +1711,7 @@ impl Spotify {
         });
         let params = build_map! {
             optional "country": country.map(|x| x.as_ref()),
-            optional "additional_types": additional_types.as_ref(),
+            optional "additional_types": additional_types.as_deref(),
         };
 
         let result = self.endpoint_get("me/player", &params).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -393,6 +393,7 @@ impl Spotify {
             opt limit => &limit,
             opt offset => &offset,
         };
+        println!("params: {:#?}", params);
 
         let result = self.endpoint_get("search", &params).await?;
         self.convert_result(&result)

--- a/src/client.rs
+++ b/src/client.rs
@@ -275,9 +275,9 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt album_type => album_type.as_ref(),
-            opt market => &market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt market => market.as_ref(),
+            opt limit,
+            opt offset,
         };
 
         let url = format!("artists/{}/albums", artist_id.id());
@@ -390,8 +390,8 @@ impl Spotify {
             req r#type => r#type.as_ref(),
             opt market => market.as_ref(),
             opt include_external => include_external.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
         println!("params: {:#?}", params);
 
@@ -431,8 +431,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let url = format!("albums/{}/tracks", album_id.id());
@@ -504,8 +504,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("me/playlists", &params).await?;
@@ -544,8 +544,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let url = format!("users/{}/playlists", user_id.id());
@@ -622,8 +622,8 @@ impl Spotify {
         let params = build_map! {
             opt fields,
             opt market => market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -1001,8 +1001,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("me/albums", &params).await?;
@@ -1039,8 +1039,8 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("me/tracks", &params).await?;
@@ -1158,8 +1158,8 @@ impl Spotify {
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
             opt time_range => time_range.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get(&"me/top/artists", &params).await?;
@@ -1201,8 +1201,8 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt time_range => time_range.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("me/top/tracks", &params).await?;
@@ -1222,7 +1222,7 @@ impl Spotify {
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
         let params = build_map! {
-            opt limit => &limit,
+            opt limit,
         };
 
         let result = self
@@ -1403,8 +1403,8 @@ impl Spotify {
             opt locale,
             opt market => market.as_ref(),
             opt timestamp,
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self
@@ -1448,8 +1448,8 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt market => market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("browse/new-releases", &params).await?;
@@ -1497,8 +1497,8 @@ impl Spotify {
         let params = build_map! {
             opt locale,
             opt market => market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
         let result = self.endpoint_get("browse/categories", &params).await?;
         self.convert_result::<PageCategory>(&result)
@@ -1545,8 +1545,8 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt market => market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let url = format!("browse/categories/{}/playlists", category_id);
@@ -1589,7 +1589,7 @@ impl Spotify {
             opt seed_genres,
             opt seed_tracks,
             opt market => market.as_ref(),
-            opt limit => &limit,
+            opt limit,
         };
 
         // TODO: this probably can be improved.
@@ -2027,8 +2027,8 @@ impl Spotify {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let result = self.endpoint_get("me/shows", &params).await?;
@@ -2071,7 +2071,7 @@ impl Spotify {
     ) -> ClientResult<Vec<SimplifiedShow>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => ids.as_ref(),
+            req ids => &ids,
             opt market => market.as_ref(),
         };
 
@@ -2121,8 +2121,8 @@ impl Spotify {
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             opt market => market.as_ref(),
-            opt limit => &limit,
-            opt offset => &offset,
+            opt limit,
+            opt offset,
         };
 
         let url = format!("shows/{}/episodes", id.id());
@@ -2169,7 +2169,7 @@ impl Spotify {
     ) -> ClientResult<Vec<FullEpisode>> {
         let ids = join_ids(ids);
         let params = build_map! {
-            req ids => ids.as_ref(),
+            req ids => &ids,
             opt market => market.as_ref(),
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -386,7 +386,7 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = map_query! {
-            req q => q,
+            req q,
             req r#type => r#type.as_ref(),
             opt market => market.as_ref(),
             opt include_external => include_external.as_ref(),
@@ -467,7 +467,7 @@ impl Spotify {
         market: Option<Market>,
     ) -> ClientResult<FullPlaylist> {
         let params = map_query! {
-            opt fields => fields,
+            opt fields,
             opt market => market.as_ref(),
         };
 
@@ -568,7 +568,7 @@ impl Spotify {
         fields: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
         let params = map_query! {
-            opt fields => fields,
+            opt fields,
         };
 
         let url = match playlist_id {
@@ -619,10 +619,10 @@ impl Spotify {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = map_query! {
+            opt fields,
             opt limit => &limit,
             opt offset => &offset,
             opt market => market.as_ref(),
-            opt fields => fields,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -641,7 +641,7 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-create-playlist)
     #[maybe_async]
-    pub async fn user_playlist_creat(
+    pub async fn user_playlist_create(
         &self,
         user_id: &UserId,
         name: &str,
@@ -650,10 +650,10 @@ impl Spotify {
         description: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
         let params = map_json! {
-            req name => name,
-            opt public => public,
-            opt collaborative => collaborative,
-            opt description => description,
+            req name,
+            opt public,
+            opt collaborative,
+            opt description,
         };
 
         let url = format!("users/{}/playlists", user_id.id());
@@ -681,10 +681,10 @@ impl Spotify {
         collaborative: Option<bool>,
     ) -> ClientResult<String> {
         let params = map_json! {
-            opt name => name,
-            opt public => public,
-            opt collaborative => collaborative,
-            opt description => description,
+            opt name,
+            opt public,
+            opt collaborative,
+            opt description,
         };
 
         let url = format!("playlists/{}", playlist_id);
@@ -720,8 +720,8 @@ impl Spotify {
     ) -> ClientResult<PlaylistResult> {
         let uris = track_ids.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = map_json! {
-            req uris => uris,
-            req position => position,
+            req uris,
+            req position,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -778,12 +778,12 @@ impl Spotify {
     ) -> ClientResult<PlaylistResult> {
         let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
         let params = map_json! {
-            req playlist_id => playlist_id,
-            opt uris => uris,
-            opt range_start => range_start,
-            opt insert_before => insert_before,
-            opt range_length => range_length,
-            opt snapshot_id => snapshot_id,
+            req playlist_id,
+            opt uris,
+            opt range_start,
+            opt insert_before,
+            opt range_length,
+            opt snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -816,8 +816,8 @@ impl Spotify {
             .collect::<Vec<_>>();
 
         let params = map_json! {
-            req tracks => tracks,
-            opt snapshot_id => snapshot_id,
+            req tracks,
+            opt snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -872,8 +872,8 @@ impl Spotify {
             .collect::<Vec<_>>();
 
         let params = map_json! {
-            req tracks => tracks,
-            opt snapshot_id => snapshot_id,
+            req tracks,
+            opt snapshot_id,
         };
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
@@ -896,7 +896,7 @@ impl Spotify {
         let url = format!("playlists/{}/followers", playlist_id.id());
 
         let params = map_json! {
-            opt public => public,
+            opt public,
         };
 
         self.endpoint_put(&url, &params).await?;
@@ -1401,9 +1401,9 @@ impl Spotify {
         let params = map_query! {
             opt limit => &limit,
             opt offset => &offset,
-            opt locale => locale,
+            opt locale,
             opt market => market.as_ref(),
-            opt timestamp => timestamp,
+            opt timestamp,
         };
 
         let result = self
@@ -1496,7 +1496,7 @@ impl Spotify {
         let params = map_query! {
             opt limit => &limit,
             opt offset => &offset,
-            opt locale => locale,
+            opt locale,
             opt market => market.as_ref(),
         };
         let result = self.endpoint_get("browse/categories", &params).await?;
@@ -1584,9 +1584,9 @@ impl Spotify {
         let seed_tracks = seed_tracks.map(join_ids);
         let limit = limit.map(|x| x.to_string());
         let mut params = map_query! {
-            opt seed_artists => seed_artists,
-            opt seed_genres => seed_genres,
-            opt seed_tracks => seed_tracks,
+            opt seed_artists,
+            opt seed_genres,
+            opt seed_tracks,
             opt market => market.as_ref(),
             opt limit => &limit,
         };
@@ -1708,7 +1708,7 @@ impl Spotify {
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = map_query! {
             opt market => market.as_ref(),
-            opt additional_types => additional_types,
+            opt additional_types,
         };
 
         let result = self.endpoint_get("me/player", &params).await?;
@@ -1738,7 +1738,7 @@ impl Spotify {
             additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = map_query! {
             opt market => market.as_ref(),
-            opt additional_types => additional_types,
+            opt additional_types,
         };
 
         let result = self
@@ -1770,7 +1770,7 @@ impl Spotify {
     ) -> ClientResult<()> {
         let params = map_json! {
             req device_ids => vec![device_id.to_owned()],
-            opt force_play => force_play,
+            opt force_play,
         };
 
         self.endpoint_put("me/player", &params).await?;
@@ -1830,11 +1830,11 @@ impl Spotify {
 
         let params = map_json! {
             req uris => uris.iter().map(|id| id.uri()).collect::<Vec<_>>(),
+            opt position_ms,
             opt offset => match offset {
                 Offset::Position(position) => json!({ "position": position }),
                 Offset::Uri(uri) => json!({ "uri": uri.uri() }),
             },
-            opt position_ms => position_ms,
         };
 
         let url = self.append_device_id("me/player/play", device_id);

--- a/src/client.rs
+++ b/src/client.rs
@@ -271,7 +271,7 @@ impl Spotify {
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
-        let limit: Option<String> = limit.map(|x| x.to_string());
+        let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
             optional "album_type": album_type.map(|x| x.as_ref()),

--- a/src/client.rs
+++ b/src/client.rs
@@ -570,18 +570,13 @@ impl Spotify {
         let params = map_query! {
             opt fields => fields,
         };
-        match playlist_id {
-            Some(playlist_id) => {
-                let url = format!("users/{}/playlists/{}", user_id.id(), playlist_id.id());
-                let result = self.endpoint_get(&url, &params).await?;
-                self.convert_result(&result)
-            }
-            None => {
-                let url = format!("users/{}/starred", user_id.id());
-                let result = self.endpoint_get(&url, &params).await?;
-                self.convert_result(&result)
-            }
-        }
+
+        let url = match playlist_id {
+            Some(playlist_id) => format!("users/{}/playlists/{}", user_id.id(), playlist_id.id()),
+            None => format!("users/{}/starred", user_id.id()),
+        };
+        let result = self.endpoint_get(&url, &params).await?;
+        self.convert_result(&result)
     }
 
     /// Get full details of the tracks of a playlist owned by a user.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1698,13 +1698,13 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
     #[maybe_async]
-    pub async fn current_playback(
+    pub async fn current_playback<'a>(
         &self,
         country: Option<&Market>,
-        additional_types: Option<Vec<AdditionalType>>,
+        additional_types: Option<impl IntoIterator<Item = &'a AdditionalType>>,
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let additional_types =
-            additional_types.map(|x| x.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
+            additional_types.map(|x| x.into_iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(","));
         let params = build_map! {
             optional "country": country.map(|x| x.as_ref()),
             optional "additional_types": additional_types.as_ref(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,9 +144,10 @@ macro_rules! map_json {
 
 #[cfg(test)]
 mod test {
+    use crate::{map_query, map_json, scopes};
     use crate::http::Query;
     use crate::model::Modality;
-    use crate::{map_query, scopes};
+    use serde_json::{Map, Value, json};
 
     #[test]
     fn test_hashset() {
@@ -184,6 +185,31 @@ mod test {
         }
 
         assert_eq!(with_macro, manually);
+    }
+
+    #[test]
+    fn test_json_query() {
+        // Passed as parameters, for example.
+        let id = "Pink Lemonade";
+        let artist = Some("The Wombats");
+        let modality: Option<Modality> = None;
+
+        let with_macro = map_json! {
+            req id,
+            opt artist,
+            opt modality => modality.as_ref(),
+        };
+
+        let mut manually = Map::new();
+        manually.insert("id".to_string(), json!(id));
+        if let Some(ref artist) = artist {
+            manually.insert("artist".to_string(), json!(artist));
+        }
+        if let Some(ref modality) = modality {
+            manually.insert("modality".to_string(), json!(modality.as_ref()));
+        }
+
+        assert_eq!(with_macro, Value::from(manually));
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -62,7 +62,8 @@ macro_rules! count_items {
     ($($item:expr),*) => {<[()]>::len(&[$($crate::replace_expr!($item ())),*])};
 }
 
-/// Hack to convert an identifier to a string, including raw identifiers.
+/// Hack to convert an identifier to a string, including raw identifiers like
+/// `r#type`.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! ident_str {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,7 +77,7 @@ macro_rules! params_internal {
 }
 
 /// TODO: use with_capacity?
-/// This macro and [`map_json`] help make the endpoints as concise as possible
+/// This macro and [`build_json`] help make the endpoints as concise as possible
 /// and boilerplate-free, which is specially important when initializing the
 /// parameters of the query with a HashMap/similar. Their items follow the
 /// syntax:
@@ -94,11 +94,11 @@ macro_rules! params_internal {
 /// a key and a value with `MyStruct { key: value }`, or if both have the same
 /// name as the key, `MyStruct { key }` is enough.
 ///
-/// For more information, please refer to the `test::test_map_query` function in
+/// For more information, please refer to the `test::test_build_map` function in
 /// this module to see an example, or the real usages in Rspotify's client.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! map_query {
+macro_rules! build_map {
     (
         $(
             $kind:ident $name:ident $( => $val:expr )?
@@ -118,11 +118,11 @@ macro_rules! map_query {
     });
 }
 
-/// Refer to the [`map_query`] documentation; this is the same but for JSON
+/// Refer to the [`build_map`] documentation; this is the same but for JSON
 /// maps.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! map_json {
+macro_rules! build_json {
     (
         $(
             $kind:ident $name:ident $( => $val:expr )?
@@ -144,7 +144,7 @@ macro_rules! map_json {
 
 #[cfg(test)]
 mod test {
-    use crate::{map_query, map_json, scopes};
+    use crate::{build_map, build_json, scopes};
     use crate::http::Query;
     use crate::model::Modality;
     use serde_json::{Map, Value, json};
@@ -160,13 +160,13 @@ mod test {
     }
 
     #[test]
-    fn test_map_query() {
+    fn test_build_map() {
         // Passed as parameters, for example.
         let id = "Pink Lemonade";
         let artist = Some("The Wombats");
         let modality: Option<Modality> = None;
 
-        let with_macro = map_query! {
+        let with_macro = build_map! {
             // Mandatory (not an `Option<T>`)
             req id,
             // Can be used directly
@@ -194,7 +194,7 @@ mod test {
         let artist = Some("The Wombats");
         let modality: Option<Modality> = None;
 
-        let with_macro = map_json! {
+        let with_macro = build_json! {
             req id,
             opt artist,
             opt modality => modality.as_ref(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,10 +99,10 @@ macro_rules! params_internal {
 ///   [req|opt] key [=> value]
 ///
 /// The first keyword is just to distinguish between a direct insert into the
-/// hashmap (required parameter), and an insert only if the value is
-/// `Some(...)`, respectively (optional parameter). This is followed by the
-/// variable to be inserted, which shall have the same name as the key in the
-/// map (meaning that `r#type` may have to be used).
+/// hashmap (required parameter), and an insert only if the value is `Some(...)`
+/// (optional parameter). This is followed by the variable to be inserted, which
+/// shall have the same name as the key in the map (meaning that `r#type` may
+/// have to be used).
 ///
 /// It also works similarly to how struct initialization works. You may provide
 /// a key and a value with `MyStruct { key: value }`, or if both have the same

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,6 +45,41 @@ macro_rules! json_insert {
     };
 }
 
+#[macro_export]
+macro_rules! params_internal {
+    ($map:ident, req, $key:ident, $val:expr) => (
+        $map.insert(stringify!($key), $val);
+    );
+    ($map:ident, opt, $key:ident, $val:expr) => (
+        if let Some(ref $key) = $key {
+            $map.insert(stringify!($key), $val);
+        }
+    );
+}
+
+/// TODO: use with_capacity?
+#[macro_export]
+macro_rules! map_params {
+    (
+        $(
+            $kind:ident $key:ident => $val:expr
+        ),* $(,)?
+    ) => ({
+        let mut params = crate::http::Query::new();
+        $(
+            crate::params_internal!(params, $kind, $key, $val);
+        )*
+        params
+    });
+}
+
+#[macro_export]
+macro_rules! json_params {
+    () => {
+
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{json_insert, scopes};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,22 +45,34 @@ macro_rules! params_internal {
     };
 }
 
+#[macro_export]
+macro_rules! opt {
+    (, $def:expr) => {
+        $def
+    };
+    ($opt:expr, $def:expr) => {
+        $opt
+    };
+}
+
 /// TODO: use with_capacity?
+/// The usage of this macro is similar to a struct initialization, in the sense
+/// that you may provide a single identifier if
 #[macro_export]
 macro_rules! map_query {
     (
         $(
-            $kind:ident $name:ident => $val:expr
+            $kind:ident $name:ident $( => $val:expr )?
         ),* $(,)?
     ) => ({
-        let mut params = crate::http::Query::new();
+        let mut params = $crate::http::Query::new();
         $(
-            crate::params_internal!(
+            $crate::params_internal!(
                 params,
                 $kind,
                 $name,
                 stringify!($name),
-                $val
+                $crate::opt!($( $val )?, $name)
             );
         )*
         params
@@ -71,18 +83,17 @@ macro_rules! map_query {
 macro_rules! map_json {
     (
         $(
-            $kind:ident $name:ident => $val:expr
+            $kind:ident $name:ident $( => $val:expr )?
         ),* $(,)?
     ) => ({
         let mut params = ::serde_json::map::Map::new();
         $(
-
-            crate::params_internal!(
+            $crate::params_internal!(
                 params,
                 $kind,
                 $name,
                 stringify!($name).to_string(),
-                json!($val)
+                json!($crate::opt!($( $val )?, $name))
             );
         )*
         ::serde_json::Value::from(params)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -117,7 +117,7 @@ macro_rules! build_map {
     (
         $(
             $kind:ident $name:ident $( => $val:expr )?
-        ),* $(,)?
+        ),+ $(,)?
     ) => {{
         let mut params = $crate::http::Query::with_capacity(
             $crate::count_items!($( $name ),*)
@@ -130,7 +130,7 @@ macro_rules! build_map {
                 $crate::ident_str!($name),
                 $crate::opt!($( $val )?, $name)
             );
-        )*
+        )+
         params
     }};
 }
@@ -143,7 +143,7 @@ macro_rules! build_json {
     (
         $(
             $kind:ident $name:ident $( => $val:expr )?
-        ),* $(,)?
+        ),+ $(,)?
     ) => {{
         let mut params = ::serde_json::map::Map::with_capacity(
             $crate::count_items!($( $name ),*)
@@ -156,7 +156,7 @@ macro_rules! build_json {
                 $crate::ident_str!($name).to_string(),
                 json!($crate::opt!($( $val )?, $name))
             );
-        )*
+        )+
         ::serde_json::Value::from(params)
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,7 +55,7 @@ macro_rules! ident_str {
         const NAME: &str = stringify!($name);
         match &NAME.get(..2) {
             Some("r#") => &NAME[2..],
-            _ => &NAME[..],
+            _ => NAME,
         }
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -152,10 +152,10 @@ mod test {
     fn test_hashset() {
         let scope = scopes!("hello", "world", "foo", "bar");
         assert_eq!(scope.len(), 4);
-        assert!(scope.contains(&"hello".to_owned()));
-        assert!(scope.contains(&"world".to_owned()));
-        assert!(scope.contains(&"foo".to_owned()));
-        assert!(scope.contains(&"bar".to_owned()));
+        assert!(scope.contains("hello"));
+        assert!(scope.contains("world"));
+        assert!(scope.contains("foo"));
+        assert!(scope.contains("bar"));
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -70,7 +70,7 @@ macro_rules! params_internal {
 /// syntax:
 ///
 ///   [req|opt] key [=> value]
-/// 
+///
 /// The first keyword is just to distinguish between a direct insert into the
 /// hashmap (required parameter), and an insert only if the value is
 /// `Some(...)`, respectively (optional parameter). This is followed by the
@@ -131,9 +131,9 @@ macro_rules! map_json {
 
 #[cfg(test)]
 mod test {
-    use crate::{map_query, scopes};
-    use crate::model::{AlbumId, Market};
     use crate::http::Query;
+    use crate::model::Modality;
+    use crate::{map_query, scopes};
 
     #[test]
     fn test_hashset() {
@@ -145,22 +145,20 @@ mod test {
         assert!(scope.contains(&"bar".to_owned()));
     }
 
+    #[test]
     fn test_map_query() {
         // Passed as parameters, for example.
         let id = "Pink Lemonade";
-        let artist: Option<&str> = None;
-        let album = Some(AlbumId::from_uri("spotify:album:0XOseclZGO4NnaBz5Shjxp").unwrap());
-        let market = Some(Market::FromToken);
+        let artist = Some("The Wombats");
+        let modality: Option<Modality> = None;
 
         let with_macro = map_query! {
             // Mandatory (not an `Option<T>`)
             req id,
-            // Is `None`, so it won't be inserted
-            opt artist,
             // Can be used directly
-            opt album,
-            // `Market` needs to be converted to &str
-            opt market => market.as_ref(),
+            opt artist,
+            // `Modality` needs to be converted to &str
+            opt modality => modality.as_ref(),
         };
 
         let mut manually = Query::new();
@@ -168,8 +166,8 @@ mod test {
         if let Some(ref artist) = artist {
             manually.insert("artist", artist);
         }
-        if let Some(ref market) = market {
-            manually.insert("market", market.as_ref());
+        if let Some(ref modality) = modality {
+            manually.insert("modality", modality.as_ref());
         }
 
         assert_eq!(with_macro, manually);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -97,7 +97,7 @@ macro_rules! params_internal {
 /// parameters of the query with a HashMap/similar. Their items follow the
 /// syntax:
 ///
-///   [required|optional] key [=> value]
+///   (required|optional) key [=> value]
 ///
 /// The first keyword is just to distinguish between a direct insert into the
 /// hashmap (required parameter), and an insert only if the value is `Some(...)`

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -80,10 +80,10 @@ macro_rules! ident_str {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! params_internal {
-    ($map:ident, req, $name:ident, $key:expr, $val:expr) => {
+    ($map:ident, required, $name:ident, $key:expr, $val:expr) => {
         $map.insert($key, $val);
     };
-    ($map:ident, opt, $name:ident, $key:expr, $val:expr) => {
+    ($map:ident, optional, $name:ident, $key:expr, $val:expr) => {
         // Will only insert when `$name` is not None.
         if let Some(ref $name) = $name {
             $map.insert($key, $val);
@@ -96,7 +96,7 @@ macro_rules! params_internal {
 /// parameters of the query with a HashMap/similar. Their items follow the
 /// syntax:
 ///
-///   [req|opt] key [=> value]
+///   [required|optional] key [=> value]
 ///
 /// The first keyword is just to distinguish between a direct insert into the
 /// hashmap (required parameter), and an insert only if the value is `Some(...)`
@@ -186,11 +186,11 @@ mod test {
 
         let with_macro = build_map! {
             // Mandatory (not an `Option<T>`)
-            req id,
+            required id,
             // Can be used directly
-            opt artist,
+            optional artist,
             // `Modality` needs to be converted to &str
-            opt modality => modality.as_ref(),
+            optional modality => modality.as_ref(),
         };
 
         let mut manually = Query::with_capacity(3);
@@ -213,9 +213,9 @@ mod test {
         let modality: Option<Modality> = None;
 
         let with_macro = build_json! {
-            req id,
-            opt artist,
-            opt modality => modality.as_ref(),
+            required id,
+            optional artist,
+            optional modality => modality.as_ref(),
         };
 
         let mut manually = Map::with_capacity(3);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,20 +33,6 @@ macro_rules! scopes {
     }};
 }
 
-/// If there's an optional value, the macro will return its value. Otherwise, a
-/// default value will be returned. This is helpful to handle `$( expr )?`
-/// cases in macros.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! opt {
-    (, $default:expr) => {
-        $default
-    };
-    ($optional:expr, $default:expr) => {
-        $optional
-    };
-}
-
 /// Count items in a list of items within a macro, taken from here:
 /// https://danielkeep.github.io/tlborm/book/blk-counting.html
 #[doc(hidden)]
@@ -62,42 +48,12 @@ macro_rules! count_items {
     ($($item:expr),*) => {<[()]>::len(&[$($crate::replace_expr!($item ())),*])};
 }
 
-/// Hack to convert an identifier to a string, including raw identifiers like
-/// `r#type`.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! ident_str {
-    ($name:ident) => {{
-        const NAME: &str = stringify!($name);
-        match &NAME.get(..2) {
-            Some("r#") => &NAME[2..],
-            _ => NAME,
-        }
-    }};
-}
-
-/// Private macro to insert either required or optional fields. Pattern matching
-/// will accordingly pick the branch, and then insert ($key, $val) into $map.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! params_internal {
-    ($map:ident, required, $name:ident, $key:expr, $val:expr) => {
-        $map.insert($key, $val);
-    };
-    ($map:ident, optional, $name:ident, $key:expr, $val:expr) => {
-        // Will only insert when `$name` is not None.
-        if let Some(ref $name) = $name {
-            $map.insert($key, $val);
-        }
-    };
-}
-
 /// This macro and [`build_json`] help make the endpoints as concise as possible
 /// and boilerplate-free, which is specially important when initializing the
 /// parameters of the query with a HashMap/similar. Their items follow the
 /// syntax:
 ///
-///   (required|optional) key [=> value]
+///   [optional] "key": value
 ///
 /// The first keyword is just to distinguish between a direct insert into the
 /// hashmap (required parameter), and an insert only if the value is `Some(...)`
@@ -114,21 +70,29 @@ macro_rules! params_internal {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! build_map {
+    (@/* required */, $map:ident, $key:expr, $val:expr) => {
+        $map.insert($key, $val);
+    };
+    (@optional, $map:ident, $key:expr, $val:expr) => {
+        if let Some(val) = $val {
+            $map.insert($key, val);
+        }
+    };
+
     (
         $(
-            $kind:ident $name:ident $( => $val:expr )?
+            $( $kind:ident )? $key:literal : $val:expr
         ),+ $(,)?
     ) => {{
         let mut params = $crate::http::Query::with_capacity(
-            $crate::count_items!($( $name ),*)
+            $crate::count_items!($( $key ),*)
         );
         $(
-            $crate::params_internal!(
+            $crate::build_map!(
+                @$( $kind )?,
                 params,
-                $kind,
-                $name,
-                $crate::ident_str!($name),
-                $crate::opt!($( $val )?, $name)
+                $key,
+                $val
             );
         )+
         params
@@ -140,21 +104,29 @@ macro_rules! build_map {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! build_json {
+    (@/* required */, $map:ident, $key:expr, $val:expr) => {
+        $map.insert($key.to_string(), json!($val));
+    };
+    (@optional, $map:ident, $key:expr, $val:expr) => {
+        if let Some(val) = $val {
+            $map.insert($key.to_string(), json!(val));
+        }
+    };
+
     (
         $(
-            $kind:ident $name:ident $( => $val:expr )?
+            $( $kind:ident )? $key:literal : $val:expr
         ),+ $(,)?
     ) => {{
         let mut params = ::serde_json::map::Map::with_capacity(
-            $crate::count_items!($( $name ),*)
+            $crate::count_items!($( $key ),*)
         );
         $(
-            $crate::params_internal!(
+            $crate::build_json!(
+                @$( $kind )?,
                 params,
-                $kind,
-                $name,
-                $crate::ident_str!($name).to_string(),
-                json!($crate::opt!($( $val )?, $name))
+                $key,
+                $val
             );
         )+
         ::serde_json::Value::from(params)
@@ -164,7 +136,7 @@ macro_rules! build_json {
 #[cfg(test)]
 mod test {
     use crate::http::Query;
-    use crate::model::Modality;
+    use crate::model::Market;
     use crate::{build_json, build_map, scopes};
     use serde_json::{json, Map, Value};
 
@@ -183,24 +155,24 @@ mod test {
         // Passed as parameters, for example.
         let id = "Pink Lemonade";
         let artist = Some("The Wombats");
-        let modality: Option<Modality> = None;
+        let market: Option<Market> = None;
 
         let with_macro = build_map! {
             // Mandatory (not an `Option<T>`)
-            required id,
+            "id": id,
             // Can be used directly
-            optional artist,
+            optional "artist": artist,
             // `Modality` needs to be converted to &str
-            optional modality => modality.as_ref(),
+            optional "market": market.map(|x| x.as_ref()),
         };
 
         let mut manually = Query::with_capacity(3);
         manually.insert("id", id);
-        if let Some(ref artist) = artist {
-            manually.insert("artist", artist);
+        if let Some(val) = artist {
+            manually.insert("artist", val);
         }
-        if let Some(ref modality) = modality {
-            manually.insert("modality", modality.as_ref());
+        if let Some(val) = market.map(|x| x.as_ref()) {
+            manually.insert("market", val);
         }
 
         assert_eq!(with_macro, manually);
@@ -211,32 +183,23 @@ mod test {
         // Passed as parameters, for example.
         let id = "Pink Lemonade";
         let artist = Some("The Wombats");
-        let modality: Option<Modality> = None;
+        let market: Option<Market> = None;
 
         let with_macro = build_json! {
-            required id,
-            optional artist,
-            optional modality => modality.as_ref(),
+            "id": id,
+            optional "artist": artist,
+            optional "market": market.map(|x| x.as_ref()),
         };
 
         let mut manually = Map::with_capacity(3);
         manually.insert("id".to_string(), json!(id));
-        if let Some(ref artist) = artist {
-            manually.insert("artist".to_string(), json!(artist));
+        if let Some(val) = artist.map(|x| json!(x)) {
+            manually.insert("artist".to_string(), val);
         }
-        if let Some(ref modality) = modality {
-            manually.insert("modality".to_string(), json!(modality.as_ref()));
+        if let Some(val) = market.map(|x| x.as_ref()).map(|x| json!(x)) {
+            manually.insert("market".to_string(), val);
         }
 
         assert_eq!(with_macro, Value::from(manually));
-    }
-
-    #[test]
-    fn test_ident_str() {
-        assert_eq!(ident_str!(i), "i");
-        assert_eq!(ident_str!(r#i), "i");
-        assert_eq!(ident_str!(test), "test");
-        assert_eq!(ident_str!(a_b_c_d), "a_b_c_d");
-        assert_eq!(ident_str!(r#type), "type");
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,7 +55,7 @@ macro_rules! ident_str {
         const NAME: &str = stringify!($name);
         match &NAME.get(..2) {
             Some("r#") => &NAME[2..],
-            _ => &NAME[..]
+            _ => &NAME[..],
         }
     }};
 }
@@ -144,10 +144,10 @@ macro_rules! build_json {
 
 #[cfg(test)]
 mod test {
-    use crate::{build_map, build_json, scopes};
     use crate::http::Query;
     use crate::model::Modality;
-    use serde_json::{Map, Value, json};
+    use crate::{build_json, build_map, scopes};
+    use serde_json::{json, Map, Value};
 
     #[test]
     fn test_hashset() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -193,7 +193,7 @@ mod test {
             opt modality => modality.as_ref(),
         };
 
-        let mut manually = Query::new();
+        let mut manually = Query::with_capacity(3);
         manually.insert("id", id);
         if let Some(ref artist) = artist {
             manually.insert("artist", artist);
@@ -218,7 +218,7 @@ mod test {
             opt modality => modality.as_ref(),
         };
 
-        let mut manually = Map::new();
+        let mut manually = Map::with_capacity(3);
         manually.insert("id".to_string(), json!(id));
         if let Some(ref artist) = artist {
             manually.insert("artist".to_string(), json!(artist));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,31 +33,57 @@ macro_rules! scopes {
     }};
 }
 
+/// If there's an optional value, the macro will return its value. Otherwise, a
+/// default value will be returned. This is helpful to handle `$( expr )?`
+/// cases in macros.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! opt {
+    (, $default:expr) => {
+        $default
+    };
+    ($optional:expr, $default:expr) => {
+        $optional
+    };
+}
+
+/// Private macro to insert either required or optional fields. Pattern matching
+/// will accordingly pick the branch, and then insert ($key, $val) into $map.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! params_internal {
     ($map:ident, req, $name:ident, $key:expr, $val:expr) => {
         $map.insert($key, $val);
     };
     ($map:ident, opt, $name:ident, $key:expr, $val:expr) => {
+        // Will only insert when `$name` is not None.
         if let Some(ref $name) = $name {
             $map.insert($key, $val);
         }
     };
 }
 
-#[macro_export]
-macro_rules! opt {
-    (, $def:expr) => {
-        $def
-    };
-    ($opt:expr, $def:expr) => {
-        $opt
-    };
-}
-
 /// TODO: use with_capacity?
-/// The usage of this macro is similar to a struct initialization, in the sense
-/// that you may provide a single identifier if
+/// This macro and [`map_json`] help make the endpoints as concise as possible
+/// and boilerplate-free, which is specially important when initializing the
+/// parameters of the query with a HashMap/similar. Their items follow the
+/// syntax:
+///
+///   [req|opt] key [=> value]
+/// 
+/// The first keyword is just to distinguish between a direct insert into the
+/// hashmap (required parameter), and an insert only if the value is
+/// `Some(...)`, respectively (optional parameter). This is followed by the
+/// variable to be inserted, which shall have the same name as the key in the
+/// map (meaning that `r#type` may have to be used).
+///
+/// It also works similarly to how struct initialization works. You may provide
+/// a key and a value with `MyStruct { key: value }`, or if both have the same
+/// name as the key, `MyStruct { key }` is enough.
+///
+/// For more information, please refer to the `test::test_map_query` function in
+/// this module to see an example, or the real usages in Rspotify's client.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! map_query {
     (
@@ -79,6 +105,9 @@ macro_rules! map_query {
     });
 }
 
+/// Refer to the [`map_query`] documentation; this is the same but for JSON
+/// maps.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! map_json {
     (
@@ -102,8 +131,9 @@ macro_rules! map_json {
 
 #[cfg(test)]
 mod test {
-    use crate::{json_insert, scopes};
-    use serde_json::json;
+    use crate::{map_query, scopes};
+    use crate::model::{AlbumId, Market};
+    use crate::http::Query;
 
     #[test]
     fn test_hashset() {
@@ -115,11 +145,33 @@ mod test {
         assert!(scope.contains(&"bar".to_owned()));
     }
 
-    #[test]
-    fn test_json_insert() {
-        let mut params = json!({});
-        let name = "ramsay";
-        json_insert!(params, "name", name);
-        assert_eq!(params["name"], name);
+    fn test_map_query() {
+        // Passed as parameters, for example.
+        let id = "Pink Lemonade";
+        let artist: Option<&str> = None;
+        let album = Some(AlbumId::from_uri("spotify:album:0XOseclZGO4NnaBz5Shjxp").unwrap());
+        let market = Some(Market::FromToken);
+
+        let with_macro = map_query! {
+            // Mandatory (not an `Option<T>`)
+            req id,
+            // Is `None`, so it won't be inserted
+            opt artist,
+            // Can be used directly
+            opt album,
+            // `Market` needs to be converted to &str
+            opt market => market.as_ref(),
+        };
+
+        let mut manually = Query::new();
+        manually.insert("id", id);
+        if let Some(ref artist) = artist {
+            manually.insert("artist", artist);
+        }
+        if let Some(ref market) = market {
+            manually.insert("market", market.as_ref());
+        }
+
+        assert_eq!(with_macro, manually);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -103,7 +103,7 @@ macro_rules! build_map {
         $(
             $kind:ident $name:ident $( => $val:expr )?
         ),* $(,)?
-    ) => ({
+    ) => {{
         let mut params = $crate::http::Query::new();
         $(
             $crate::params_internal!(
@@ -115,7 +115,7 @@ macro_rules! build_map {
             );
         )*
         params
-    });
+    }};
 }
 
 /// Refer to the [`build_map`] documentation; this is the same but for JSON
@@ -127,7 +127,7 @@ macro_rules! build_json {
         $(
             $kind:ident $name:ident $( => $val:expr )?
         ),* $(,)?
-    ) => ({
+    ) => {{
         let mut params = ::serde_json::map::Map::new();
         $(
             $crate::params_internal!(
@@ -139,7 +139,7 @@ macro_rules! build_json {
             );
         )*
         ::serde_json::Value::from(params)
-    });
+    }};
 }
 
 #[cfg(test)]

--- a/src/model/enums/misc.rs
+++ b/src/model/enums/misc.rs
@@ -102,11 +102,8 @@ pub enum Market {
     Country(Country),
     FromToken,
 }
-pub trait AsRefStr {
-    fn as_ref(&self) -> &str;
-}
 
-impl AsRefStr for Market {
+impl AsRef<str> for Market {
     fn as_ref(&self) -> &str {
         match self {
             Market::Country(country) => country.as_ref(),

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -85,7 +85,7 @@ async fn test_artists_albums() {
         .await
         .artist_albums_manual(
             birdy_uri,
-            Some(AlbumType::Album),
+            Some(&AlbumType::Album),
             Some(&Market::Country(Country::UnitedStates)),
             Some(10),
             None,

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -101,7 +101,12 @@ pub async fn oauth_client() -> Spotify {
 async fn test_categories() {
     oauth_client()
         .await
-        .categories_manual(None, Some(&Market::Country(Country::UnitedStates)), 10, 0)
+        .categories_manual(
+            None,
+            Some(&Market::Country(Country::UnitedStates)),
+            Some(10),
+            Some(0),
+        )
         .await
         .unwrap();
 }
@@ -112,7 +117,12 @@ async fn test_categories() {
 async fn test_category_playlists() {
     oauth_client()
         .await
-        .category_playlists_manual("pop", Some(&Market::Country(Country::UnitedStates)), 10, 0)
+        .category_playlists_manual(
+            "pop",
+            Some(&Market::Country(Country::UnitedStates)),
+            Some(10),
+            Some(0),
+        )
         .await
         .unwrap();
 }
@@ -145,7 +155,7 @@ async fn test_current_playing() {
 async fn test_current_user_followed_artists() {
     oauth_client()
         .await
-        .current_user_followed_artists(10, None)
+        .current_user_followed_artists(None, Some(10))
         .await
         .unwrap();
 }
@@ -167,7 +177,7 @@ async fn test_current_user_playing_track() {
 async fn test_current_user_playlists() {
     oauth_client()
         .await
-        .current_user_playlists_manual(10, None)
+        .current_user_playlists_manual(Some(10), None)
         .await
         .unwrap();
 }
@@ -178,7 +188,7 @@ async fn test_current_user_playlists() {
 async fn test_current_user_recently_played() {
     oauth_client()
         .await
-        .current_user_recently_played(10)
+        .current_user_recently_played(Some(10))
         .await
         .unwrap();
 }
@@ -221,7 +231,7 @@ async fn test_current_user_saved_albums_delete() {
 async fn test_current_user_saved_albums() {
     oauth_client()
         .await
-        .current_user_saved_albums_manual(10, 0)
+        .current_user_saved_albums_manual(Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -280,7 +290,7 @@ async fn test_current_user_saved_tracks_delete() {
 async fn test_current_user_saved_tracks() {
     oauth_client()
         .await
-        .current_user_saved_tracks_manual(10, 0)
+        .current_user_saved_tracks_manual(Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -291,7 +301,7 @@ async fn test_current_user_saved_tracks() {
 async fn test_current_user_top_artists() {
     oauth_client()
         .await
-        .current_user_top_artists_manual(Some(&TimeRange::ShortTerm), 10, 0)
+        .current_user_top_artists_manual(Some(&TimeRange::ShortTerm), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -302,7 +312,7 @@ async fn test_current_user_top_artists() {
 async fn test_current_user_top_tracks() {
     oauth_client()
         .await
-        .current_user_top_tracks_manual(Some(&TimeRange::ShortTerm), 10, 0)
+        .current_user_top_tracks_manual(Some(&TimeRange::ShortTerm), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -321,7 +331,7 @@ async fn test_featured_playlists() {
     let now: DateTime<Utc> = Utc::now();
     oauth_client()
         .await
-        .featured_playlists(None, None, Some(now), 10, 0)
+        .featured_playlists(None, None, Some(now), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -339,7 +349,7 @@ async fn test_me() {
 async fn test_new_releases() {
     oauth_client()
         .await
-        .new_releases_manual(Some(&Market::Country(Country::Sweden)), 10, 0)
+        .new_releases_manual(Some(&Market::Country(Country::Sweden)), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -350,7 +360,7 @@ async fn test_new_releases() {
 async fn test_new_releases_with_from_token() {
     oauth_client()
         .await
-        .new_releases_manual(Some(&Market::FromToken), 10, 0)
+        .new_releases_manual(Some(&Market::FromToken), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -359,7 +369,7 @@ async fn test_new_releases_with_from_token() {
 #[maybe_async_test]
 #[ignore]
 async fn test_next_playback() {
-    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let device_id = "74ASZWbe4lXaubB36ztrGX";
     oauth_client()
         .await
         .next_track(Some(device_id))
@@ -371,7 +381,7 @@ async fn test_next_playback() {
 #[maybe_async_test]
 #[ignore]
 async fn test_pause_playback() {
-    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let device_id = "74ASZWbe4lXaubB36ztrGX";
     oauth_client()
         .await
         .pause_playback(Some(device_id))
@@ -383,7 +393,7 @@ async fn test_pause_playback() {
 #[maybe_async_test]
 #[ignore]
 async fn test_previous_playback() {
-    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let device_id = "74ASZWbe4lXaubB36ztrGX";
     oauth_client()
         .await
         .previous_track(Some(device_id))
@@ -403,12 +413,12 @@ async fn test_recommendations() {
     oauth_client()
         .await
         .recommendations(
+            &payload,
             Some(seed_artists),
             None,
             Some(seed_tracks),
-            10,
+            Some(10),
             Some(Market::Country(Country::UnitedStates)),
-            &payload,
         )
         .await
         .unwrap();
@@ -432,7 +442,7 @@ async fn test_search_album() {
     let query = "album:arrival artist:abba";
     oauth_client()
         .await
-        .search(query, SearchType::Album, 10, 0, None, None)
+        .search(query, SearchType::Album, None, None, Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -447,10 +457,10 @@ async fn test_search_artist() {
         .search(
             query,
             SearchType::Artist,
-            10,
-            0,
             Some(Market::Country(Country::UnitedStates)),
             None,
+            Some(10),
+            Some(0),
         )
         .await
         .unwrap();
@@ -466,10 +476,10 @@ async fn test_search_playlist() {
         .search(
             query,
             SearchType::Playlist,
-            10,
-            0,
             Some(Market::Country(Country::UnitedStates)),
             None,
+            Some(10),
+            Some(0),
         )
         .await
         .unwrap();
@@ -485,10 +495,10 @@ async fn test_search_track() {
         .search(
             query,
             SearchType::Track,
-            10,
-            0,
             Some(Market::Country(Country::UnitedStates)),
             None,
+            Some(10),
+            Some(0),
         )
         .await
         .unwrap();
@@ -512,7 +522,7 @@ async fn test_shuffle() {
 #[maybe_async_test]
 #[ignore]
 async fn test_start_playback() {
-    let device_id = String::from("74ASZWbe4lXaubB36ztrGX");
+    let device_id = "74ASZWbe4lXaubB36ztrGX";
     let uris = vec![TrackId::from_uri("spotify:track:4iV5W9uYEdYUVa79Axb7Rh").unwrap()];
     oauth_client()
         .await
@@ -528,7 +538,7 @@ async fn test_transfer_playback() {
     let device_id = "74ASZWbe4lXaubB36ztrGX";
     oauth_client()
         .await
-        .transfer_playback(device_id, true)
+        .transfer_playback(device_id, Some(true))
         .await
         .unwrap();
 }
@@ -644,7 +654,7 @@ async fn test_user_playlist_create() {
     let playlist_name = "A New Playlist";
     oauth_client()
         .await
-        .user_playlist_create(user_id, playlist_name, false, None)
+        .user_playlist_create(user_id, playlist_name, Some(false), None, None)
         .await
         .unwrap();
 }
@@ -656,7 +666,7 @@ async fn test_playlist_follow_playlist() {
     let playlist_id = Id::from_id("2v3iNvBX8Ay1Gt2uXtUKUT").unwrap();
     oauth_client()
         .await
-        .playlist_follow(playlist_id, true)
+        .playlist_follow(playlist_id, Some(true))
         .await
         .unwrap();
 }
@@ -665,13 +675,21 @@ async fn test_playlist_follow_playlist() {
 #[maybe_async_test]
 #[ignore]
 async fn test_playlist_recorder_tracks() {
+    let uris: Option<&[&EpisodeId]> = None;
     let playlist_id = Id::from_id("5jAOgWXCBKuinsGiZxjDQ5").unwrap();
     let range_start = 0;
     let insert_before = 1;
     let range_length = 1;
     oauth_client()
         .await
-        .playlist_reorder_tracks(playlist_id, range_start, range_length, insert_before, None)
+        .playlist_reorder_tracks(
+            playlist_id,
+            uris,
+            Some(range_start),
+            Some(insert_before),
+            Some(range_length),
+            None,
+        )
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -418,7 +418,7 @@ async fn test_recommendations() {
             None,
             Some(seed_tracks),
             Some(10),
-            Some(Market::Country(Country::UnitedStates)),
+            Some(&Market::Country(Country::UnitedStates)),
         )
         .await
         .unwrap();
@@ -457,7 +457,7 @@ async fn test_search_artist() {
         .search(
             query,
             SearchType::Artist,
-            Some(Market::Country(Country::UnitedStates)),
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -476,7 +476,7 @@ async fn test_search_playlist() {
         .search(
             query,
             SearchType::Playlist,
-            Some(Market::Country(Country::UnitedStates)),
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -495,7 +495,7 @@ async fn test_search_track() {
         .search(
             query,
             SearchType::Track,
-            Some(Market::Country(Country::UnitedStates)),
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -133,7 +133,7 @@ async fn test_category_playlists() {
 async fn test_current_playback() {
     oauth_client()
         .await
-        .current_playback(None, None)
+        .current_playback(None, Option::<&[_]>::None)
         .await
         .unwrap();
 }
@@ -417,8 +417,8 @@ async fn test_recommendations() {
             Some(seed_artists),
             None,
             Some(seed_tracks),
-            Some(10),
             Some(&Market::Country(Country::UnitedStates)),
+            Some(10),
         )
         .await
         .unwrap();

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -133,7 +133,7 @@ async fn test_category_playlists() {
 async fn test_current_playback() {
     oauth_client()
         .await
-        .current_playback(None, Option::<&[_]>::None)
+        .current_playback::<&[_]>(None, None)
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

* Leaves default parameter handling to Spotify, removing `.unwrap_or`
* Implements a macro for both query and json parameters so that endpoints are much nicer to read.
* Closes #134, we're consistently using `Option<T>` instead of `Into<Opton<T>>` now. If you don't like this please let me know, but I didn't get any more feedback so I went for the simpler option.

## Motivation and Context

* Default values should be assigned by the Spotify API instead by us, clearly. We shouldn't touch things we don't have to.
* As #127 said, endpoints should be as concise as possible because they're the most important part of the library after all, and it's important that they are easy to maintain.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] There are a couple new tests for the macros
