### PR TITLE
Refresh token with Rwlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,11 @@ required-features = ["env-file", "cli", "client-ureq"]
 path = "examples/ureq/seek_track.rs"
 
 [[example]]
+name = "threading"
+required-features = ["env-file", "cli", "client-ureq"]
+path = "examples/ureq/threading.rs"
+
+[[example]]
 name = "pagination_manual"
 required-features = ["env-file", "cli", "client-reqwest"]
 path = "examples/pagination_manual.rs"

--- a/examples/ureq/threading.rs
+++ b/examples/ureq/threading.rs
@@ -1,0 +1,45 @@
+//! This example showcases how the Rspotify client can be used to perform
+//! multithreaded requests as well.
+
+use rspotify::{model::Id, prelude::*, ClientCredsSpotify, Credentials};
+use std::{
+    sync::{mpsc::channel, Arc},
+    thread,
+};
+
+fn main() {
+    let creds = Credentials::from_env().unwrap();
+
+    let mut spotify = ClientCredsSpotify::new(creds);
+    let ids = [
+        Id::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap(),
+        Id::from_uri("spotify:album:5EBb7SSkPgxO9Lmt8NjAPT").unwrap(),
+        Id::from_uri("spotify:album:3jtOeny1Xh5fp6aSOHahe2").unwrap(),
+    ];
+    let mut handles = Vec::new();
+    let (wr, rd) = channel();
+
+    spotify.request_token().unwrap();
+
+    // Performing the requests concurrently
+    let spotify = Arc::new(spotify);
+    for id in ids {
+        let spotify = Arc::clone(&spotify);
+        let wr = wr.clone();
+        let handle = thread::spawn(move || {
+            let albums = spotify.album(id).unwrap();
+            wr.send(albums).unwrap();
+        });
+
+        handles.push(handle);
+    }
+
+    for _ in ids {
+        let album = rd.recv().unwrap();
+        println!("Album: {}", album.name);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}

--- a/examples/with_refresh_token.rs
+++ b/examples/with_refresh_token.rs
@@ -69,8 +69,8 @@ async fn main() {
         .await
         .expect("couldn't authenticate successfully");
     let refresh_token = spotify
-        .token
-        .borrow()
+        .get_token()
+        .await
         .as_ref()
         .unwrap()
         .refresh_token
@@ -111,7 +111,7 @@ async fn main() {
 
     let now = Utc::now();
     now.checked_sub_signed(Duration::seconds(10));
-    spotify.get_token_mut().await.as_mut().unwrap().expires_at = Some(now);
+    spotify.get_token_mut().as_mut().unwrap().expires_at = Some(now);
     println!(">>> The token should expire, then re-auth automatically");
     do_things(spotify).await;
 }

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -91,14 +91,14 @@ impl BaseClient for AuthCodeSpotify {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.read().unwrap()
+        self.token.read().expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.write().unwrap()
+        self.token.write().expect("Failed to write token; the lock has been poisoned")
     }
 }
 

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -91,14 +91,18 @@ impl BaseClient for AuthCodeSpotify {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.read().expect("Failed to read token; the lock has been poisoned")
+        self.token
+            .read()
+            .expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.write().expect("Failed to write token; the lock has been poisoned")
+        self.token
+            .write()
+            .expect("Failed to write token; the lock has been poisoned")
     }
 }
 

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -6,10 +6,12 @@ use crate::{
     ClientResult, Config, Credentials, OAuth, Token,
 };
 
+use std::{
+    collections::HashMap,
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
 use maybe_async::maybe_async;
-use std::cell::{Ref, RefCell, RefMut};
-use std::collections::HashMap;
-use std::rc::Rc;
 use url::Url;
 
 /// The [Authorization Code Flow](reference) client for the Spotify API.
@@ -61,12 +63,12 @@ use url::Url;
 /// [example-main]: https://github.com/ramsayleung/rspotify/blob/master/examples/auth_code.rs
 /// [example-webapp]: https://github.com/ramsayleung/rspotify/tree/master/examples/webapp
 /// [example-refresh-token]: https://github.com/ramsayleung/rspotify/blob/master/examples/with_refresh_token.rs
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct AuthCodeSpotify {
     pub creds: Credentials,
     pub oauth: OAuth,
     pub config: Config,
-    pub token: Rc<RefCell<Option<Token>>>,
+    pub token: RwLock<Option<Token>>,
     pub(in crate) http: HttpClient,
 }
 
@@ -85,18 +87,18 @@ impl BaseClient for AuthCodeSpotify {
         &self.config
     }
 
-    async fn get_token(&self) -> Ref<Option<Token>> {
+    async fn get_token(&self) -> RwLockReadGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.borrow()
+        self.token.read().unwrap()
     }
 
-    async fn get_token_mut(&self) -> RefMut<Option<Token>> {
+    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.borrow_mut()
+        self.token.write().unwrap()
     }
 }
 
@@ -111,7 +113,7 @@ impl OAuthClient for AuthCodeSpotify {
     async fn auto_reauth(&self) -> ClientResult<()> {
         // Rust only allow us to have one mutable reference or multiple
         // immutable reference once, so extract it early.
-        let mut token = self.token.borrow_mut();
+        let mut token = self.get_token_mut();
         if self.config.token_refreshing
             && token
                 .as_ref()
@@ -148,7 +150,7 @@ impl OAuthClient for AuthCodeSpotify {
         data.insert(headers::STATE, oauth.state.as_ref());
 
         let token = self.fetch_access_token(&data).await?;
-        *self.token.borrow_mut() = Some(token);
+        *self.get_token_mut() = Some(token);
 
         self.write_token_cache().await
     }
@@ -169,7 +171,7 @@ impl OAuthClient for AuthCodeSpotify {
     /// The obtained token will be saved internally.
     async fn refresh_token(&self, refresh_token: &str) -> ClientResult<()> {
         let token = self.refetch_token(refresh_token).await?;
-        *self.token.borrow_mut() = Some(token);
+        *self.get_token_mut() = Some(token);
 
         self.write_token_cache().await
     }
@@ -191,7 +193,7 @@ impl AuthCodeSpotify {
     /// client credentials aren't known.
     pub fn from_token(token: Token) -> Self {
         AuthCodeSpotify {
-            token: Rc::new(RefCell::new(Some(token))),
+            token: RwLock::new(Some(token)),
             ..Default::default()
         }
     }

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -96,10 +96,7 @@ impl BaseClient for AuthCodeSpotify {
             .expect("Failed to read token; the lock has been poisoned")
     }
 
-    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
-        self.auto_reauth()
-            .await
-            .expect("Failed to re-authenticate automatically, please authenticate");
+    fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.token
             .write()
             .expect("Failed to write token; the lock has been poisoned")

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -47,14 +47,18 @@ impl BaseClient for AuthCodePkceSpotify {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.read().expect("Failed to read token; the lock has been poisoned")
+        self.token
+            .read()
+            .expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.write().expect("Failed to write token; the lock has been poisoned")
+        self.token
+            .write()
+            .expect("Failed to write token; the lock has been poisoned")
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -52,10 +52,7 @@ impl BaseClient for AuthCodePkceSpotify {
             .expect("Failed to read token; the lock has been poisoned")
     }
 
-    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
-        self.auto_reauth()
-            .await
-            .expect("Failed to re-authenticate automatically, please authenticate");
+    fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.token
             .write()
             .expect("Failed to write token; the lock has been poisoned")

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -47,14 +47,14 @@ impl BaseClient for AuthCodePkceSpotify {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.read().unwrap()
+        self.token.read().expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.auto_reauth()
             .await
             .expect("Failed to re-authenticate automatically, please authenticate");
-        self.token.write().unwrap()
+        self.token.write().expect("Failed to write token; the lock has been poisoned")
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -37,11 +37,15 @@ impl BaseClient for ClientCredsSpotify {
     }
 
     async fn get_token(&self) -> RwLockReadGuard<Option<Token>> {
-        self.token.read().expect("Failed to read token; the lock has been poisoned")
+        self.token
+            .read()
+            .expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
-        self.token.write().expect("Failed to write token; the lock has been poisoned")
+        self.token
+            .write()
+            .expect("Failed to write token; the lock has been poisoned")
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -37,11 +37,11 @@ impl BaseClient for ClientCredsSpotify {
     }
 
     async fn get_token(&self) -> RwLockReadGuard<Option<Token>> {
-        self.token.read().unwrap()
+        self.token.read().expect("Failed to read token; the lock has been poisoned")
     }
 
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
-        self.token.write().unwrap()
+        self.token.write().expect("Failed to write token; the lock has been poisoned")
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -42,7 +42,7 @@ impl BaseClient for ClientCredsSpotify {
             .expect("Failed to read token; the lock has been poisoned")
     }
 
-    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
+    fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
         self.token
             .write()
             .expect("Failed to write token; the lock has been poisoned")

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -5,8 +5,9 @@ use crate::{
     ClientResult, Config, Credentials, Token,
 };
 
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
 use maybe_async::maybe_async;
-use std::cell::{Ref, RefCell, RefMut};
 
 /// The [Client Credentials Flow][reference] client for the Spotify API.
 ///
@@ -20,11 +21,11 @@ use std::cell::{Ref, RefCell, RefMut};
 ///
 /// [reference]: https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
 /// [example-main]: https://github.com/ramsayleung/rspotify/blob/master/examples/client_creds.rs
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ClientCredsSpotify {
     pub config: Config,
     pub creds: Credentials,
-    pub token: RefCell<Option<Token>>,
+    pub token: RwLock<Option<Token>>,
     pub(in crate) http: HttpClient,
 }
 
@@ -35,12 +36,12 @@ impl BaseClient for ClientCredsSpotify {
         &self.http
     }
 
-    async fn get_token(&self) -> Ref<Option<Token>> {
-        self.token.borrow()
+    async fn get_token(&self) -> RwLockReadGuard<Option<Token>> {
+        self.token.read().unwrap()
     }
 
-    async fn get_token_mut(&self) -> RefMut<Option<Token>> {
-        self.token.borrow_mut()
+    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>> {
+        self.token.write().unwrap()
     }
 
     fn get_creds(&self) -> &Credentials {
@@ -67,7 +68,7 @@ impl ClientCredsSpotify {
     /// as the client credentials aren't known.
     pub fn from_token(token: Token) -> Self {
         ClientCredsSpotify {
-            token: RefCell::new(Some(token)),
+            token: RwLock::new(Some(token)),
             ..Default::default()
         }
     }
@@ -109,7 +110,7 @@ impl ClientCredsSpotify {
         let mut data = Form::new();
         data.insert(headers::GRANT_TYPE, headers::GRANT_CLIENT_CREDS);
 
-        *self.token.borrow_mut() = Some(self.fetch_access_token(&data).await?);
+        *self.get_token_mut() = Some(self.fetch_access_token(&data).await?);
 
         self.write_token_cache().await
     }

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -33,13 +33,12 @@ where
     /// You may notice two things upon seeing the function signature of
     /// `get_token`:
     ///
-    /// 1. They're getters but use `async`
-    /// 2. They return a `RwLockReadGuard`
+    /// 1. It's a getter but it uses `async`
+    /// 2. It returns a `RwLockReadGuard`
     ///
-    /// Firstly, the getters are async because of the self-refreshing feature.
-    /// If activated, the token may be automatically refreshed when these
-    /// getters are called, which may perform requests that can be handled
-    /// asynchronously.
+    /// Firstly, the getter is async because of the self-refreshing feature. If
+    /// activated, the token may be automatically refreshed when the getter is
+    /// called, which may perform requests that can be handled asynchronously.
     ///
     /// Secondly, the token is wrapped by a `RwLock` in order to allow interior
     /// mutability. This is required so that the entire client doesn't have to

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -30,7 +30,24 @@ where
 {
     fn get_config(&self) -> &Config;
     fn get_http(&self) -> &HttpClient;
-    // TODO: explain the rwlock
+    /// You may notice two things upon seeing the function signature of
+    /// `get_token` and `get_token_mut`:
+    ///
+    /// 1. They're getters but use `async`
+    /// 2. They return a `RwLockReadGuard`
+    ///
+    /// Firstly, the getters are async because of the self-refreshing feature.
+    /// If activated, the token may be automatically refreshed when these
+    /// getters are called, which may perform requests that can be handled
+    /// asynchronously.
+    ///
+    /// Secondly, the token is wrapped by a `RwLock` in order to allow interior
+    /// mutability. This is required so that the entire client doesn't have to
+    /// be mutable (the token is accessed to from every endpoint). Unlike a
+    /// mutex, this allows multiple reads at the same time, which will be
+    /// happening most times. It is also preferred to use a `RwLock` over a
+    /// `RefCell` because that way it is possible to use the Spotify client
+    /// concurrently.
     async fn get_token(&self) -> RwLockReadGuard<Option<Token>>;
     async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>>;
     fn get_creds(&self) -> &Credentials;

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -10,11 +10,15 @@ use crate::{
     ClientResult, Config, Credentials, Token,
 };
 
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{RwLockReadGuard, RwLockWriteGuard},
+};
+
 use chrono::Utc;
 use maybe_async::maybe_async;
 use serde_json::{Map, Value};
-use std::cell::{Ref, RefMut};
-use std::{collections::HashMap, fmt};
 
 /// This trait implements the basic endpoints from the Spotify API that may be
 /// accessed without user authorization, including parts of the authentication
@@ -22,12 +26,13 @@ use std::{collections::HashMap, fmt};
 #[maybe_async(?Send)]
 pub trait BaseClient
 where
-    Self: Default + Clone + fmt::Debug,
+    Self: Default + fmt::Debug,
 {
     fn get_config(&self) -> &Config;
     fn get_http(&self) -> &HttpClient;
-    async fn get_token(&self) -> Ref<Option<Token>>;
-    async fn get_token_mut(&self) -> RefMut<Option<Token>>;
+    // TODO: explain the rwlock
+    async fn get_token(&self) -> RwLockReadGuard<Option<Token>>;
+    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>>;
     fn get_creds(&self) -> &Credentials;
 
     /// If it's a relative URL like "me", the prefix is appended to it.

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -31,7 +31,7 @@ where
     fn get_config(&self) -> &Config;
     fn get_http(&self) -> &HttpClient;
     /// You may notice two things upon seeing the function signature of
-    /// `get_token` and `get_token_mut`:
+    /// `get_token`:
     ///
     /// 1. They're getters but use `async`
     /// 2. They return a `RwLockReadGuard`
@@ -48,8 +48,11 @@ where
     /// happening most times. It is also preferred to use a `RwLock` over a
     /// `RefCell` because that way it is possible to use the Spotify client
     /// concurrently.
+    ///
+    /// Note that this isn't required for `get_token_mut` because in that case
+    /// the token is going to be overwritten anyway.
     async fn get_token(&self) -> RwLockReadGuard<Option<Token>>;
-    async fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>>;
+    fn get_token_mut(&self) -> RwLockWriteGuard<Option<Token>>;
     fn get_creds(&self) -> &Credentials;
 
     /// If it's a relative URL like "me", the prefix is appended to it.

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -105,7 +105,7 @@ pub trait OAuthClient: BaseClient {
     async fn prompt_for_token(&mut self, url: &str) -> ClientResult<()> {
         match self.read_token_cache().await {
             Some(new_token) => {
-                self.get_token_mut().await.replace(new_token);
+                self.get_token_mut().replace(new_token);
             }
             // Otherwise following the usual procedure to get the token.
             None => {


### PR DESCRIPTION
This is my attempt at #224 with a RwLock to enable concurrency.

The main drawback is that we can't derive `Clone` for the clients. But it allows concurrency for the client, which may be a must for blocking clients?