### PR TITLE
Implement `Default` when it is possible to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,8 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
     + `get_an_episode`
     + `get_several_episodes`
     + `remove_users_saved_shows`
+- `PageSimpliedAlbums` has been renamed to `PageSimplifiedAlbums`
+- `Default` has been implemented for all the possible models
 
 ## 0.10 (2020/07/01)
 

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Simplified Album Object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedalbumobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedAlbum {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub album_group: Option<String>,
@@ -56,7 +56,7 @@ pub struct FullAlbum {
     pub tracks: Page<SimplifiedTrack>,
 }
 
-/// Full Albums wrapped by Vec object
+/// Intermediate full Albums wrapped by Vec object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
 #[derive(Deserialize)]
@@ -64,11 +64,11 @@ pub struct FullAlbums {
     pub albums: Vec<FullAlbum>,
 }
 
-/// Simplified Albums wrapped by Page object
+/// Intermediate simplified Albums wrapped by Page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-new-releases)
 #[derive(Deserialize)]
-pub struct PageSimpliedAlbums {
+pub struct PageSimplifiedAlbums {
     pub albums: Page<SimplifiedAlbum>,
 }
 

--- a/rspotify-model/src/artist.rs
+++ b/rspotify-model/src/artist.rs
@@ -9,7 +9,7 @@ use crate::{ArtistId, CursorBasedPage, Followers, Image};
 /// Simplified Artist Object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedartistobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedArtist {
     pub external_urls: HashMap<String, String>,
     pub href: Option<String>,
@@ -32,7 +32,7 @@ pub struct FullArtist {
     pub popularity: u32,
 }
 
-/// Full artist object wrapped by `Vec`
+/// Intermediate full artist object wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
 #[derive(Deserialize)]
@@ -40,7 +40,7 @@ pub struct FullArtists {
     pub artists: Vec<FullArtist>,
 }
 
-/// Full Artists vector wrapped by cursor-based-page object
+/// Intermediate full Artists vector wrapped by cursor-based-page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-followed)
 #[derive(Deserialize)]

--- a/rspotify-model/src/audio.rs
+++ b/rspotify-model/src/audio.rs
@@ -34,7 +34,7 @@ pub struct AudioFeatures {
     pub valence: f32,
 }
 
-/// Audio feature object wrapped by `Vec`
+/// Intermediate audio feature object wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features)
 #[derive(Deserialize)]
@@ -58,7 +58,7 @@ pub struct AudioAnalysis {
 
 /// Time interval object
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct TimeInterval {
     pub start: f32,
     pub duration: f32,
@@ -87,7 +87,7 @@ pub struct AudioAnalysisSection {
 /// Audio analysis meta object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct AudioAnalysisMeta {
     pub analyzer_version: String,
     pub platform: String,
@@ -101,7 +101,7 @@ pub struct AudioAnalysisMeta {
 /// Audio analysis segment object
 ///
 ///[Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct AudioAnalysisSegment {
     #[serde(flatten)]
     pub time_interval: TimeInterval,

--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// Spotify access token information
 ///
 /// [Reference](https://developer.spotify.com/documentation/general/guides/authorization-guide/)
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Token {
     /// An access token that can be provided in subsequent calls
     pub access_token: String,

--- a/rspotify-model/src/category.rs
+++ b/rspotify-model/src/category.rs
@@ -7,7 +7,7 @@ use crate::{Image, Page};
 /// Category object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Category {
     pub href: String,
     pub icons: Vec<Image>,
@@ -15,7 +15,7 @@ pub struct Category {
     pub name: String,
 }
 
-/// Categories wrapped by page object
+/// Intermediate categories wrapped by page object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
 #[derive(Deserialize)]

--- a/rspotify-model/src/context.rs
+++ b/rspotify-model/src/context.rs
@@ -61,7 +61,7 @@ pub struct CurrentPlaybackContext {
 /// Actions object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, Default)]
 pub struct Actions {
     pub disallows: Vec<DisallowKey>,
 }

--- a/rspotify-model/src/device.rs
+++ b/rspotify-model/src/device.rs
@@ -16,7 +16,7 @@ pub struct Device {
     pub volume_percent: Option<u32>,
 }
 
-/// Device payload object
+/// Intermediate device payload object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 #[derive(Deserialize)]

--- a/rspotify-model/src/image.rs
+++ b/rspotify-model/src/image.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Image object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-imageobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Image {
     pub height: Option<u32>,
     pub url: String,

--- a/rspotify-model/src/lib.rs
+++ b/rspotify-model/src/lib.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 /// Followers object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-followersobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Followers {
     // This field will always set to null, as the Web API does not support it at the moment.
     // pub href: Option<String>,

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Paging object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-pagingobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Page<T> {
     pub href: String,
     pub items: Vec<T>,
@@ -19,7 +19,7 @@ pub struct Page<T> {
 /// Cursor-based paging object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorpagingobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct CursorBasedPage<T> {
     pub href: String,
     pub items: Vec<T>,
@@ -34,7 +34,7 @@ pub struct CursorBasedPage<T> {
 /// Cursor object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Cursor {
     pub after: Option<String>,
 }

--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -10,7 +10,7 @@ use crate::{Followers, Image, Page, PlayableItem, PlaylistId, PublicUser};
 /// Playlist result object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistResult {
     pub snapshot_id: String,
 }
@@ -18,7 +18,7 @@ pub struct PlaylistResult {
 /// Playlist Track Reference Object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttracksrefobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistTracksRef {
     pub href: String,
     pub total: u32,
@@ -63,7 +63,7 @@ pub struct FullPlaylist {
 /// Playlist track object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttrackobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistItem {
     pub added_at: Option<DateTime<Utc>>,
     pub added_by: Option<PublicUser>,
@@ -78,7 +78,7 @@ pub struct FeaturedPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,
 }
 
-/// Category playlists object wrapped by `Page`
+/// Intermediate category playlists object wrapped by `Page`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-categories-playlists)
 #[derive(Deserialize)]

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -8,7 +8,7 @@ use crate::{RecommendationsSeedType, SimplifiedTrack};
 /// Recommendations object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Recommendations {
     pub seeds: Vec<RecommendationsSeed>,
     pub tracks: Vec<SimplifiedTrack>,

--- a/rspotify-model/src/search.rs
+++ b/rspotify-model/src/search.rs
@@ -18,7 +18,7 @@ pub struct SearchPlaylists {
 /// Search for albums
 ///
 ///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SearchAlbums {
     pub albums: Page<SimplifiedAlbum>,
 }

--- a/rspotify-model/src/show.rs
+++ b/rspotify-model/src/show.rs
@@ -130,10 +130,10 @@ pub struct FullEpisode {
     pub show: SimplifiedShow,
 }
 
-/// Episodes feature object wrapped by `Vec`
+/// Intermediate episodes feature object wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-episodes)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Deserialize)]
 pub struct EpisodesPayload {
     pub episodes: Vec<FullEpisode>,
 }
@@ -141,7 +141,7 @@ pub struct EpisodesPayload {
 /// Resume point object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-resumepointobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ResumePoint {
     pub fully_played: bool,
     #[serde(with = "duration_ms", rename = "resume_position_ms")]

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -47,7 +47,7 @@ pub struct TrackLink {
     pub id: TrackId,
 }
 
-/// Full track wrapped by `Vec`
+/// Intermediate full track wrapped by `Vec`
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
 #[derive(Deserialize)]
@@ -61,7 +61,7 @@ pub struct FullTracks {
 /// relinking is applied.
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedtrackobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedTrack {
     pub artists: Vec<SimplifiedArtist>,
     pub available_markets: Option<Vec<String>>,

--- a/rspotify-model/src/user.rs
+++ b/rspotify-model/src/user.rs
@@ -40,7 +40,7 @@ pub struct PrivateUser {
 /// Explicit content setting object
 ///
 /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-explicitcontentsettingsobject)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ExplicitContent {
     pub filter_enabled: bool,
     pub filter_locked: bool,

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -880,7 +880,7 @@ where
         };
 
         let result = self.endpoint_get("browse/new-releases", &params).await?;
-        convert_result::<PageSimpliedAlbums>(&result).map(|x| x.albums)
+        convert_result::<PageSimplifiedAlbums>(&result).map(|x| x.albums)
     }
 
     /// Get Recommendations Based on Seeds


### PR DESCRIPTION
## Description

This adds a `#[derive(Default)]` where it is possible. I've also included a couple minor fixes, like renaming a model with a typo, or updating the docs of intermediate structs (i.e. holders of `Vec<T>` which are then simplified to just a `Vec<T>` in the client).

## Motivation and Context

This closes #33 and leaves #223 and #221 as the only issues left for the new release :))

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tests still pass perfectly.