### PR TITLE
Fix `is_playable` always being `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,7 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
     + `get_an_episode`
     + `get_several_episodes`
     + `remove_users_saved_shows`
+- ([#260](https://github.com/ramsayleung/rspotify/pull/260)) The `current_user_saved_albums` and `current_user_saved_tracks` now have a `market` parameter
 
 ## 0.10 (2020/07/01)
 

--- a/examples/pagination_async.rs
+++ b/examples/pagination_async.rs
@@ -25,7 +25,7 @@ async fn main() {
     spotify.prompt_for_token(&url).await.unwrap();
 
     // Executing the futures sequentially
-    let stream = spotify.current_user_saved_tracks();
+    let stream = spotify.current_user_saved_tracks(None);
     pin_mut!(stream);
     println!("Items (blocking):");
     while let Some(item) = stream.try_next().await.unwrap() {
@@ -33,7 +33,7 @@ async fn main() {
     }
 
     // Executing the futures concurrently
-    let stream = spotify.current_user_saved_tracks();
+    let stream = spotify.current_user_saved_tracks(None);
     println!("\nItems (concurrent):");
     stream
         .try_for_each_concurrent(10, |item| async move {

--- a/examples/pagination_manual.rs
+++ b/examples/pagination_manual.rs
@@ -24,7 +24,7 @@ async fn main() {
     println!("Items:");
     loop {
         let page = spotify
-            .current_user_saved_tracks_manual(Some(limit), Some(offset))
+            .current_user_saved_tracks_manual(None, Some(limit), Some(offset))
             .await
             .unwrap();
         for item in page.items {

--- a/examples/pagination_sync.rs
+++ b/examples/pagination_sync.rs
@@ -25,7 +25,7 @@ fn main() {
     spotify.prompt_for_token(&url).unwrap();
 
     // Typical iteration, no extra boilerplate needed.
-    let stream = spotify.current_user_saved_tracks();
+    let stream = spotify.current_user_saved_tracks(None);
     println!("Items:");
     for item in stream {
         println!("* {}", item.unwrap().track.name);

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -482,9 +482,14 @@ pub trait OAuthClient: BaseClient {
     /// of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-albums)
-    fn current_user_saved_albums(&self) -> Paginator<'_, ClientResult<SavedAlbum>> {
+    fn current_user_saved_albums<'a>(
+        &'a self,
+        market: Option<&'a Market>,
+    ) -> Paginator<'a, ClientResult<SavedAlbum>> {
         paginate(
-            move |limit, offset| self.current_user_saved_albums_manual(Some(limit), Some(offset)),
+            move |limit, offset| {
+                self.current_user_saved_albums_manual(market, Some(limit), Some(offset))
+            },
             self.get_config().pagination_chunks,
         )
     }
@@ -492,12 +497,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_saved_albums`].
     async fn current_user_saved_albums_manual(
         &self,
+        market: Option<&Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SavedAlbum>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
+            optional "market": market.map(|x| x.as_ref()),
             optional "limit": limit.as_deref(),
             optional "offset": offset.as_deref(),
         };
@@ -518,9 +525,14 @@ pub trait OAuthClient: BaseClient {
     /// version of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-users-saved-tracks)
-    fn current_user_saved_tracks(&self) -> Paginator<'_, ClientResult<SavedTrack>> {
+    fn current_user_saved_tracks<'a>(
+        &'a self,
+        market: Option<&'a Market>,
+    ) -> Paginator<'a, ClientResult<SavedTrack>> {
         paginate(
-            move |limit, offset| self.current_user_saved_tracks_manual(Some(limit), Some(offset)),
+            move |limit, offset| {
+                self.current_user_saved_tracks_manual(market, Some(limit), Some(offset))
+            },
             self.get_config().pagination_chunks,
         )
     }
@@ -528,12 +540,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_saved_tracks`].
     async fn current_user_saved_tracks_manual(
         &self,
+        market: Option<&Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SavedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
+            optional "market": market.map(|x| x.as_ref()),
             optional "limit": limit.as_deref(),
             optional "offset": offset.as_deref(),
         };

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -199,7 +199,7 @@ async fn test_current_user_saved_albums() {
         .unwrap();
 
     // Making sure the new albums appear
-    let all_albums = fetch_all(client.current_user_saved_albums()).await;
+    let all_albums = fetch_all(client.current_user_saved_albums(None)).await;
     let all_uris = all_albums
         .into_iter()
         .map(|a| a.album.id)
@@ -221,32 +221,32 @@ async fn test_current_user_saved_albums() {
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 #[ignore]
 async fn test_current_user_saved_tracks_add() {
+    let client = oauth_client().await;
     let tracks_ids = [
         &TrackId::from_uri("spotify:track:4iV5W9uYEdYUVa79Axb7Rh").unwrap(),
         &TrackId::from_uri("spotify:track:1301WleyT98MSxVHPZCA6M").unwrap(),
     ];
-    oauth_client()
-        .await
+    client
         .current_user_saved_tracks_add(tracks_ids)
         .await
         .unwrap();
 
-    let contains = oauth_client()
-        .await
+    let contains = client
         .current_user_saved_tracks_contains(tracks_ids)
         .await
         .unwrap();
     // Every track should be saved
     assert!(contains.into_iter().all(|x| x));
 
-    oauth_client()
+    let all = client
+        .current_user_saved_tracks(None)
         .await
-        .current_user_saved_tracks_manual(Some(10), Some(0))
-        .await
-        .unwrap();
+        .filter_map(|saved| Some(saved.ok()?.track.id))
+        .collect::<Vec<_>>();
+    // All the initial tracks should appear
+    assert!(tracks_ids.iter().all(|track| all.contains(track)));
 
-    oauth_client()
-        .await
+    client
         .current_user_saved_tracks_delete(tracks_ids)
         .await
         .unwrap();

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -238,10 +238,10 @@ async fn test_current_user_saved_tracks_add() {
     // Every track should be saved
     assert!(contains.into_iter().all(|x| x));
 
-    let all = client
-        .current_user_saved_tracks(None)
-        .await
-        .filter_map(|saved| Some(saved.ok()?.track.id))
+    let all = fetch_all(client.current_user_saved_tracks(None)).await;
+    let all = all
+        .into_iter()
+        .filter_map(|saved| Some(saved.track.id))
         .collect::<Vec<_>>();
     // All the initial tracks should appear
     assert!(tracks_ids.iter().all(|track| all.contains(track)));


### PR DESCRIPTION
## Description

As #190 explains, `is_playable` was always `None` because the `market` parameter was missing in these endpoints.

I suggest merging #259 first, as I wrote this over that branch by mistake.

## Motivation and Context

Closes #190

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Check out the test I modified. Can be ran with, for example:

```
$ cargo test --no-default-features --features=client-ureq,ureq-rustls-tls -- --ignored test_current_user_saved_tracks_add
```