### PR TITLE
Fix new clippy warnings about references

### DIFF
--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -36,7 +36,7 @@ impl UreqClient {
         // Setting the headers, which will be the token auth if unspecified.
         if let Some(headers) = headers {
             for (key, val) in headers.iter() {
-                request = request.set(&key, &val);
+                request = request.set(key, val);
             }
         }
 
@@ -59,7 +59,7 @@ impl BaseHttpClient for UreqClient {
         let request = ureq::get(url);
         let sender = |mut req: Request| {
             for (key, val) in payload.iter() {
-                req = req.query(&key, &val)
+                req = req.query(key, val)
             }
             req.call()
         };

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -955,7 +955,7 @@ where
             )
             .collect::<HashMap<_, _>>();
 
-        for (ref key, ref value) in &map_to_hold_owned_value {
+        for (key, value) in &map_to_hold_owned_value {
             params.insert(key, value);
         }
 

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -69,7 +69,7 @@ pub trait OAuthClient: BaseClient {
     fn get_code_from_user(&self, url: &str) -> ClientResult<String> {
         use crate::ClientError;
 
-        match webbrowser::open(&url) {
+        match webbrowser::open(url) {
             Ok(_) => println!("Opened {} in your browser.", url),
             Err(why) => eprintln!(
                 "Error when trying to open an URL in your browser: {:?}. \
@@ -623,7 +623,7 @@ pub trait OAuthClient: BaseClient {
             optional "offset": offset.as_deref(),
         };
 
-        let result = self.endpoint_get(&"me/top/artists", &params).await?;
+        let result = self.endpoint_get("me/top/artists", &params).await?;
         convert_result(&result)
     }
 


### PR DESCRIPTION
## Description

Clippy apparently includes new warnings about references to references and similars. This PR fixes all of them so that the CI continues to pass.

## Dependencies 
None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The clippy CI passes