### PR TITLE
Add READMEs

### DIFF
--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -6,7 +6,6 @@ authors = [
 name = "rspotify-http"
 version = "0.11.0"
 license = "MIT"
-readme = "README.md"
 description = "HTTP compatibility layer for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"
 repository = "https://github.com/ramsayleung/rspotify"

--- a/rspotify-macros/Cargo.toml
+++ b/rspotify-macros/Cargo.toml
@@ -6,7 +6,6 @@ authors = [
 ]
 version = "0.11.0"
 license = "MIT"
-readme = "README.md"
 description = "Macros for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"
 repository = "https://github.com/ramsayleung/rspotify"

--- a/rspotify-model/Cargo.toml
+++ b/rspotify-model/Cargo.toml
@@ -6,7 +6,6 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 license = "MIT"
-readme = "README.md"
 description = "Model for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"
 repository = "https://github.com/ramsayleung/rspotify"


### PR DESCRIPTION
## Description

It is unexpectable that the reason of why CI flow of publishing failed is the lack of `README.md`, just adding `README.md` for all crates. Just an old Chinese proverb saying:

"good things never come easy" 

https://github.com/ramsayleung/rspotify/runs/3896242685?check_suite_focus=true

## Motivation and Context

Fix CI flow

## Dependencies 


## Type of change


## How Has This Been Tested?

