### PR TITLE
HTTP Error cleanup

### DIFF
--- a/rspotify-http/src/common.rs
+++ b/rspotify-http/src/common.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fmt;
 
 use maybe_async::maybe_async;
-use rspotify_model::ApiError;
 use serde_json::Value;
 
 pub type Headers = HashMap<String, String>;
@@ -21,10 +20,6 @@ pub enum HttpError {
     #[cfg(feature = "client-reqwest")]
     #[error("reqwest: {0}")]
     Reqwest(#[from] crate::reqwest::Error),
-
-    /// Something failed server-side (a logic error, the server is down, etc)
-    #[error("unsuccessful status code: {0}")]
-    StatusCode(u16, Option<ApiError>),
 }
 
 pub type HttpResult<T> = Result<T, HttpError>;

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -17,6 +17,9 @@ pub enum Error {
 
     #[error("I/O: {0}")]
     Io(#[from] io::Error),
+
+    #[error("status code {}", ureq::Response::status(.0))]
+    StatusCode(ureq::Response),
 }
 
 #[derive(Default, Debug, Clone)]
@@ -54,8 +57,8 @@ impl UreqClient {
                 .into_string()
                 .map_err(|error| HttpError::Ureq(Error::Io(error))),
             Err(err) => match err {
-                ureq::Error::Status(status, response) => {
-                    Err(HttpError::StatusCode(status, response.into_json().ok()))
+                ureq::Error::Status(_, response) => {
+                    Err(HttpError::Ureq(Error::StatusCode(response)))
                 }
                 ureq::Error::Transport(transport) => {
                     Err(HttpError::Ureq(Error::Transport(transport)))


### PR DESCRIPTION
## Description

This cleans up the errors for `rspotify-http`, according to #137.

## Motivation and Context

The [current error type for http](https://github.com/ramsayleung/rspotify/blob/bcfb7842aae7d2a0b8c82c53966efacc7e1f3966/rspotify-http/src/common.rs#L13) tries to wrap up all the errors from the clients we support under the same interface. However, it's a mess because:

1. It mixes multiple kinds of errors for different clients; `HttpError::Io` is only needed for ureq
2. It serializes only specific kinds of errors. Why is there a variant for `RateLimited` or `Unauthorized` but it's `StatusCode` for the rest?
3. Aren't the `Api` and `StatusCode` variants the same?

So this PR attempts to fix it by simply having a variant of error for each client supported by `rspotify-http`. It's as easy as delegating error handling to the HTTP client. If the user has enabled `ureq`, then they should deal with `ureq::Error` instead of some wrapper of our own that might not have everything they need.

This way, error handling is *complete*. There is nothing of functionality we miss by wrapping all of them under the same interface. And we also don't have to maintain such a complex wrapper ourselves.

I remember that @hrkfdn pointed out that the `RateLimited` variant was a must for him in order to retry a request. Well, this design still makes it possible to do so. It's just dependent on what HTTP client he's using. If he uses reqwest then it should be something like:

```rust
match request(...) {
    ClientError::Http(HttpError::Reqwest(ReqwestError::StatusCode(response))) => {
        // This is a reqwest::Response with full information about the error
        let timeout = response
            .headers()
            .get(reqwest::header::RETRY_AFTER)
            .and_then(|header| header.to_str().ok())
            .and_then(|duration| duration.parse().ok());
        time::sleep(timeout);
    }
    _ => { todo!() }
}
```

And if someone wanted to get the API error from Spotify:

```rust
match request(...) {
    ClientError::Http(HttpError::Reqwest(ReqwestError::StatusCode(response))) => {
        let api_err = response
            .json::<rspotify::model::ApiError>()?;
    }
    _ => { todo!() }
}
```

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

The CI still passes