### PR TITLE
Fix IDs v2

### DIFF
--- a/rspotify-model/src/context.rs
+++ b/rspotify-model/src/context.rs
@@ -8,15 +8,15 @@ use std::time::Duration;
 
 use crate::{
     millisecond_timestamp, option_duration_ms, CurrentlyPlayingType, Device, DisallowKey, IdBuf,
-    PlayableIdType, PlayableItem, RepeatState, Type,
+    PlayableIdBuf, PlayableItem, RepeatState, Type,
 };
 
 /// Context object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Context<T> {
-    pub id: IdBuf<T>,
+pub struct Context<T: IdBuf> {
+    pub id: T,
     pub href: String,
     pub external_urls: HashMap<String, String>,
     #[serde(rename = "type")]
@@ -27,7 +27,7 @@ pub struct Context<T> {
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CurrentlyPlayingContext<T: PlayableIdType> {
+pub struct CurrentlyPlayingContext<T: PlayableIdBuf> {
     pub context: Option<Context<T>>,
     #[serde(with = "millisecond_timestamp")]
     pub timestamp: DateTime<Utc>,
@@ -41,7 +41,7 @@ pub struct CurrentlyPlayingContext<T: PlayableIdType> {
 }
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CurrentPlaybackContext<T: PlayableIdType> {
+pub struct CurrentPlaybackContext<T: PlayableIdBuf> {
     pub device: Device,
     pub repeat_state: RepeatState,
     pub shuffle_state: bool,

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -42,7 +42,6 @@ pub enum Type {
     User,
     Show,
     Episode,
-    Unknown,
 }
 
 /// Additional typs: `track`, `episode`

--- a/rspotify-model/src/lib.rs
+++ b/rspotify-model/src/lib.rs
@@ -233,15 +233,10 @@ pub enum PlayableItem {
     Episode(show::FullEpisode),
 }
 
-pub use idtypes::{
-    AlbumId, AlbumIdBuf, ArtistId, ArtistIdBuf, EpisodeId, EpisodeIdBuf, Id, IdBuf, IdError,
-    PlayableIdType, PlaylistId, PlaylistIdBuf, ShowId, ShowIdBuf, TrackId, TrackIdBuf, UnknownId,
-    UnknownIdBuf, UserId, UserIdBuf,
-};
 pub use {
     album::*, artist::*, audio::*, category::*, context::*, device::*, enums::*, error::*,
-    image::*, offset::*, page::*, playing::*, playlist::*, recommend::*, search::*, show::*,
-    track::*, user::*,
+    idtypes::*, image::*, offset::*, page::*, playing::*, playlist::*, recommend::*, search::*,
+    show::*, track::*, user::*,
 };
 
 #[cfg(test)]
@@ -252,37 +247,33 @@ mod tests {
     fn test_get_id() {
         // Assert artist
         let artist_id = "spotify:artist:2WX2uTcsvV5OnS0inACecP";
-        let id = Id::<idtypes::Artist>::from_id_or_uri(artist_id).unwrap();
+        let id = ArtistId::from_id_or_uri(artist_id).unwrap();
         assert_eq!("2WX2uTcsvV5OnS0inACecP", id.id());
 
         // Assert album
         let album_id_a = "spotify/album/2WX2uTcsvV5OnS0inACecP";
         assert_eq!(
             "2WX2uTcsvV5OnS0inACecP",
-            Id::<idtypes::Album>::from_id_or_uri(album_id_a)
-                .unwrap()
-                .id()
+            AlbumId::from_id_or_uri(album_id_a).unwrap().id()
         );
 
         // Mismatch type
         assert_eq!(
             Err(IdError::InvalidType),
-            Id::<idtypes::Artist>::from_id_or_uri(album_id_a)
+            ArtistId::from_id_or_uri(album_id_a)
         );
 
         // Could not split
         let artist_id_c = "spotify-album-2WX2uTcsvV5OnS0inACecP";
         assert_eq!(
             Err(IdError::InvalidId),
-            Id::<idtypes::Artist>::from_id_or_uri(artist_id_c)
+            ArtistId::from_id_or_uri(artist_id_c)
         );
 
         let playlist_id = "spotify:playlist:59ZbFPES4DQwEjBpWHzrtC";
         assert_eq!(
             "59ZbFPES4DQwEjBpWHzrtC",
-            Id::<idtypes::Playlist>::from_id_or_uri(playlist_id)
-                .unwrap()
-                .id()
+            PlaylistId::from_id_or_uri(playlist_id).unwrap().id()
         );
     }
 
@@ -290,8 +281,8 @@ mod tests {
     fn test_get_uri() {
         let track_id1 = "spotify:track:4iV5W9uYEdYUVa79Axb7Rh";
         let track_id2 = "1301WleyT98MSxVHPZCA6M";
-        let id1 = Id::<idtypes::Track>::from_id_or_uri(track_id1).unwrap();
-        let id2 = Id::<idtypes::Track>::from_id_or_uri(track_id2).unwrap();
+        let id1 = TrackId::from_id_or_uri(track_id1).unwrap();
+        let id2 = TrackId::from_id_or_uri(track_id2).unwrap();
         assert_eq!(track_id1, &id1.uri());
         assert_eq!("spotify:track:1301WleyT98MSxVHPZCA6M", &id2.uri());
     }

--- a/rspotify-model/src/offset.rs
+++ b/rspotify-model/src/offset.rs
@@ -1,22 +1,22 @@
 //! Offset object
 
-use crate::{Id, IdBuf, PlayableIdType};
+use crate::{Id, IdBuf, PlayableId};
 
 /// Offset object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Offset<T> {
+pub enum Offset<T: IdBuf> {
     Position(u32),
-    Uri(IdBuf<T>),
+    Uri(T),
 }
 
-impl<T: PlayableIdType> Offset<T> {
+impl<T: PlayableId> Offset<T> {
     pub fn for_position(position: u32) -> Offset<T> {
         Offset::Position(position)
     }
 
-    pub fn for_uri(uri: &Id<T>) -> Offset<T> {
+    pub fn for_uri(uri: &T) -> Offset<T> {
         Offset::Uri(uri.to_owned())
     }
 }

--- a/rspotify-model/src/offset.rs
+++ b/rspotify-model/src/offset.rs
@@ -1,6 +1,6 @@
 //! Offset object
 
-use crate::{Id, IdBuf, PlayableId};
+use crate::{IdBuf, PlayableIdBuf};
 
 /// Offset object
 ///
@@ -11,7 +11,7 @@ pub enum Offset<T: IdBuf> {
     Uri(T),
 }
 
-impl<T: PlayableId> Offset<T> {
+impl<T: PlayableIdBuf> Offset<T> {
     pub fn for_position(position: u32) -> Offset<T> {
         Offset::Position(position)
     }

--- a/rspotify-model/src/playing.rs
+++ b/rspotify-model/src/playing.rs
@@ -3,7 +3,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{idtypes, Context, FullTrack};
+use crate::{Context, FullTrack, TrackId};
 
 /// Playing history object
 ///
@@ -12,5 +12,5 @@ use crate::{idtypes, Context, FullTrack};
 pub struct PlayHistory {
     pub track: FullTrack,
     pub played_at: DateTime<Utc>,
-    pub context: Option<Context<idtypes::Track>>,
+    pub context: Option<Context<TrackId>>,
 }

--- a/rspotify-model/src/playing.rs
+++ b/rspotify-model/src/playing.rs
@@ -3,7 +3,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{Context, FullTrack, TrackId};
+use crate::{Context, FullTrack, TrackIdBuf};
 
 /// Playing history object
 ///
@@ -12,5 +12,5 @@ use crate::{Context, FullTrack, TrackId};
 pub struct PlayHistory {
     pub track: FullTrack,
     pub played_at: DateTime<Utc>,
-    pub context: Option<Context<TrackId>>,
+    pub context: Option<Context<TrackIdBuf>>,
 }

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -2,14 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{RecommendationsSeedType, SimplifiedTrack, UnknownIdBuf};
+use crate::{IdBuf, RecommendationsSeedType, SimplifiedTrack};
 
 /// Recommendations object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Recommendations {
-    pub seeds: Vec<RecommendationsSeed>,
+    pub seeds: Vec<Box<RecommendationsSeed<dyn IdBuf>>>,
     pub tracks: Vec<SimplifiedTrack>,
 }
 
@@ -17,13 +17,13 @@ pub struct Recommendations {
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RecommendationsSeed {
+pub struct RecommendationsSeed<T: IdBuf> {
     #[serde(rename = "afterFilteringSize")]
     pub after_filtering_size: u32,
     #[serde(rename = "afterRelinkingSize")]
     pub after_relinking_size: u32,
     pub href: Option<String>,
-    pub id: UnknownIdBuf,
+    pub id: T,
     #[serde(rename = "initialPoolSize")]
     pub initial_pool_size: u32,
     #[serde(rename = "type")]

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -9,7 +9,7 @@ use crate::{IdBuf, RecommendationsSeedType, SimplifiedTrack};
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Recommendations {
-    pub seeds: Vec<Box<RecommendationsSeed<dyn IdBuf>>>,
+    pub seeds: Vec<RecommendationsSeed<Box<dyn IdBuf>>>,
     pub tracks: Vec<SimplifiedTrack>,
 }
 
@@ -17,7 +17,7 @@ pub struct Recommendations {
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RecommendationsSeed<T: IdBuf> {
+pub struct RecommendationsSeed<T> {
     #[serde(rename = "afterFilteringSize")]
     pub after_filtering_size: u32,
     #[serde(rename = "afterRelinkingSize")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ use thiserror::Error;
 
 pub mod prelude {
     pub use crate::clients::{BaseClient, OAuthClient};
+    pub use crate::model::idtypes::{Id, IdBuf, PlayContextId, PlayableId};
 }
 
 pub(in crate) mod headers {


### PR DESCRIPTION
## Description

This attempt tries to implement what i described in #203:

> A different approach would be to scratch `Id<T>` and just use `ArtistId` and similars directly. What I mean is that we wouldn't have a single type for IDs called `Id<T>` that implements its logic. We could make `ArtistId` and similars, and implement the trait the same way clients work. The main component would be a trait that implements all the logic, say `Id`, and a struct for each type (`ArtistId`, etc) that implements the trait. With this one could be generic over `Id` directly, have `Box<dyn Id> for runtime usage, and `Vec<Box<dyn Id>>` for multiple values, which is exactly what we need.
> 
>   The main problems are:
> 
>   1. We can't use type inference to our benefit; `Id::from_uri` can't work with this solution; `ArtistId::from_uri` would have to be used explicitly.
>   2. We need the trait `Id` always available when using IDs; we'd have to add it to the prelude. Considering the user needs to import the prelude to use the clients anyway I don't think it's a big deal
> 
>   So this solution is basically the same as how clients work. We have a big trait that does everything, and we let Rust "clone" the code for each of our implementations. It's also basically the newtype pattern, but with a common trait for all the newtypes.