### PR TITLE
Pass parameters by reference and use iterators wherever possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,22 @@ If we missed any change or there's something you'd like to discuss about this ve
 - No default values are set from Rspotify now, they will be left to the Spotify API.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `collaborative` parameter to `user_playlist_create`.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `uris` parameter to `playlist_reorder_tracks`.
+- ([]()) Update the endpoint signatures to pass parameters by reference, affected endpoint list:
+    + `tracks`
+    + `artist_albums`
+    + `artist_albums_manual`
+    + `artist_top_tracks`
+    + `search`
+    + `playlist`
+    + `playlist_remove_specific_occurences_of_tracks`
+    + `featured_playlists`
+    + `recommendations`
+    + `current_playlist`
+    + `repeat`
+    + `get_seversal_shows`
+    + `get_an_episode`
+    + `get_several_episodes`
+    + `remove_users_saved_shows`
 
 ## 0.10 (2020/07/01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@ If we missed any change or there's something you'd like to discuss about this ve
 - No default values are set from Rspotify now, they will be left to the Spotify API.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `collaborative` parameter to `user_playlist_create`.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `uris` parameter to `playlist_reorder_tracks`.
-- ([]()) Update the endpoint signatures to pass parameters by reference, affected endpoint list:
+- ([#206](https://github.com/ramsayleung/rspotify/pull/206)) Update the endpoint signatures to pass parameters by reference, affected endpoint list:
     + `tracks`
     + `artist_albums`
     + `artist_albums_manual`

--- a/src/client.rs
+++ b/src/client.rs
@@ -865,7 +865,7 @@ impl Spotify {
             .map(|track| {
                 let mut map = Map::new();
                 map.insert("uri".to_owned(), track.id.uri().into());
-                map.insert("positions".to_owned(), track.positions.clone().into());
+                map.insert("positions".to_owned(), json!(track.positions));
                 map
             })
             .collect::<Vec<_>>();
@@ -2262,87 +2262,6 @@ mod test {
         assert_eq!(
             new_path,
             "me/player/shuffle?state=true&device_id=fdafdsadfa"
-        );
-    }
-
-    #[test]
-    fn test_cartesian_product() {
-        let attributes = [
-            "acousticness",
-            "danceability",
-            "duration_ms",
-            "energy",
-            "instrumentalness",
-            "key",
-            "liveness",
-            "loudness",
-            "mode",
-            "popularity",
-            "speechiness",
-            "tempo",
-            "time_signature",
-            "valence",
-        ];
-        let prefixes = ["min", "max", "target"];
-
-        let iterator_product_result = attributes
-            .iter()
-            .flat_map(|attribute| {
-                prefixes
-                    .iter()
-                    .map(move |prefix| format!("{}_{}", prefix, attribute))
-            })
-            .collect::<Vec<_>>();
-        let mut loop_product_result = vec![];
-        for attribute in attributes.iter() {
-            for prefix in prefixes.iter() {
-                let param = format!("{}_{}", prefix, attribute);
-                loop_product_result.push(param);
-            }
-        }
-        assert!(iterator_product_result
-            .iter()
-            .eq(loop_product_result.iter()));
-    }
-    #[test]
-    fn test_cartesian_product_and_filter_map() {
-        let attributes = [
-            "acousticness",
-            "danceability",
-            "duration_ms",
-            "energy",
-            "instrumentalness",
-            "key",
-            "liveness",
-            "loudness",
-            "mode",
-            "popularity",
-            "speechiness",
-            "tempo",
-            "time_signature",
-            "valence",
-        ];
-        let prefixes = ["min", "max", "target"];
-        let mut store = HashMap::new();
-        store.insert("min_valence".to_owned(), "foo".to_owned());
-        store.insert("max_tempo".to_owned(), "bar".to_owned());
-        let found_key_value = attributes
-            .iter()
-            .flat_map(|attribute| {
-                prefixes
-                    .iter()
-                    .map(move |prefix| format!("{}_{}", prefix, attribute))
-            })
-            .filter_map(|param| store.get(&param).map(|value| (param, value.to_owned())))
-            .collect::<HashMap<String, String>>();
-        assert_eq!(found_key_value.len(), 2);
-        assert_eq!(
-            found_key_value.get(&"min_valence".to_string()),
-            Some(&"foo".to_string())
-        );
-        assert_eq!(
-            found_key_value.get(&"max_tempo".to_string()),
-            Some(&"bar".to_string())
         );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -767,16 +767,16 @@ impl Spotify {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-reorder-or-replace-playlists-tracks)
     #[maybe_async]
-    pub async fn playlist_reorder_tracks(
+    pub async fn playlist_reorder_tracks<'a, T: PlayableIdType + 'a>(
         &self,
         playlist_id: &PlaylistId,
-        uris: Option<&[&Id<impl PlayableIdType>]>,
+        uris: Option<impl IntoIterator<Item = &'a Id<T>>>,
         range_start: Option<i32>,
         insert_before: Option<i32>,
         range_length: Option<u32>,
         snapshot_id: Option<&str>,
     ) -> ClientResult<PlaylistResult> {
-        let uris = uris.map(|u| u.iter().map(|id| id.uri()).collect::<Vec<_>>());
+        let uris = uris.map(|u| u.into_iter().map(|id| id.uri()).collect::<Vec<_>>());
         let params = build_json! {
             optional "uris": uris,
             optional "range_start": range_start,
@@ -1826,9 +1826,9 @@ impl Spotify {
     }
 
     #[maybe_async]
-    pub async fn start_uris_playback<T: PlayableIdType>(
+    pub async fn start_uris_playback<'a, T: PlayableIdType + 'a>(
         &self,
-        uris: &[&Id<T>],
+        uris: impl IntoIterator<Item = &'a Id<T>>,
         device_id: Option<&str>,
         offset: Option<super::model::Offset<T>>,
         position_ms: Option<u32>,
@@ -1836,7 +1836,7 @@ impl Spotify {
         use super::model::Offset;
 
         let params = build_json! {
-            "uris": uris.iter().map(|id| id.uri()).collect::<Vec<_>>(),
+            "uris": uris.into_iter().map(|id| id.uri()).collect::<Vec<_>>(),
             optional "position_ms": position_ms,
             optional "offset": offset.map(|x| match x {
                 Offset::Position(position) => json!({ "position": position }),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1623,7 +1623,7 @@ impl Spotify {
                 // might add quotes to the strings.
                 |param| payload.get(&param).map(|value| (param, value.to_string())),
             )
-            .collect::<HashMap<String, String>>();
+            .collect::<HashMap<_, _>>();
 
         for (ref key, ref value) in &map_to_hold_owned_value {
             params.insert(key, value);

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -85,7 +85,7 @@ async fn test_artists_albums() {
         .await
         .artist_albums_manual(
             birdy_uri,
-            Some(AlbumType::Album),
+            Some(&AlbumType::Album),
             Some(&Market::Country(Country::UnitedStates)),
             Some(10),
             None,
@@ -109,7 +109,7 @@ async fn test_artist_top_tracks() {
     let birdy_uri = Id::from_uri("spotify:artist:2WX2uTcsvV5OnS0inACecP").unwrap();
     creds_client()
         .await
-        .artist_top_tracks(birdy_uri, Market::Country(Country::UnitedStates))
+        .artist_top_tracks(birdy_uri, &Market::Country(Country::UnitedStates))
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -30,6 +30,7 @@ use rspotify::{
 
 use chrono::prelude::*;
 use maybe_async::maybe_async;
+use serde_json::map::Map;
 use std::env;
 
 /// Generating a new OAuth client for the requests.
@@ -414,7 +415,7 @@ async fn test_recommendations() {
         .recommendations(
             &payload,
             Some(seed_artists),
-            None::<&[&str]>,
+            None::<Vec<&str>>,
             Some(seed_tracks),
             Some(&Market::Country(Country::UnitedStates)),
             Some(10),

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -18,7 +18,6 @@ mod common;
 
 use common::maybe_async_test;
 use rspotify::model::offset::Offset;
-use rspotify::model::AdditionalType;
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder, TokenBuilder};
 use rspotify::{
     client::{Spotify, SpotifyBuilder},
@@ -31,7 +30,6 @@ use rspotify::{
 
 use chrono::prelude::*;
 use maybe_async::maybe_async;
-use serde_json::map::Map;
 use std::env;
 
 /// Generating a new OAuth client for the requests.
@@ -145,7 +143,7 @@ async fn test_current_playback() {
 async fn test_current_playing() {
     oauth_client()
         .await
-        .current_playing(None, None::<Box<dyn Iterator<Item = &AdditionalType>>>)
+        .current_playing(None, None::<&[_]>)
         .await
         .unwrap();
 }
@@ -416,7 +414,7 @@ async fn test_recommendations() {
         .recommendations(
             &payload,
             Some(seed_artists),
-            None::<Box<dyn Iterator<Item = &str>>>,
+            None::<&[&str]>,
             Some(seed_tracks),
             Some(&Market::Country(Country::UnitedStates)),
             Some(10),

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -18,6 +18,7 @@ mod common;
 
 use common::maybe_async_test;
 use rspotify::model::offset::Offset;
+use rspotify::model::AdditionalType;
 use rspotify::oauth2::{CredentialsBuilder, OAuthBuilder, TokenBuilder};
 use rspotify::{
     client::{Spotify, SpotifyBuilder},
@@ -144,7 +145,7 @@ async fn test_current_playback() {
 async fn test_current_playing() {
     oauth_client()
         .await
-        .current_playing(None, None)
+        .current_playing(None, None::<Box<dyn Iterator<Item = &AdditionalType>>>)
         .await
         .unwrap();
 }
@@ -331,7 +332,7 @@ async fn test_featured_playlists() {
     let now: DateTime<Utc> = Utc::now();
     oauth_client()
         .await
-        .featured_playlists(None, None, Some(now), Some(10), Some(0))
+        .featured_playlists(None, None, Some(&now), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -415,7 +416,7 @@ async fn test_recommendations() {
         .recommendations(
             &payload,
             Some(seed_artists),
-            None,
+            None::<Box<dyn Iterator<Item = &str>>>,
             Some(seed_tracks),
             Some(10),
             Some(Market::Country(Country::UnitedStates)),
@@ -430,7 +431,7 @@ async fn test_recommendations() {
 async fn test_repeat() {
     oauth_client()
         .await
-        .repeat(RepeatState::Context, None)
+        .repeat(&RepeatState::Context, None)
         .await
         .unwrap();
 }
@@ -442,7 +443,7 @@ async fn test_search_album() {
     let query = "album:arrival artist:abba";
     oauth_client()
         .await
-        .search(query, SearchType::Album, None, None, Some(10), Some(0))
+        .search(query, &SearchType::Album, None, None, Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -456,8 +457,8 @@ async fn test_search_artist() {
         .await
         .search(
             query,
-            SearchType::Artist,
-            Some(Market::Country(Country::UnitedStates)),
+            &SearchType::Artist,
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -475,8 +476,8 @@ async fn test_search_playlist() {
         .await
         .search(
             query,
-            SearchType::Playlist,
-            Some(Market::Country(Country::UnitedStates)),
+            &SearchType::Playlist,
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -494,8 +495,8 @@ async fn test_search_track() {
         .await
         .search(
             query,
-            SearchType::Track,
-            Some(Market::Country(Country::UnitedStates)),
+            &SearchType::Track,
+            Some(&Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -716,19 +717,18 @@ async fn test_playlist_remove_all_occurrences_of_tracks() {
 #[ignore]
 async fn test_playlist_remove_specific_occurrences_of_tracks() {
     let playlist_id = Id::from_id("5jAOgWXCBKuinsGiZxjDQ5").unwrap();
-    let tracks = vec![
-        TrackPositions::new(
-            Id::from_uri("spotify:track:4iV5W9uYEdYUVa79Axb7Rh").unwrap(),
-            vec![0, 3],
-        ),
-        TrackPositions::new(
-            Id::from_uri("spotify:track:1301WleyT98MSxVHPZCA6M").unwrap(),
-            vec![7],
-        ),
-    ];
+    let track_position_0_3 = TrackPositions::new(
+        Id::from_uri("spotify:track:4iV5W9uYEdYUVa79Axb7Rh").unwrap(),
+        vec![0, 3],
+    );
+    let track_position_7 = TrackPositions::new(
+        Id::from_uri("spotify:track:1301WleyT98MSxVHPZCA6M").unwrap(),
+        vec![7],
+    );
+    let tracks = vec![&track_position_0_3, &track_position_7];
     oauth_client()
         .await
-        .playlist_remove_specific_occurrences_of_tracks(playlist_id, tracks, None)
+        .playlist_remove_specific_occurrences_of_tracks(&playlist_id, tracks, None::<&str>)
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -527,7 +527,7 @@ async fn test_start_playback() {
     let uris = vec![TrackId::from_uri("spotify:track:4iV5W9uYEdYUVa79Axb7Rh").unwrap()];
     oauth_client()
         .await
-        .start_uris_playback(&uris, Some(device_id), Some(Offset::for_position(0)), None)
+        .start_uris_playback(uris, Some(device_id), Some(Offset::for_position(0)), None)
         .await
         .unwrap();
 }
@@ -676,7 +676,7 @@ async fn test_playlist_follow_playlist() {
 #[maybe_async_test]
 #[ignore]
 async fn test_playlist_recorder_tracks() {
-    let uris: Option<&[&EpisodeId]> = None;
+    let uris = Some(vec![EpisodeId::from_id("0lbiy3LKzIY2fnyjioC11p").unwrap()]);
     let playlist_id = Id::from_id("5jAOgWXCBKuinsGiZxjDQ5").unwrap();
     let range_start = 0;
     let insert_before = 1;

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -728,7 +728,7 @@ async fn test_playlist_remove_specific_occurrences_of_tracks() {
     let tracks = vec![&track_position_0_3, &track_position_7];
     oauth_client()
         .await
-        .playlist_remove_specific_occurrences_of_tracks(&playlist_id, tracks, None::<&str>)
+        .playlist_remove_specific_occurrences_of_tracks(playlist_id, tracks, None::<&str>)
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

Currently the parameters mostly are passed by value, which means the compiler will `Copy` the parameter when passes them into a method, it's a little inefficient, then pass them by reference instead.

Using iterators wherever possible, since it's more atomic and rusty.

Fixed #127 

## Motivation and Context

Improve the efficiency of this library.

## Dependencies 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] All existing tests pass.
- [x] Add some tests for iterator