### PR TITLE
Support re-authenticate automatically and refresh token when it expired.

### DIFF
--- a/examples/webapp/Cargo.toml
+++ b/examples/webapp/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Ramsay <ramsayleung@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-rocket = "0.4.5"
-rocket_contrib = { version = "0.4.5", features = ["tera_templates"] }
+
+rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket_dyn_templates={ version = "0.1.0-rc.1", features = ["tera", "handlebars"] }
 getrandom = "0.2.0"
 # Rocket is synchronous, so this uses the `ureq` client
 rspotify = { path = "../..", features = ["client-ureq", "ureq-rustls-tls"], default-features = false }

--- a/examples/with_refresh_token.rs
+++ b/examples/with_refresh_token.rs
@@ -110,7 +110,7 @@ async fn main() {
         .expect("couldn't refresh user token");
 
     let now = Utc::now();
-    now.checked_sub_signed(Duration::seconds(1));
+    now.checked_sub_signed(Duration::seconds(10));
     spotify.get_token_mut().await.as_mut().unwrap().expires_at = Some(now);
     println!(">>> The token should expire, then re-auth automatically");
     do_things(spotify).await;

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -80,7 +80,7 @@ impl BaseClient for AuthCodeSpotify {
         self.token.borrow()
     }
 
-    async fn get_token_mut(&mut self) -> RefMut<Option<Token>> {
+    async fn get_token_mut(&self) -> RefMut<Option<Token>> {
         self.token.borrow_mut()
     }
 

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -103,7 +103,7 @@ impl OAuthClient for AuthCodeSpotify {
 
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
-    async fn request_token(&mut self, code: &str) -> ClientResult<()> {
+    async fn request_token(&self, code: &str) -> ClientResult<()> {
         let mut data = Form::new();
         let oauth = self.get_oauth();
         let scopes = oauth
@@ -127,7 +127,7 @@ impl OAuthClient for AuthCodeSpotify {
     /// Refreshes the current access token given a refresh token.
     ///
     /// The obtained token will be saved internally.
-    async fn refresh_token(&mut self, refresh_token: &str) -> ClientResult<()> {
+    async fn refresh_token(&self, refresh_token: &str) -> ClientResult<()> {
         let mut data = Form::new();
         data.insert(headers::REFRESH_TOKEN, refresh_token);
         data.insert(headers::GRANT_TYPE, headers::GRANT_REFRESH_TOKEN);

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -76,11 +76,11 @@ impl BaseClient for AuthCodeSpotify {
         &self.http
     }
 
-    fn get_token(&self) -> Option<&Token> {
+    async fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
+    async fn get_token_mut(&mut self) -> Option<&mut Token> {
         self.token.as_mut()
     }
 
@@ -121,7 +121,7 @@ impl OAuthClient for AuthCodeSpotify {
         let token = self.fetch_access_token(&data).await?;
         self.token = Some(token);
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 
     /// Refreshes the current access token given a refresh token.
@@ -136,7 +136,7 @@ impl OAuthClient for AuthCodeSpotify {
         token.refresh_token = Some(refresh_token.to_string());
         self.token = Some(token);
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 }
 

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -34,16 +34,17 @@ pub struct AuthCodePkceSpotify {
 }
 
 /// This client has access to the base methods.
+#[maybe_async(?Send)]
 impl BaseClient for AuthCodePkceSpotify {
     fn get_http(&self) -> &HttpClient {
         &self.http
     }
 
-    fn get_token(&self) -> Option<&Token> {
+    async fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
+    async fn get_token_mut(&mut self) -> Option<&mut Token> {
         self.token.as_mut()
     }
 
@@ -83,7 +84,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         let token = self.fetch_access_token(&data).await?;
         self.token = Some(token);
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 
     async fn refresh_token(&mut self, refresh_token: &str) -> ClientResult<()> {
@@ -96,7 +97,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         token.refresh_token = Some(refresh_token.to_string());
         self.token = Some(token);
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 }
 

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -66,7 +66,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         &self.oauth
     }
 
-    async fn request_token(&mut self, code: &str) -> ClientResult<()> {
+    async fn request_token(&self, code: &str) -> ClientResult<()> {
         // TODO
         let mut data = Form::new();
         let oauth = self.get_oauth();
@@ -88,7 +88,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         self.write_token_cache().await
     }
 
-    async fn refresh_token(&mut self, refresh_token: &str) -> ClientResult<()> {
+    async fn refresh_token(&self, refresh_token: &str) -> ClientResult<()> {
         // TODO
         let mut data = Form::new();
         data.insert(headers::REFRESH_TOKEN, refresh_token);

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -45,7 +45,7 @@ impl BaseClient for AuthCodePkceSpotify {
         self.token.borrow()
     }
 
-    async fn get_token_mut(&mut self) -> RefMut<Option<Token>> {
+    async fn get_token_mut(&self) -> RefMut<Option<Token>> {
         self.token.borrow_mut()
     }
 

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -39,7 +39,7 @@ impl BaseClient for ClientCredsSpotify {
         self.token.borrow()
     }
 
-    async fn get_token_mut(&mut self) -> RefMut<Option<Token>> {
+    async fn get_token_mut(&self) -> RefMut<Option<Token>> {
         self.token.borrow_mut()
     }
 

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -28,16 +28,17 @@ pub struct ClientCredsSpotify {
 }
 
 /// This client has access to the base methods.
+#[maybe_async(?Send)]
 impl BaseClient for ClientCredsSpotify {
     fn get_http(&self) -> &HttpClient {
         &self.http
     }
 
-    fn get_token(&self) -> Option<&Token> {
+    async fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
+    async fn get_token_mut(&mut self) -> Option<&mut Token> {
         self.token.as_mut()
     }
 
@@ -109,6 +110,6 @@ impl ClientCredsSpotify {
 
         self.token = Some(self.fetch_access_token(&data).await?);
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 }

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -27,7 +27,7 @@ where
     fn get_config(&self) -> &Config;
     fn get_http(&self) -> &HttpClient;
     async fn get_token(&self) -> Ref<Option<Token>>;
-    async fn get_token_mut(&mut self) -> RefMut<Option<Token>>;
+    async fn get_token_mut(&self) -> RefMut<Option<Token>>;
     fn get_creds(&self) -> &Credentials;
 
     /// If it's a relative URL like "me", the prefix is appended to it.

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -116,8 +116,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_auth_headers() {
+    #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
+    async fn test_auth_headers() {
         let tok = Token {
             access_token: "test-access_token".to_string(),
             expires_in: Duration::seconds(1),
@@ -127,7 +127,7 @@ mod test {
         };
 
         let spotify = ClientCredsSpotify::from_token(tok);
-        let headers = spotify.auth_headers().unwrap();
+        let headers = spotify.auth_headers().await.unwrap();
         assert_eq!(
             headers.get("authorization"),
             Some(&"Bearer test-access_token".to_owned())

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -31,6 +31,9 @@ use url::Url;
 pub trait OAuthClient: BaseClient {
     fn get_oauth(&self) -> &OAuth;
 
+    /// Re-authenticate automatically if it's configured to do so, which uses the refresh token to obtain a new access token.
+    async fn auto_reauth(&self) -> ClientResult<()>;
+
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
     async fn request_token(&self, code: &str) -> ClientResult<()>;

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -38,6 +38,9 @@ pub trait OAuthClient: BaseClient {
     /// authentication. The access token will be saved internally.
     async fn request_token(&self, code: &str) -> ClientResult<()>;
 
+    /// Refetch the current access token given a refresh token
+    async fn refetch_token(&self, refresh_token: &str) -> ClientResult<Token>;
+
     /// Refreshes the current access token given a refresh token. The obtained
     /// token will be saved internally.
     async fn refresh_token(&self, refresh_token: &str) -> ClientResult<()>;

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -33,11 +33,11 @@ pub trait OAuthClient: BaseClient {
 
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
-    async fn request_token(&mut self, code: &str) -> ClientResult<()>;
+    async fn request_token(&self, code: &str) -> ClientResult<()>;
 
     /// Refreshes the current access token given a refresh token. The obtained
     /// token will be saved internally.
-    async fn refresh_token(&mut self, refresh_token: &str) -> ClientResult<()>;
+    async fn refresh_token(&self, refresh_token: &str) -> ClientResult<()>;
 
     /// Tries to read the cache file's token, which may not exist.
     async fn read_token_cache(&mut self) -> Option<Token> {

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -102,8 +102,8 @@ pub trait OAuthClient: BaseClient {
     async fn prompt_for_token(&mut self, url: &str) -> ClientResult<()> {
         match self.read_token_cache().await {
             // TODO: shouldn't this also refresh the obtained token?
-            Some(ref mut new_token) => {
-                self.get_token_mut().replace(new_token);
+            Some(new_token) => {
+                self.get_token_mut().await.replace(new_token);
             }
             // Otherwise following the usual procedure to get the token.
             None => {
@@ -113,7 +113,7 @@ pub trait OAuthClient: BaseClient {
             }
         }
 
-        self.write_token_cache()
+        self.write_token_cache().await
     }
 
     /// Get current user playlists without required getting his profile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,11 @@ impl Token {
         self.expires_at
             .map_or(true, |x| Utc::now().timestamp() > x.timestamp())
     }
+
+    /// Check if the token is ready to re-authenticate automatically
+    pub fn is_capable_to_reauth(&self) -> bool {
+        self.is_expired() && self.refresh_token.is_some()
+    }
 }
 
 /// Simple client credentials object for Spotify.

--- a/tests/test_oauth2.rs
+++ b/tests/test_oauth2.rs
@@ -54,7 +54,7 @@ async fn test_read_token_cache() {
     predefined_spotify.config = config.clone();
 
     // write token data to cache_path
-    predefined_spotify.write_token_cache().unwrap();
+    predefined_spotify.write_token_cache().await.unwrap();
     assert!(predefined_spotify.config.cache_path.exists());
 
     let mut spotify = ClientCredsSpotify::default();
@@ -93,7 +93,7 @@ fn test_write_token() {
     spotify.config = config;
 
     let tok_str = serde_json::to_string(&tok).unwrap();
-    spotify.write_token_cache().unwrap();
+    spotify.write_token_cache().await.unwrap();
 
     let mut file = fs::File::open(&spotify.config.cache_path).unwrap();
     let mut tok_str_file = String::new();


### PR DESCRIPTION
## Description

Fixed #223 and #4, since @marioortizmanero already implemented the cache token feature, what I need to do is implement the re-authenticate feature and refresh token when it expired.

To be honest, it's a little hard to implement than I expect before. The major problem is that to maintain a mutable token inside the immutable client.

+ `Cell<T>` doesn't work as expected, since it requires the types that implement `Copy` trait, but `Token` doesn't implement the `Copy` trait and has no way to do so. Since the String type doesn't implement.
+ `Mutex<T>` seems to be unnecessary, for that we don't need to handle the shared-state between threads(or we should do so?)
+ `RefCell<T>` is great, it looks pretty suitable for our case, but it also follows Rust borrow-check rules, even though the check delays to runtime:
> At any given time, you can have either (but not both of) one mutable reference or any number of immutable references.

So the following code will fail:

```rust
let c = RefCell::new(5);
let m = c.borrow();

let b = c.borrow_mut(); // this causes a panic
```
Thus, we need to take good care of the borrowed immutable reference and borrowed mutable reference.

And there are a little `TODO` items I left to discuss, I am not sure which way should we choose:

+ I change the function signature of `request_token/refresh_token` from `&mut self` to `&self`, so we have an immutable client now. But the trade-off is we use `borrow_mut` internally, which means we leave the immutable or mutable borrows checked at runtime, we are in charge of compiler's jobs. It looks like a landmine, will bomb someday by mistake.

## Motivation and Context

+ #176
+ #4 
+ #223  

## Dependencies 

Nope

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] Test A: examples/with_refresh_token
