### PR TITLE
Fix  not adding auth headers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -960,7 +960,7 @@ impl Spotify {
         &self,
     ) -> ClientResult<Option<CurrentlyPlayingContext>> {
         let result = self
-            .get("me/player/currently-playing", None, &Query::new())
+            .endpoint_get("me/player/currently-playing", &Query::new())
             .await?;
         if result.is_empty() {
             Ok(None)


### PR DESCRIPTION
## Description

Due to an issue with the method `current_user_playing_track` it does not add the auth headers required by spotify

## Motivation and Context

I have also created an issue #208 where the issue is explained.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

See #208 and run it with this patch it should return the `CurrentPlayingContext` struct.
