### PR TITLE
Fix oauth set token and fix unauthorized playback control

### DIFF
--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -80,8 +80,8 @@ impl BaseClient for AuthCodeSpotify {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
-        self.token.as_mut()
+    fn get_token_mut(&mut self) -> &mut Option<Token> {
+        &mut self.token
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -101,10 +101,6 @@ impl OAuthClient for AuthCodeSpotify {
         &self.oauth
     }
 
-    fn set_token(&mut self, token: Option<Token>) {
-        self.token = token;
-    }
-
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
     async fn request_token(&mut self, code: &str) -> ClientResult<()> {

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -101,6 +101,10 @@ impl OAuthClient for AuthCodeSpotify {
         &self.oauth
     }
 
+    fn set_token(&mut self, token: Option<Token>) {
+        self.token = token;
+    }
+
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
     async fn request_token(&mut self, code: &str) -> ClientResult<()> {

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -43,8 +43,8 @@ impl BaseClient for AuthCodePkceSpotify {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
-        self.token.as_mut()
+    fn get_token_mut(&mut self) -> &mut Option<Token> {
+        &mut self.token
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -64,6 +64,10 @@ impl OAuthClient for AuthCodePkceSpotify {
         &self.oauth
     }
 
+    fn set_token(&mut self, token: Option<Token>) {
+        self.token = token;
+    }
+
     async fn request_token(&mut self, code: &str) -> ClientResult<()> {
         // TODO
         let mut data = Form::new();

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -64,10 +64,6 @@ impl OAuthClient for AuthCodePkceSpotify {
         &self.oauth
     }
 
-    fn set_token(&mut self, token: Option<Token>) {
-        self.token = token;
-    }
-
     async fn request_token(&mut self, code: &str) -> ClientResult<()> {
         // TODO
         let mut data = Form::new();

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -37,8 +37,8 @@ impl BaseClient for ClientCredsSpotify {
         self.token.as_ref()
     }
 
-    fn get_token_mut(&mut self) -> Option<&mut Token> {
-        self.token.as_mut()
+    fn get_token_mut(&mut self) -> &mut Option<Token> {
+        &mut self.token
     }
 
     fn get_creds(&self) -> &Credentials {

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -27,7 +27,7 @@ where
     fn get_config(&self) -> &Config;
     fn get_http(&self) -> &HttpClient;
     fn get_token(&self) -> Option<&Token>;
-    fn get_token_mut(&mut self) -> Option<&mut Token>;
+    fn get_token_mut(&mut self) -> &mut Option<Token>;
     fn get_creds(&self) -> &Credentials;
 
     /// If it's a relative URL like "me", the prefix is appended to it.

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -981,7 +981,7 @@ pub trait OAuthClient: BaseClient {
         };
 
         let url = append_device_id("me/player/play", device_id);
-        self.put(&url, None, &params).await?;
+        self.endpoint_put(&url, &params).await?;
 
         Ok(())
     }

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -30,6 +30,8 @@ use url::Url;
 pub trait OAuthClient: BaseClient {
     fn get_oauth(&self) -> &OAuth;
 
+    fn set_token(&mut self, token: Option<Token>);
+
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
     async fn request_token(&mut self, code: &str) -> ClientResult<()>;
@@ -107,8 +109,8 @@ pub trait OAuthClient: BaseClient {
     #[maybe_async]
     async fn prompt_for_token(&mut self, url: &str) -> ClientResult<()> {
         match self.read_token_cache().await {
-            Ok(Some(ref mut new_token)) => {
-                self.get_token_mut().replace(new_token);
+            Ok(Some(new_token)) => {
+                self.set_token(Some(new_token));
             }
             // Otherwise following the usual procedure to get the token.
             _ => {

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -30,8 +30,6 @@ use url::Url;
 pub trait OAuthClient: BaseClient {
     fn get_oauth(&self) -> &OAuth;
 
-    fn set_token(&mut self, token: Option<Token>);
-
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
     async fn request_token(&mut self, code: &str) -> ClientResult<()>;

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -108,7 +108,8 @@ pub trait OAuthClient: BaseClient {
     async fn prompt_for_token(&mut self, url: &str) -> ClientResult<()> {
         match self.read_token_cache().await {
             Ok(Some(new_token)) => {
-                self.set_token(Some(new_token));
+                let token = self.get_token_mut();
+                *token = Some(new_token);
             }
             // Otherwise following the usual procedure to get the token.
             _ => {


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. The `prompt_for_token` oauth flow was not loading the token after reading from the cache.
2. All calls to `start_context_playback` resulted in "request unauthorized"

## Motivation and Context

Regarding the first issue:  Looks like the previous code was expecting the `String.replace()` method to mutate the original string, but `replace` [creates a new string](https://doc.rust-lang.org/std/string/struct.String.html#method.replace). I've added a new method to explicitly set the token. Unless there's a more consitent way?

For the second issue, the `start_context_playback` method was using the `.put` method and passing `None` for the headers, hence why all requests were unauthorized. I switched this to use `endpoint_put`, which appears to simply abstract the headers placement?

## Dependencies 

None.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

For the token cache issue, you can reproduce on master by 

1. setting the auth config `token_cached: true`
2. run prompt_for_token the first time to get the token (all requests are auth'ned)
3. restart the program to load the token from the cache
4. all requests are not auth'ned

For the not authorized playback control issue:

1. Get the auth token and device id and a playback context uri
2. Make the request and see the error
