### PR TITLE
Make `available_markets` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.11.3
 
-* Make `available_markets` optional for `FullAlbum`
+**Breaking changes:**
+- ([#286](https://github.com/ramsayleung/rspotify/pull/286)) Make `available_markets` optional for `FullAlbum`
 
 ## 0.11 (2021.10.14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.3
+
+* Make `available_markets` optional for `FullAlbum`
+
 ## 0.11 (2021.10.14)
 
 This release contains *lots* of breaking changes. These were necessary to continue Rspotify's development, and this shouldn't happen again. From now on we'll work on getting closer to the first stable release. Lots of internal code was rewritten to make Rspotify more flexible, performant and easier to use. Sorry for the inconvenience!

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -41,7 +41,7 @@ pub struct SimplifiedAlbum {
 pub struct FullAlbum {
     pub artists: Vec<SimplifiedArtist>,
     pub album_type: AlbumType,
-    pub available_markets: Vec<String>,
+    pub available_markets: Option<Vec<String>>,
     pub copyrights: Vec<Copyright>,
     pub external_ids: HashMap<String, String>,
     pub external_urls: HashMap<String, String>,

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -209,6 +209,9 @@ async fn test_current_user_saved_albums() {
 
     // Making sure the new albums appear
     let all_albums = fetch_all(client.current_user_saved_albums(None)).await;
+    // Can handle albums without available_market
+    let _albums_from_token =
+        fetch_all(client.current_user_saved_albums(Some(&Market::FromToken))).await;
     let all_uris = all_albums
         .into_iter()
         .map(|a| a.album.id)


### PR DESCRIPTION
## Description

Fixes https://github.com/ramsayleung/rspotify/issues/285

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Test suite was extended
