### PR TITLE
 Added missing parameter from current_user_recently_played()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,7 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
     + `get_an_episode`
     + `get_several_episodes`
     + `remove_users_saved_shows`
+- ([#256](https://github.com/ramsayleung/rspotify/pull/256), [#198](https://github.com/ramsayleung/rspotify/pull/198)) Added missing `before` and `after` parameters from `current_user_recently_played`
 
 ## 0.10 (2020/07/01)
 

--- a/rspotify-model/src/enums/misc.rs
+++ b/rspotify-model/src/enums/misc.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 
@@ -118,6 +119,6 @@ impl AsRef<str> for Market {
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 pub enum TimeLimits {
-    Before(i64),
-    After(i64),
+    Before(DateTime<Utc>),
+    After(DateTime<Utc>),
 }

--- a/rspotify-model/src/enums/misc.rs
+++ b/rspotify-model/src/enums/misc.rs
@@ -112,3 +112,12 @@ impl AsRef<str> for Market {
         }
     }
 }
+
+/// Time limits in miliseconds (unix timestamps)
+///
+/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
+pub enum TimeLimits {
+    Before(i64),
+    After(i64),
+}

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -701,16 +701,32 @@ pub trait OAuthClient: BaseClient {
     ///
     /// Parameters:
     /// - limit - the number of entities to return
+    /// - time_limit - a Unix timestamp in milliseconds. Returns all items after
+    /// or before (but not including) this cursor position. 
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
     async fn current_user_recently_played(
         &self,
         limit: Option<u32>,
+        time_limit: Option<TimeLimits>
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
-        let params = build_map! {
+        let mut params = build_map! {
             optional "limit": limit.as_deref(),
         };
+
+        let time_limit = match time_limit {
+            Some(TimeLimits::Before(y)) => {
+                Some(("before", y.to_string()))
+            }
+            Some(TimeLimits::After(y)) => {
+                Some(("after", y.to_string()))
+            }
+            None => None
+        };
+        if let Some((name, value)) = time_limit.as_ref() {
+            params.insert(name, value);
+        }
 
         let result = self
             .endpoint_get("me/player/recently-played", &params)

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -716,8 +716,8 @@ pub trait OAuthClient: BaseClient {
         };
 
         let time_limit = match time_limit {
-            Some(TimeLimits::Before(y)) => Some(("before", y.timestamp().to_string())),
-            Some(TimeLimits::After(y)) => Some(("after", y.timestamp().to_string())),
+            Some(TimeLimits::Before(y)) => Some(("before", y.timestamp_millis().to_string())),
+            Some(TimeLimits::After(y)) => Some(("after", y.timestamp_millis().to_string())),
             None => None,
         };
         if let Some((name, value)) = time_limit.as_ref() {

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -702,13 +702,13 @@ pub trait OAuthClient: BaseClient {
     /// Parameters:
     /// - limit - the number of entities to return
     /// - time_limit - a Unix timestamp in milliseconds. Returns all items after
-    /// or before (but not including) this cursor position. 
+    /// or before (but not including) this cursor position.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
     async fn current_user_recently_played(
         &self,
         limit: Option<u32>,
-        time_limit: Option<TimeLimits>
+        time_limit: Option<TimeLimits>,
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
         let mut params = build_map! {
@@ -716,13 +716,9 @@ pub trait OAuthClient: BaseClient {
         };
 
         let time_limit = match time_limit {
-            Some(TimeLimits::Before(y)) => {
-                Some(("before", y.to_string()))
-            }
-            Some(TimeLimits::After(y)) => {
-                Some(("after", y.to_string()))
-            }
-            None => None
+            Some(TimeLimits::Before(y)) => Some(("before", y.timestamp().to_string())),
+            Some(TimeLimits::After(y)) => Some(("after", y.timestamp().to_string())),
+            None => None,
         };
         if let Some((name, value)) = time_limit.as_ref() {
             params.insert(name, value);

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -28,7 +28,7 @@ use rspotify::{
 
 use std::env;
 
-use chrono::prelude::*;
+use chrono::{prelude::*, Duration};
 use maybe_async::maybe_async;
 
 /// Generating a new OAuth client for the requests.
@@ -175,9 +175,10 @@ async fn test_current_user_playing_track() {
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 #[ignore]
 async fn test_current_user_recently_played() {
+    let limit = TimeLimits::After(Utc::now() - Duration::days(2));
     oauth_client()
         .await
-        .current_user_recently_played(Some(10), Some(TimeLimits::After(1)))
+        .current_user_recently_played(Some(10), Some(limit))
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -20,7 +20,7 @@ use rspotify::{
     model::{
         AlbumId, ArtistId, Country, CurrentPlaybackContext, Device, EpisodeId, FullPlaylist,
         Market, Offset, PlaylistId, RecommendationsAttribute, RepeatState, SearchType, ShowId,
-        TimeRange, TrackId, TrackPositions, UserId,
+        TimeLimits, TimeRange, TrackId, TrackPositions, UserId,
     },
     prelude::*,
     scopes, AuthCodeSpotify, ClientResult, Credentials, OAuth, Token,
@@ -177,7 +177,7 @@ async fn test_current_user_playing_track() {
 async fn test_current_user_recently_played() {
     oauth_client()
         .await
-        .current_user_recently_played(Some(10))
+        .current_user_recently_played(Some(10), Some(TimeLimits::After(1)))
         .await
         .unwrap();
 }


### PR DESCRIPTION
Credits to @hellbound22 for the original PR: #198. I've rewritten it for the updated `rspotify` and applied the review comments.

## Description

Fix the implementation of ```current_user_recently_played()``` with the missing parameters.

## Motivation and Context

The Spotify web api of ```current_user_recently_played()``` has the parameters ```before``` and ```after``` that are not implemented in this crate.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

The OAuth2 test passes when adding the ```None``` as the second parameter. Might have to write another test when the Option is ```Some(_)```

Also, been using this with success in a project of mine.

Please also list any relevant details for your test configuration

- [x] ```test_with_oauth::test_current_user_recently_played()```
