### PR TITLE
Fix docs for v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify"
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT"
 readme = "README.md"
 description = "Spotify API wrapper"
@@ -27,9 +27,9 @@ exclude = [
 resolver = "2"
 
 [dependencies]
-rspotify-macros = { path = "rspotify-macros", version = "0.11.0" }
-rspotify-model = { path = "rspotify-model", version = "0.11.0" }
-rspotify-http = { path = "rspotify-http", version = "0.11.0", default-features = false }
+rspotify-macros = { path = "rspotify-macros", version = "0.11.1" }
+rspotify-model = { path = "rspotify-model", version = "0.11.1" }
+rspotify-http = { path = "rspotify-http", version = "0.11.1", default-features = false }
 
 async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify-http"
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT"
 description = "HTTP compatibility layer for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"
@@ -28,7 +28,7 @@ ureq = { version = "2.2.0", default-features = false, features = ["json", "cooki
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
-rspotify-model = { path = "../rspotify-model", version = "0.11.0" }
+rspotify-model = { path = "../rspotify-model", version = "0.11.1" }
 
 [features]
 default = ["client-reqwest", "reqwest-default-tls"]

--- a/rspotify-macros/Cargo.toml
+++ b/rspotify-macros/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT"
 description = "Macros for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"

--- a/rspotify-model/Cargo.toml
+++ b/rspotify-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspotify-model"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"


### PR DESCRIPTION
Turns out we also need #268 for `rspotify-http`, since the docs failed in the new release: https://docs.rs/crate/rspotify/0.11.0/builds/447703