### PR TITLE
Add reminder about changelog in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Please delete options that are not relevant.
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
-## How Has This Been Tested?
+## How has this been tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
 
@@ -27,3 +27,9 @@ Please also list any relevant details for your test configuration
 
 - [ ] Test A: xxx
 - [ ] Test B: xxx
+
+## Is this change properly documented?
+
+Please make sure you've properly documented the changes you're making.
+
+Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).


### PR DESCRIPTION
## Description

This adds a small reminder to document and update the changelog when creating a new PR. I always forget about the latter myself, so it's good to have. Let me know if you like the text, Ramsay.

## Motivation and Context

https://github.com/ramsayleung/rspotify/pull/282#issuecomment-974654020

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No need to
