### PR TITLE
PKCE Auth Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
 - ([#189](https://github.com/ramsayleung/rspotify/pull/189)) Add `scopes!` macro to generate scopes for `Token` from string literal
 - Rspotify has now been split up into independent crates, so that it can be used without the client. See `rspotify-macros` and `rspotify-model`.
 - ([#128](https://github.com/ramsayleung/rspotify/pull/128)) Reexport `model` module to allow user to write `rspotify::model::FullAlbum` instead of  `rspotify::model::album::FullAlbum`.
+- ([#246](https://github.com/ramsayleung/rspotify/pull/246)) Add support for PKCE, see `AuthCodePkceSpotify`.
 
 **Breaking changes:**
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Rspotify now consistently uses `Option<T>` for optional parameters. Those generic over `Into<Option<T>>` have been changed, which makes calling endpoints a bit ugiler but more consistent and simpler.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ log = "0.4.11"
 maybe-async = "0.2.1"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
+sha2 = "0.9.6"
 thiserror = "1.0.20"
 url = "2.2.2"
 webbrowser = { version = "0.5.5", optional = true }

--- a/examples/auth_code.rs
+++ b/examples/auth_code.rs
@@ -9,8 +9,8 @@ async fn main() {
     // You can use any logger for debugging.
     env_logger::init();
 
-    // Set RSPOTIFY_CLIENT_ID, RSPOTIFY_CLIENT_SECRET and
-    // RSPOTIFY_REDIRECT_URI in an .env file or export them manually:
+    // Set RSPOTIFY_CLIENT_ID and RSPOTIFY_CLIENT_SECRET in an .env file or
+    // export them manually:
     //
     // export RSPOTIFY_CLIENT_ID="your client_id"
     // export RSPOTIFY_CLIENT_SECRET="secret"
@@ -20,14 +20,11 @@ async fn main() {
     // Otherwise, set client_id and client_secret explictly:
     //
     // ```
-    // let creds = Credentials {
-    //     id: "this-is-my-client-id".to_string(),
-    //     secret: "this-is-my-client-secret".to_string()
-    // };
+    // let creds = Credentials::new("my-client-id", "my-client-secret");
     // ```
     let creds = Credentials::from_env().unwrap();
 
-    // Or set the redirect_uri explictly:
+    // Same for RSPOTIFY_REDIRECT_URI. You can also set it explictly:
     //
     // ```
     // let oauth = OAuth {

--- a/examples/auth_code_pkce.rs
+++ b/examples/auth_code_pkce.rs
@@ -37,7 +37,7 @@ async fn main() {
     let mut spotify = AuthCodePkceSpotify::new(creds, oauth);
 
     // Obtaining the access token
-    let url = spotify.get_authorize_url().unwrap();
+    let url = spotify.get_authorize_url(None).unwrap();
     spotify.prompt_for_token(&url).await.unwrap();
 
     // Running the requests

--- a/examples/auth_code_pkce.rs
+++ b/examples/auth_code_pkce.rs
@@ -5,25 +5,20 @@ async fn main() {
     // You can use any logger for debugging.
     env_logger::init();
 
-    // Set RSPOTIFY_CLIENT_ID, RSPOTIFY_CLIENT_SECRET and
-    // RSPOTIFY_REDIRECT_URI in an .env file or export them manually:
+    // Set RSPOTIFY_CLIENT_ID in an .env file or export it manually:
     //
     // export RSPOTIFY_CLIENT_ID="your client_id"
-    // export RSPOTIFY_CLIENT_SECRET="secret"
     //
-    // These will then be read with `from_env`.
+    // It will then be read with `from_env`.
     //
-    // Otherwise, set client_id and client_secret explictly:
+    // Otherwise, set client_id explictly:
     //
     // ```
-    // let creds = Credentials {
-    //     id: "this-is-my-client-id".to_string(),
-    //     secret: "this-is-my-client-secret".to_string()
-    // };
+    // let creds = Credentials::new_pkce("my-client-id");
     // ```
     let creds = Credentials::from_env().unwrap();
 
-    // Or set the redirect_uri explictly:
+    // Same for RSPOTIFY_REDIRECT_URI. You can also set it explictly:
     //
     // ```
     // let oauth = OAuth {

--- a/examples/auth_code_pkce.rs
+++ b/examples/auth_code_pkce.rs
@@ -27,7 +27,7 @@ async fn main() {
     //     ..Default::default(),
     // };
     // ```
-    let oauth = OAuth::from_env(scopes!("user-read-recently-played")).unwrap();
+    let oauth = OAuth::from_env(scopes!("user-read-playback-state")).unwrap();
 
     let mut spotify = AuthCodePkceSpotify::new(creds, oauth);
 

--- a/examples/client_creds.rs
+++ b/examples/client_creds.rs
@@ -5,11 +5,12 @@ async fn main() {
     // You can use any logger for debugging.
     env_logger::init();
 
-    // Set RSPOTIFY_CLIENT_ID, RSPOTIFY_CLIENT_SECRET and
-    // RSPOTIFY_REDIRECT_URI in an .env file or export them manually:
+    // Set RSPOTIFY_CLIENT_ID and RSPOTIFY_CLIENT_SECRET in an .env file or
+    // export them manually:
     //
     // export RSPOTIFY_CLIENT_ID="your client_id"
     // export RSPOTIFY_CLIENT_SECRET="secret"
+    // export RSPOTIFY_REDIRECT_URI="your redirect uri"
     //
     // These will then be read with `from_env`.
     //
@@ -18,7 +19,7 @@ async fn main() {
     // ```
     // let creds = Credentials {
     //     id: "this-is-my-client-id".to_string(),
-    //     secret: "this-is-my-client-secret".to_string()
+    //     secret: Some("this-is-my-client-secret".to_string())
     // };
     // ```
     let creds = Credentials::from_env().unwrap();

--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -92,3 +92,23 @@ impl Token {
         headers
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::Token;
+
+    #[test]
+    fn test_bearer_auth() {
+        let tok = Token {
+            access_token: "access_token".to_string(),
+            ..Default::default()
+        };
+
+        let headers = tok.auth_headers();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"Bearer access_token".to_owned())
+        );
+    }
+}

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -107,7 +107,7 @@ impl OAuthClient for AuthCodeSpotify {
         let scopes = join_scopes(&self.oauth.scopes);
 
         let mut data = Form::new();
-        data.insert(headers::GRANT_TYPE, headers::GRANT_AUTH_CODE);
+        data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_AUTH_CODE);
         data.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         data.insert(headers::CODE, code);
         data.insert(headers::SCOPE, &scopes);
@@ -125,7 +125,7 @@ impl OAuthClient for AuthCodeSpotify {
     async fn refresh_token(&mut self, refresh_token: &str) -> ClientResult<()> {
         let mut data = Form::new();
         data.insert(headers::REFRESH_TOKEN, refresh_token);
-        data.insert(headers::GRANT_TYPE, headers::GRANT_REFRESH_TOKEN);
+        data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_REFRESH_TOKEN);
 
         let mut token = self.fetch_access_token(&data).await?;
         token.refresh_token = Some(refresh_token.to_string());
@@ -174,7 +174,7 @@ impl AuthCodeSpotify {
 
         let mut payload: HashMap<&str, &str> = HashMap::new();
         payload.insert(headers::CLIENT_ID, &self.creds.id);
-        payload.insert(headers::RESPONSE_TYPE, headers::RESPONSE_CODE);
+        payload.insert(headers::RESPONSE_TYPE, headers::RESPONSE_TYPE_CODE);
         payload.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         payload.insert(headers::SCOPE, &scopes);
         payload.insert(headers::STATE, &self.oauth.state);

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -113,7 +113,12 @@ impl OAuthClient for AuthCodeSpotify {
         data.insert(headers::SCOPE, &scopes);
         data.insert(headers::STATE, &self.oauth.state);
 
-        let token = self.fetch_access_token(&data).await?;
+        let headers = self
+            .creds
+            .auth_headers()
+            .expect("No client secret set in the credentials.");
+
+        let token = self.fetch_access_token(&data, Some(&headers)).await?;
         self.token = Some(token);
 
         self.write_token_cache()
@@ -127,7 +132,12 @@ impl OAuthClient for AuthCodeSpotify {
         data.insert(headers::REFRESH_TOKEN, refresh_token);
         data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_REFRESH_TOKEN);
 
-        let mut token = self.fetch_access_token(&data).await?;
+        let headers = self
+            .creds
+            .auth_headers()
+            .expect("No client secret set in the credentials.");
+
+        let mut token = self.fetch_access_token(&data, Some(&headers)).await?;
         token.refresh_token = Some(refresh_token.to_string());
         self.token = Some(token);
 

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -86,7 +86,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         data.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         data.insert(headers::CODE_VERIFIER, verifier);
 
-        let token = self.fetch_access_token(&data).await?;
+        let token = self.fetch_access_token(&data, None).await?;
         self.token = Some(token);
 
         self.write_token_cache()
@@ -98,7 +98,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         data.insert(headers::REFRESH_TOKEN, refresh_token);
         data.insert(headers::CLIENT_ID, &self.creds.id);
 
-        let mut token = self.fetch_access_token(&data).await?;
+        let mut token = self.fetch_access_token(&data, None).await?;
         token.refresh_token = Some(refresh_token.to_string());
         self.token = Some(token);
 

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -3,7 +3,7 @@ use crate::{
     clients::{BaseClient, OAuthClient},
     generate_random_string, headers,
     http::{Form, HttpClient},
-    ClientResult, Config, Credentials, OAuth, Token,
+    join_scopes, ClientResult, Config, Credentials, OAuth, Token,
 };
 
 use std::collections::HashMap;
@@ -70,20 +70,14 @@ impl OAuthClient for AuthCodePkceSpotify {
     }
 
     async fn request_token(&mut self, code: &str) -> ClientResult<()> {
-        // TODO
+        let scopes = join_scopes(&self.oauth.scopes);
+
         let mut data = Form::new();
-        let oauth = self.get_oauth();
-        let scopes = oauth
-            .scopes
-            .clone()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .join(" ");
         data.insert(headers::GRANT_TYPE, headers::GRANT_AUTH_CODE);
-        data.insert(headers::REDIRECT_URI, oauth.redirect_uri.as_ref());
+        data.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         data.insert(headers::CODE, code);
-        data.insert(headers::SCOPE, scopes.as_ref());
-        data.insert(headers::STATE, oauth.state.as_ref());
+        data.insert(headers::SCOPE, &scopes);
+        data.insert(headers::STATE, &self.oauth.state);
         data.insert(headers::CODE_VERIFIER, todo!());
 
         let token = self.fetch_access_token(&data).await?;
@@ -139,6 +133,22 @@ impl AuthCodePkceSpotify {
         }
     }
 
+    /// Generate the verifier code and the challenge code.
+    fn generate_codes(&self, verifier_bytes: usize) -> (String, String) {
+        debug_assert!(43 <= verifier_bytes);
+        debug_assert!(verifier_bytes <= 128);
+        // The code verifier is just the randomly generated string.
+        let verifier = generate_random_string(verifier_bytes, alphabets::PKCE_CODE_VERIFIER);
+        // The code challenge is the code verifier hashed with SHA256 and then
+        // encoded with base64.
+        let mut hasher = Sha256::new();
+        hasher.update(verifier.as_bytes());
+        let challenge = hasher.finalize();
+        let challenge = base64::encode(challenge);
+
+        (verifier, challenge)
+    }
+
     /// Returns the URL needed to authorize the current client as the first step
     /// in the authorization flow.
     ///
@@ -151,33 +161,18 @@ impl AuthCodePkceSpotify {
     /// [reference]: https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
     /// [rfce]: https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
     pub fn get_authorize_url(&mut self, verifier_bytes: Option<usize>) -> ClientResult<String> {
+        let scopes = join_scopes(&self.oauth.scopes);
         let verifier_bytes = verifier_bytes.unwrap_or(43);
-        debug_assert!(43 <= verifier_bytes);
-        debug_assert!(verifier_bytes <= 128);
-        // The code verifier is just the randomly generated string.
-        let verifier = generate_random_string(verifier_bytes, alphabets::PKCE_CODE_VERIFIER);
-        // The code challenge is the code verifier hashed with SHA256 and then
-        // encoded with base64.
-        let mut hasher = Sha256::new();
-        hasher.update(verifier.as_bytes());
-        let challenge = hasher.finalize();
-        let challenge = base64::encode(challenge);
+        let (verifier, challenge) = self.generate_codes(verifier_bytes);
+        // The verifier will be needed later when requesting the token
         self.verifier = Some(verifier);
 
         let mut payload: HashMap<&str, &str> = HashMap::new();
-        let oauth = self.get_oauth();
-        let scopes = oauth
-            .scopes
-            .clone()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .join(" ");
-
         payload.insert(headers::CLIENT_ID, &self.get_creds().id);
         payload.insert(headers::RESPONSE_TYPE, headers::RESPONSE_CODE);
-        payload.insert(headers::REDIRECT_URI, &oauth.redirect_uri);
+        payload.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         payload.insert(headers::SCOPE, &scopes);
-        payload.insert(headers::STATE, &oauth.state);
+        payload.insert(headers::STATE, &self.oauth.state);
         payload.insert(headers::CODE_CHALLENGE, &challenge);
         payload.insert(
             headers::CODE_CHALLENGE_METHOD,

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -73,7 +73,7 @@ impl OAuthClient for AuthCodePkceSpotify {
         let scopes = join_scopes(&self.oauth.scopes);
 
         let mut data = Form::new();
-        data.insert(headers::GRANT_TYPE, headers::GRANT_AUTH_CODE);
+        data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_AUTH_CODE);
         data.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         data.insert(headers::CODE, code);
         data.insert(headers::SCOPE, &scopes);
@@ -90,8 +90,8 @@ impl OAuthClient for AuthCodePkceSpotify {
         // TODO
         let mut data = Form::new();
         data.insert(headers::REFRESH_TOKEN, refresh_token);
-        data.insert(headers::GRANT_TYPE, headers::GRANT_REFRESH_TOKEN);
-        data.insert(headers::CLIENT_ID, headers::CLIENT_ID);
+        data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_REFRESH_TOKEN);
+        data.insert(headers::CLIENT_ID, &self.creds.id);
 
         let mut token = self.fetch_access_token(&data).await?;
         token.refresh_token = Some(refresh_token.to_string());
@@ -168,8 +168,8 @@ impl AuthCodePkceSpotify {
         self.verifier = Some(verifier);
 
         let mut payload: HashMap<&str, &str> = HashMap::new();
-        payload.insert(headers::CLIENT_ID, &self.get_creds().id);
-        payload.insert(headers::RESPONSE_TYPE, headers::RESPONSE_CODE);
+        payload.insert(headers::CLIENT_ID, &self.creds.id);
+        payload.insert(headers::RESPONSE_TYPE, headers::RESPONSE_TYPE_CODE);
         payload.insert(headers::REDIRECT_URI, &self.oauth.redirect_uri);
         payload.insert(headers::SCOPE, &scopes);
         payload.insert(headers::STATE, &self.oauth.state);

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -140,16 +140,21 @@ impl AuthCodePkceSpotify {
 
     /// Generate the verifier code and the challenge code.
     fn generate_codes(&self, verifier_bytes: usize) -> (String, String) {
-        debug_assert!(43 <= verifier_bytes);
+        debug_assert!(verifier_bytes >= 43);
         debug_assert!(verifier_bytes <= 128);
         // The code verifier is just the randomly generated string.
         let verifier = generate_random_string(verifier_bytes, alphabets::PKCE_CODE_VERIFIER);
         // The code challenge is the code verifier hashed with SHA256 and then
-        // encoded with base64.
+        // encoded with base64url.
+        //
+        // NOTE: base64url != base64; it uses a different set of characters. See
+        // https://datatracker.ietf.org/doc/html/rfc4648#section-5 for more
+        // information.
         let mut hasher = Sha256::new();
         hasher.update(verifier.as_bytes());
         let challenge = hasher.finalize();
-        let challenge = base64::encode(challenge);
+
+        let challenge = base64::encode_config(challenge, base64::URL_SAFE_NO_PAD);
 
         (verifier, challenge)
     }

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -105,7 +105,7 @@ impl ClientCredsSpotify {
     #[maybe_async]
     pub async fn request_token(&mut self) -> ClientResult<()> {
         let mut data = Form::new();
-        data.insert(headers::GRANT_TYPE, headers::GRANT_CLIENT_CREDS);
+        data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_CLIENT_CREDS);
 
         self.token = Some(self.fetch_access_token(&data).await?);
 

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -107,7 +107,12 @@ impl ClientCredsSpotify {
         let mut data = Form::new();
         data.insert(headers::GRANT_TYPE, headers::GRANT_TYPE_CLIENT_CREDS);
 
-        self.token = Some(self.fetch_access_token(&data).await?);
+        let headers = self
+            .creds
+            .auth_headers()
+            .expect("No client secret set in the credentials.");
+
+        self.token = Some(self.fetch_access_token(&data, Some(&headers)).await?);
 
         self.write_token_cache()
     }

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -171,7 +171,10 @@ where
         // This request uses a specific content type, and the client ID/secret
         // as the authentication, since the access token isn't available yet.
         let mut head = Headers::new();
-        let (key, val) = self.get_creds().auth_header();
+        let (key, val) = self.get_creds().auth_header().expect(
+            "No client secret set in the credentials, but it is required in \
+            order to generate the authentication header",
+        );
         head.insert(key, val);
 
         let response = self

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -162,6 +162,8 @@ where
     }
 
     /// Sends a request to Spotify for an access token.
+    ///
+    /// TODO: are we checking that state == self.state? I think not
     async fn fetch_access_token(
         &self,
         payload: &Form<'_>,

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -1,10 +1,11 @@
 use crate::{
     auth_urls,
     clients::{
-        basic_auth, bearer_auth, convert_result, join_ids,
+        convert_result,
         pagination::{paginate, Paginator},
     },
     http::{BaseHttpClient, Form, Headers, HttpClient, Query},
+    join_ids,
     macros::build_map,
     model::*,
     ClientResult, Config, Credentials, Token,
@@ -44,7 +45,10 @@ where
     /// The headers required for authenticated requests to the API
     fn auth_headers(&self) -> ClientResult<Headers> {
         let mut auth = Headers::new();
-        let (key, val) = bearer_auth(self.get_token().expect("Rspotify not authenticated"));
+        let (key, val) = self
+            .get_token()
+            .expect("Rspotify not authenticated")
+            .auth_header();
         auth.insert(key, val);
 
         Ok(auth)
@@ -167,7 +171,7 @@ where
         // This request uses a specific content type, and the client ID/secret
         // as the authentication, since the access token isn't available yet.
         let mut head = Headers::new();
-        let (key, val) = basic_auth(&self.get_creds().id, &self.get_creds().secret);
+        let (key, val) = self.get_creds().auth_header();
         head.insert(key, val);
 
         let response = self

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -59,7 +59,7 @@ mod test {
             ..Default::default()
         };
 
-        let (auth, value) = tok.auth_header();
+        let (auth, value) = tok.auth_headers();
         assert_eq!(auth, "authorization");
         assert_eq!(value, "Bearer access_token");
     }
@@ -68,7 +68,7 @@ mod test {
     fn test_basic_auth() {
         let creds = Credentials::new("ramsay", "123456");
 
-        let (auth, value) = creds.auth_header();
+        let (auth, value) = creds.auth_headers();
         assert_eq!(auth, "authorization");
         assert_eq!(value, "Basic cmFtc2F5OjEyMzQ1Ng==");
     }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -30,7 +30,7 @@ pub(in crate) fn append_device_id(path: &str, device_id: Option<&str>) -> String
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{scopes, ClientCredsSpotify, Credentials, Token};
+    use crate::{model::Token, scopes, ClientCredsSpotify};
     use chrono::{prelude::*, Duration};
 
     #[test]
@@ -49,37 +49,6 @@ mod test {
         assert_eq!(
             new_path,
             "me/player/shuffle?state=true&device_id=fdafdsadfa"
-        );
-    }
-
-    #[test]
-    fn test_bearer_auth() {
-        let tok = Token {
-            access_token: "access_token".to_string(),
-            ..Default::default()
-        };
-
-        let headers = tok.auth_headers();
-        assert_eq!(headers.len(), 1);
-        assert_eq!(
-            headers.get("authorization"),
-            Some(&"Bearer access_token".to_owned())
-        );
-    }
-
-    #[test]
-    fn test_basic_auth() {
-        let creds = Credentials::new_pkce("ramsay");
-        let headers = creds.auth_headers();
-        assert_eq!(headers, None);
-
-        let creds = Credentials::new("ramsay", "123456");
-
-        let headers = creds.auth_headers().unwrap();
-        assert_eq!(headers.len(), 1);
-        assert_eq!(
-            headers.get("authorization"),
-            Some(&"Basic cmFtc2F5OjEyMzQ1Ng==".to_owned())
         );
     }
 

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -59,18 +59,28 @@ mod test {
             ..Default::default()
         };
 
-        let (auth, value) = tok.auth_headers();
-        assert_eq!(auth, "authorization");
-        assert_eq!(value, "Bearer access_token");
+        let headers = tok.auth_headers();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"Bearer access_token".to_owned())
+        );
     }
 
     #[test]
     fn test_basic_auth() {
+        let creds = Credentials::new_pkce("ramsay");
+        let headers = creds.auth_headers();
+        assert_eq!(headers, None);
+
         let creds = Credentials::new("ramsay", "123456");
 
-        let (auth, value) = creds.auth_headers();
-        assert_eq!(auth, "authorization");
-        assert_eq!(value, "Basic cmFtc2F5OjEyMzQ1Ng==");
+        let headers = creds.auth_headers().unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"Basic cmFtc2F5OjEyMzQ1Ng==".to_owned())
+        );
     }
 
     #[test]
@@ -101,7 +111,7 @@ mod test {
         };
 
         let spotify = ClientCredsSpotify::from_token(tok);
-        let headers = spotify.auth_headers().unwrap();
+        let headers = spotify.auth_headers();
         assert_eq!(
             headers.get("authorization"),
             Some(&"Bearer test-access_token".to_owned())

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -5,10 +5,7 @@ pub mod pagination;
 pub use base::BaseClient;
 pub use oauth::OAuthClient;
 
-use crate::{
-    model::{idtypes::IdType, Id},
-    ClientResult, Token,
-};
+use crate::ClientResult;
 
 use serde::Deserialize;
 
@@ -30,35 +27,10 @@ pub(in crate) fn append_device_id(path: &str, device_id: Option<&str>) -> String
     new_path
 }
 
-// TODO: move to `lib.rs`
-#[inline]
-pub(in crate) fn join_ids<'a, T: 'a + IdType>(ids: impl IntoIterator<Item = &'a Id<T>>) -> String {
-    ids.into_iter().collect::<Vec<_>>().join(",")
-}
-
-// TODO: move to `lib.rs` or integrate into Token.
-/// Generates an HTTP token authorization header with proper formatting
-pub fn bearer_auth(tok: &Token) -> (String, String) {
-    let auth = "authorization".to_owned();
-    let value = format!("Bearer {}", tok.access_token);
-
-    (auth, value)
-}
-
-// TODO: move to `lib.rs` or integrate into Credentials.
-/// Generates an HTTP basic authorization header with proper formatting
-pub fn basic_auth(user: &str, password: &str) -> (String, String) {
-    let auth = "authorization".to_owned();
-    let value = format!("{}:{}", user, password);
-    let value = format!("Basic {}", base64::encode(value));
-
-    (auth, value)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{scopes, ClientCredsSpotify, Token};
+    use crate::{scopes, ClientCredsSpotify, Credentials, Token};
     use chrono::{prelude::*, Duration};
 
     #[test]
@@ -87,14 +59,16 @@ mod test {
             ..Default::default()
         };
 
-        let (auth, value) = bearer_auth(&tok);
+        let (auth, value) = tok.auth_header();
         assert_eq!(auth, "authorization");
         assert_eq!(value, "Bearer access_token");
     }
 
     #[test]
     fn test_basic_auth() {
-        let (auth, value) = basic_auth("ramsay", "123456");
+        let creds = Credentials::new("ramsay", "123456");
+
+        let (auth, value) = creds.auth_header();
         assert_eq!(auth, "authorization");
         assert_eq!(value, "Basic cmFtc2F5OjEyMzQ1Ng==");
     }

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -1,10 +1,11 @@
 use crate::{
     clients::{
-        append_device_id, convert_result, join_ids,
+        append_device_id, convert_result,
         pagination::{paginate, Paginator},
         BaseClient,
     },
     http::Query,
+    join_ids,
     macros::{build_json, build_map},
     model::*,
     ClientResult, OAuth, Token,

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -106,7 +106,6 @@ pub trait OAuthClient: BaseClient {
             // Otherwise following the usual procedure to get the token.
             None => {
                 let code = self.get_code_from_user(url)?;
-                // Will write to the cache file if successful
                 self.request_token(&code).await?;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ impl OAuth {
 
 #[cfg(test)]
 mod test {
-    use super::{alphabets, generate_random_string};
+    use crate::{alphabets, generate_random_string, Credentials};
     use std::collections::HashSet;
 
     #[test]
@@ -393,5 +393,21 @@ mod test {
             containers.insert(generate_random_string(10, alphabets::ALPHANUM));
         }
         assert_eq!(containers.len(), 100);
+    }
+
+    #[test]
+    fn test_basic_auth() {
+        let creds = Credentials::new_pkce("ramsay");
+        let headers = creds.auth_headers();
+        assert_eq!(headers, None);
+
+        let creds = Credentials::new("ramsay", "123456");
+
+        let headers = creds.auth_headers().unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"Basic cmFtc2F5OjEyMzQ1Ng==".to_owned())
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,13 +162,13 @@ pub mod prelude {
 pub(in crate) mod headers {
     pub const CLIENT_ID: &str = "client_id";
     pub const CODE: &str = "code";
-    pub const GRANT_AUTH_CODE: &str = "authorization_code";
-    pub const GRANT_CLIENT_CREDS: &str = "client_credentials";
-    pub const GRANT_REFRESH_TOKEN: &str = "refresh_token";
     pub const GRANT_TYPE: &str = "grant_type";
+    pub const GRANT_TYPE_AUTH_CODE: &str = "authorization_code";
+    pub const GRANT_TYPE_CLIENT_CREDS: &str = "client_credentials";
+    pub const GRANT_TYPE_REFRESH_TOKEN: &str = "refresh_token";
     pub const REDIRECT_URI: &str = "redirect_uri";
     pub const REFRESH_TOKEN: &str = "refresh_token";
-    pub const RESPONSE_CODE: &str = "code";
+    pub const RESPONSE_TYPE_CODE: &str = "code";
     pub const RESPONSE_TYPE: &str = "response_type";
     pub const SCOPE: &str = "scope";
     pub const SHOW_DIALOG: &str = "show_dialog";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub use client_creds::ClientCredsSpotify;
 pub use macros::scopes;
 
 use crate::{
-    http::HttpError,
+    http::{Headers, HttpError},
     model::{idtypes::IdType, Id},
 };
 
@@ -158,7 +158,8 @@ pub mod prelude {
     pub use crate::clients::{BaseClient, OAuthClient};
 }
 
-/// Common headers as constants
+/// Common headers as constants.
+/// TODO: rename; these aren't all headers. Most are keys/values for forms.
 pub(in crate) mod headers {
     pub const CLIENT_ID: &str = "client_id";
     pub const CODE: &str = "code";
@@ -393,11 +394,13 @@ impl Token {
     }
 
     /// Generates an HTTP token authorization header with proper formatting
-    pub fn auth_header(&self) -> (String, String) {
+    pub fn auth_headers(&self) -> Headers {
         let auth = "authorization".to_owned();
         let value = format!("Bearer {}", self.access_token);
 
-        (auth, value)
+        let mut headers = Headers::new();
+        headers.insert(auth, value);
+        headers
     }
 }
 
@@ -445,12 +448,14 @@ impl Credentials {
     /// Generates an HTTP basic authorization header with proper formatting
     ///
     /// This will only work when the client secret is set to `Option::Some`.
-    pub fn auth_header(&self) -> Option<(String, String)> {
+    pub fn auth_headers(&self) -> Option<Headers> {
         let auth = "authorization".to_owned();
         let value = format!("{}:{}", self.id, self.secret.as_ref()?);
         let value = format!("Basic {}", base64::encode(value));
 
-        Some((auth, value))
+        let mut headers = Headers::new();
+        headers.insert(auth, value);
+        Some(headers)
     }
 }
 


### PR DESCRIPTION
## Description

This implements the PKCE auth flow. It also removes quite a few TODOs in the code.

Closes #150

## Dependencies 

I had to add `sha2` in order to hash the verifier code with SHA256.

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

* The `examples/auth_code_pkce.rs` example
