### PR TITLE
Fixes cached tokens

### DIFF
--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -80,10 +80,14 @@ impl ClientCredsSpotify {
         }
     }
 
-    /// Tries to read the cache file's token, which may not exist.
+    /// Tries to read the cache file's token.
     ///
-    /// Similarly to [`Self::write_token_cache`], this will already check if the
-    /// cached token is enabled and return `None` in case it isn't.
+    /// This will return an error if the token couldn't be read (e.g. it's not
+    /// available or the JSON is malformed). It may return `Ok(None)` if:
+    ///
+    /// * The read token is expired
+    /// * Its scopes don't match with the current client
+    /// * The cached token is disabled in the config
     #[maybe_async]
     pub async fn read_token_cache(&self) -> ClientResult<Option<Token>> {
         if !self.get_config().token_cached {

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -86,7 +86,6 @@ impl ClientCredsSpotify {
     /// available or the JSON is malformed). It may return `Ok(None)` if:
     ///
     /// * The read token is expired
-    /// * Its scopes don't match with the current client
     /// * The cached token is disabled in the config
     #[maybe_async]
     pub async fn read_token_cache(&self) -> ClientResult<Option<Token>> {

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -44,6 +44,7 @@ pub trait OAuthClient: BaseClient {
     /// available or the JSON is malformed). It may return `Ok(None)` if:
     ///
     /// * The read token is expired
+    /// * Its scopes don't match with the current client
     /// * The cached token is disabled in the config
     async fn read_token_cache(&mut self) -> ClientResult<Option<Token>> {
         if !self.get_config().token_cached {


### PR DESCRIPTION
## Description

This fixes:

*  `prompt_for_user`, which failed when `read_token_cache` returned and error. The problem here is that we *are* expecting an error in case the cache file isn't found (`FileNotFoundError`). We just want to ignore it, but it used `?`, which caused an early return. So the `match` expression just accepts `Ok(Some())` now.
* `read_token_cache` for OAuth clients didn't check the config. Whoops

I also updated the docs to make them more exhaustive.

## Motivation and Context

This was caused by #250 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

If you remove all cached tokens in your main directory and try to run any example it won't work. Now it does. This is because `prompt_user_token` returned `FileNotFound` and propagated. For example try with:

```
cargo run --example auth_code --features="env-file,cli"
```
