### PR TITLE
Fix cached token scopes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,8 @@ pub struct Token {
     /// A list of [scopes](https://developer.spotify.com/documentation/general/guides/scopes/)
     /// which have been granted for this `access_token`
     /// You could use macro [scopes!](crate::scopes) to build it at compile time easily
-    #[serde(default, with = "space_separated_scopes")]
+    // The token response from spotify is singular, hence the rename to `scope`
+    #[serde(default, with = "space_separated_scopes", rename = "scope")]
     pub scopes: HashSet<String>,
 }
 


### PR DESCRIPTION
## Description

Serde rename "scopes" to "scope", but leave struct type as "scopes".

## Motivation and Context

The cached auth token was not being restored from the cache, prompting the login flow every time.

On inspecting the cache, the "scopes" property was empty.

Turns out this was because the form response from spotify does not contain a "scopes" field. But instead contains a "scope".

This PR simply renames the property to "scopes" as it's a small change. Let me know if there's a more appropriate fix.

## Dependencies 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [ ] Test A: xxx
- [ ] Test B: xxx
