### PR TITLE
Prettier docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,11 @@ __async = ["futures", "async-stream", "async-trait"]
 __sync = ["maybe-async/is_sync"]
 
 [package.metadata.docs.rs]
-# Documenting the CLI methods, and working links for `dotenv`
-features = ["cli", "env-file"]
+# When generating the docs, we also want to include the CLI methods, and working
+# links for `dotenv`. We generate them for ureq so that the function signatures
+# of the endpoints don't look gnarly (because of `async-trait`).
+features = ["cli", "env-file", "client-ureq"]
+default-features = false
 
 [[example]]
 name = "client_creds"


### PR DESCRIPTION
## Description

We currently generate the docs for `docs.rs` with the reqwest client. Unfortunately, since that uses async-trait, the function signatures are horrifying:

![image](https://user-images.githubusercontent.com/25647296/136866670-520fb996-a04c-4383-ae14-bcae5667fec4.png)

So this just enables `client-ureq` for the docs:

![image](https://user-images.githubusercontent.com/25647296/136866697-6e789122-f142-45b3-9d9b-d8702759bd5a.png)

Much better!

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

`cargo doc --no-default-features --features=cli,env-file,client-ureq --open`
