### PR TITLE
Allow negative values in duration_ms

### DIFF
--- a/rspotify-model/src/custom_serde.rs
+++ b/rspotify-model/src/custom_serde.rs
@@ -18,6 +18,12 @@ pub mod duration_ms {
         {
             Ok(Duration::from_millis(v))
         }
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Duration::from_millis(v.max(0) as u64))
+        }
     }
 
     /// Deserialize `std::time::Duration` from milliseconds (represented as u64)

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -592,6 +592,19 @@ fn test_resume_point() {
 }
 
 #[test]
+fn test_resume_point_negative() {
+    let json = r#"
+    {
+        "fully_played": true,
+        "resume_position_ms": -1000
+    }
+    "#;
+    let resume_point: ResumePoint = serde_json::from_str(&json).unwrap();
+    let duration = Duration::default();
+    assert_eq!(resume_point.resume_position, duration);
+}
+
+#[test]
 fn test_currently_playing_context() {
     let json = r#"
 {


### PR DESCRIPTION
## Description

This patch adds a parser for `i64` values to `duration_ms`, so that it no longer fails for negative numbers. This works, according to the [serde documentation](https://serde.rs/impl-deserialize.html#driving-a-visitor):

> The JSON `Deserializer` will call `visit_i64` for any signed integer and `visit_u64` for any unsigned integer, even if hinted a different type.

## Motivation and Context

The spotify API doesn't make any guarantees, if the returned integers are signed or unsigned. It turns out, that for the `resume_position_ms` value in the `ResumePointObject` used for `Episode`s can be negative. I've only seen the value `-1000`, but don't know when this occurs or if other values are possible.

I noticed this using the `spotify-tui` crate, that uses this crate as a dependency. See screenshot below:
![image](https://user-images.githubusercontent.com/9744647/133422112-4d862772-14e7-4372-a95c-a185d314300a.png)



## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By adding a unit test to the `test_models` file. The previous behavior is unchanged (according to existing tests)
