### PR TITLE
Simplify recommendations endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
 - ([#128](https://github.com/ramsayleung/rspotify/pull/128)) Refactor all enum files with `strum`, reduced boilerplate code.
    + All enums don't have a method named `as_str()` anymore, by leveraging `strum`, it's easy to convert strings to enum variants based on their name, with method `as_ref()`.
 - Fix typo in `transfer_playback`: `device_id` to `device_ids`.
+- ([#249](https://github.com/ramsayleung/rspotify/pull/249)) The `recommendations` endpoint has been made simpler to use; the attributes are now serialized with `RecommendationsAttribute`.
 - ([#145](https://github.com/ramsayleung/rspotify/pull/145)) Refactor models to make it easier to use:
   + Changed type of `track` in `PlayHistory` to `FullTrack` ([#139](https://github.com/ramsayleung/rspotify/pull/139)).
   + Rename model `CurrentlyPlaybackContext` to `CurrentPlaybackContext`

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -3,6 +3,7 @@
 use super::track::SimplifiedTrack;
 use crate::RecommendationsSeedType;
 use serde::{Deserialize, Serialize};
+use strum::AsRefStr;
 
 /// Recommendations object
 ///
@@ -28,4 +29,108 @@ pub struct RecommendationsSeed {
     pub initial_pool_size: u32,
     #[serde(rename = "type")]
     pub _type: RecommendationsSeedType,
+}
+
+/// The attributes for recommendations
+///
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations)
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum RecommendationsAttribute {
+    MinAcousticness(f32),
+    MaxAcousticness(f32),
+    TargetAcousticness(f32),
+    MinDanceability(f32),
+    MaxDanceability(f32),
+    TargetDanceability(f32),
+    MinDurationMs(i32),
+    MaxDurationMs(i32),
+    TargetDurationMs(i32),
+    MinEnergy(f32),
+    MaxEnergy(f32),
+    TargetEnergy(f32),
+    MinInstrumentalness(f32),
+    MaxInstrumentalness(f32),
+    TargetInstrumentalness(f32),
+    MinKey(i32),
+    MaxKey(i32),
+    TargetKey(i32),
+    MinLiveness(f32),
+    MaxLiveness(f32),
+    TargetLiveness(f32),
+    MinLoudness(f32),
+    MaxLoudness(f32),
+    TargetLoudness(f32),
+    MinMode(i32),
+    MaxMode(i32),
+    TargetMode(i32),
+    MinPopularity(i32),
+    MaxPopularity(i32),
+    TargetPopularity(i32),
+    MinSpeechiness(f32),
+    MaxSpeechiness(f32),
+    TargetSpeechiness(f32),
+    MinTempo(f32),
+    MaxTempo(f32),
+    TargetTempo(f32),
+    MinTimeSignature(i32),
+    MaxTimeSignature(i32),
+    TargetTimeSignature(i32),
+    MinValence(f32),
+    MaxValence(f32),
+    TargetValence(f32),
+}
+
+impl RecommendationsAttribute {
+    /// Obtains the value of the enum as a String, which may be helpful when
+    /// serializing it.
+    pub fn value_string(&self) -> String {
+        use RecommendationsAttribute::*;
+
+        match self {
+            MinAcousticness(x) => x.to_string(),
+            MaxAcousticness(x) => x.to_string(),
+            TargetAcousticness(x) => x.to_string(),
+            MinDanceability(x) => x.to_string(),
+            MaxDanceability(x) => x.to_string(),
+            TargetDanceability(x) => x.to_string(),
+            MinDurationMs(x) => x.to_string(),
+            MaxDurationMs(x) => x.to_string(),
+            TargetDurationMs(x) => x.to_string(),
+            MinEnergy(x) => x.to_string(),
+            MaxEnergy(x) => x.to_string(),
+            TargetEnergy(x) => x.to_string(),
+            MinInstrumentalness(x) => x.to_string(),
+            MaxInstrumentalness(x) => x.to_string(),
+            TargetInstrumentalness(x) => x.to_string(),
+            MinKey(x) => x.to_string(),
+            MaxKey(x) => x.to_string(),
+            TargetKey(x) => x.to_string(),
+            MinLiveness(x) => x.to_string(),
+            MaxLiveness(x) => x.to_string(),
+            TargetLiveness(x) => x.to_string(),
+            MinLoudness(x) => x.to_string(),
+            MaxLoudness(x) => x.to_string(),
+            TargetLoudness(x) => x.to_string(),
+            MinMode(x) => x.to_string(),
+            MaxMode(x) => x.to_string(),
+            TargetMode(x) => x.to_string(),
+            MinPopularity(x) => x.to_string(),
+            MaxPopularity(x) => x.to_string(),
+            TargetPopularity(x) => x.to_string(),
+            MinSpeechiness(x) => x.to_string(),
+            MaxSpeechiness(x) => x.to_string(),
+            TargetSpeechiness(x) => x.to_string(),
+            MinTempo(x) => x.to_string(),
+            MaxTempo(x) => x.to_string(),
+            TargetTempo(x) => x.to_string(),
+            MinTimeSignature(x) => x.to_string(),
+            MaxTimeSignature(x) => x.to_string(),
+            TargetTimeSignature(x) => x.to_string(),
+            MinValence(x) => x.to_string(),
+            MaxValence(x) => x.to_string(),
+            TargetValence(x) => x.to_string(),
+        }
+    }
 }

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -14,7 +14,7 @@ use std::{collections::HashMap, fmt};
 
 use chrono::Utc;
 use maybe_async::maybe_async;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 /// This trait implements the basic endpoints from the Spotify API that may be
 /// accessed without user authorization, including parts of the authentication
@@ -888,8 +888,10 @@ where
     ///
     /// Parameters:
     /// - attributes - restrictions on attributes for the selected tracks, such
-    ///   as `min_acousticness` or `target_duration_ms`. See the reference for a
-    ///   list of all of them.
+    ///   as `min_acousticness` or `target_duration_ms`. You can use a HashMap
+    ///   with these strings as keys and integers or floating points as values
+    ///   (which is possible thanks to `serde_json::Value`). See the reference
+    ///   for a list of all the attributes.
     /// - seed_artists - a list of artist IDs, URIs or URLs
     /// - seed_tracks - a list of artist IDs, URIs or URLs
     /// - seed_genres - a list of genre names. Available genres for
@@ -904,7 +906,7 @@ where
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations)
     async fn recommendations<'a>(
         &self,
-        attributes: &HashMap<&str, Value>,
+        attributes: impl IntoIterator<Item = (&'a str, Value)> + Send + 'a,
         seed_artists: Option<impl IntoIterator<Item = &'a ArtistId> + Send + 'a>,
         seed_genres: Option<impl IntoIterator<Item = &'a str> + Send + 'a>,
         seed_tracks: Option<impl IntoIterator<Item = &'a TrackId> + Send + 'a>,
@@ -925,8 +927,8 @@ where
 
         // First converting the attribute values into `String`s
         let owned_attributes = attributes
-            .iter()
-            .map(|(name, value)| (*name, value.to_string()))
+            .into_iter()
+            .map(|(name, value)| (name, value.to_string()))
             .collect::<HashMap<&str, String>>();
         // Then converting the values into `&str`s
         let borrowed_attributes = owned_attributes

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -19,14 +19,14 @@ use rspotify::{
     clients::pagination::Paginator,
     model::{
         AlbumId, Country, CurrentPlaybackContext, Device, EpisodeId, FullPlaylist, Id, Market,
-        Offset, PlayableItem, PlaylistId, RepeatState, SearchType, ShowId, TimeRange, TrackId,
-        TrackPositions,
+        Offset, PlayableItem, PlaylistId, RecommendationsAttribute, RepeatState, SearchType,
+        ShowId, TimeRange, TrackId, TrackPositions,
     },
     prelude::*,
     scopes, AuthCodeSpotify, ClientResult, Credentials, OAuth, Token,
 };
 
-use std::{collections::HashMap, env};
+use std::env;
 
 use chrono::prelude::*;
 use maybe_async::maybe_async;
@@ -408,15 +408,15 @@ async fn test_playback() {
 async fn test_recommendations() {
     let seed_artists = [Id::from_id("4NHQUGzhtTLFvgF5SZesLK").unwrap()];
     let seed_tracks = [Id::from_id("0c6xIDDpzE81m2q797ordA").unwrap()];
-
-    let mut payload = HashMap::new();
-    payload.insert("min_energy", 0.4.into());
-    payload.insert("min_popularity", 50.into());
+    let attributes = [
+        RecommendationsAttribute::MinEnergy(0.4),
+        RecommendationsAttribute::MinPopularity(50),
+    ];
 
     oauth_client()
         .await
         .recommendations(
-            payload,
+            attributes,
             Some(seed_artists),
             None::<Vec<&str>>,
             Some(seed_tracks),

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -411,8 +411,8 @@ async fn test_recommendations() {
     let seed_tracks = vec![Id::from_id("0c6xIDDpzE81m2q797ordA").unwrap()];
 
     let mut payload = Map::new();
-    payload.insert("min_energy".to_owned(), 0.4.into());
-    payload.insert("min_popularity".to_owned(), 50.into());
+    payload.insert("min_energy", 0.4.into());
+    payload.insert("min_popularity", 50.into());
 
     oauth_client()
         .await

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -26,11 +26,10 @@ use rspotify::{
     scopes, AuthCodeSpotify, ClientResult, Credentials, OAuth, Token,
 };
 
-use std::env;
+use std::{collections::HashMap, env};
 
 use chrono::prelude::*;
 use maybe_async::maybe_async;
-use serde_json::map::Map;
 
 /// Generating a new OAuth client for the requests.
 #[maybe_async]
@@ -407,17 +406,17 @@ async fn test_playback() {
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 #[ignore]
 async fn test_recommendations() {
-    let seed_artists = vec![Id::from_id("4NHQUGzhtTLFvgF5SZesLK").unwrap()];
-    let seed_tracks = vec![Id::from_id("0c6xIDDpzE81m2q797ordA").unwrap()];
+    let seed_artists = [Id::from_id("4NHQUGzhtTLFvgF5SZesLK").unwrap()];
+    let seed_tracks = [Id::from_id("0c6xIDDpzE81m2q797ordA").unwrap()];
 
-    let mut payload = Map::new();
+    let mut payload = HashMap::new();
     payload.insert("min_energy", 0.4.into());
     payload.insert("min_popularity", 50.into());
 
     oauth_client()
         .await
         .recommendations(
-            &payload,
+            payload,
             Some(seed_artists),
             None::<Vec<&str>>,
             Some(seed_tracks),


### PR DESCRIPTION
## Description

The recommendations endpoint was very messy and had a long-standing TODO item. I've simplified it so that it just takes a map with the attributes that are directly appended to the query payload.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

The `test_recommendations` endpoint
