### PR TITLE
Remove most references, clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.11.3 (unreleased)
 
+- ([#281](https://github.com/ramsayleung/rspotify/issues/281)) The documentation website for the Spotify API has been changed, so the links in the `rspotify` crate have been updated. Unfortunately, the object model section has been removed, so we've had to delete most reference links in `rspotify-model`. From now on, you should refer to the endpoints where they are used to see their definition.
+
 **Breaking changes:**
 - ([#286](https://github.com/ramsayleung/rspotify/pull/286)) Make `available_markets` optional for `FullAlbum`
 - ([#282](https://github.com/ramsayleung/rspotify/pull/282)) Make `id` optional for `FullTrack`

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -11,8 +11,6 @@ use crate::{
 };
 
 /// Simplified Album Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedalbumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedAlbum {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,8 +33,6 @@ pub struct SimplifiedAlbum {
 }
 
 /// Full Album Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-albumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullAlbum {
     pub artists: Vec<SimplifiedArtist>,
@@ -57,24 +53,18 @@ pub struct FullAlbum {
 }
 
 /// Intermediate full Albums wrapped by Vec object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
 #[derive(Deserialize)]
 pub struct FullAlbums {
     pub albums: Vec<FullAlbum>,
 }
 
 /// Intermediate simplified Albums wrapped by Page object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-new-releases)
 #[derive(Deserialize)]
 pub struct PageSimplifiedAlbums {
     pub albums: Page<SimplifiedAlbum>,
 }
 
 /// Saved Album object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedalbumobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SavedAlbum {
     pub added_at: DateTime<Utc>,
@@ -82,8 +72,6 @@ pub struct SavedAlbum {
 }
 
 /// Album restriction object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-albumrestrictionobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Restriction {
     pub reason: RestrictionReason,

--- a/rspotify-model/src/artist.rs
+++ b/rspotify-model/src/artist.rs
@@ -7,8 +7,6 @@ use std::collections::HashMap;
 use crate::{ArtistId, CursorBasedPage, Followers, Image};
 
 /// Simplified Artist Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedartistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedArtist {
     pub external_urls: HashMap<String, String>,
@@ -18,8 +16,6 @@ pub struct SimplifiedArtist {
 }
 
 /// Full Artist Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-artistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullArtist {
     pub external_urls: HashMap<String, String>,
@@ -33,16 +29,12 @@ pub struct FullArtist {
 }
 
 /// Intermediate full artist object wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
 #[derive(Deserialize)]
 pub struct FullArtists {
     pub artists: Vec<FullArtist>,
 }
 
 /// Intermediate full Artists vector wrapped by cursor-based-page object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-followed)
 #[derive(Deserialize)]
 pub struct CursorPageFullArtists {
     pub artists: CursorBasedPage<FullArtist>,

--- a/rspotify-model/src/audio.rs
+++ b/rspotify-model/src/audio.rs
@@ -10,8 +10,6 @@ use crate::{
 };
 
 /// Audio Feature Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-audiofeaturesobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioFeatures {
     pub acousticness: f32,
@@ -35,16 +33,12 @@ pub struct AudioFeatures {
 }
 
 /// Intermediate audio feature object wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features)
 #[derive(Deserialize)]
 pub struct AudioFeaturesPayload {
     pub audio_features: Vec<AudioFeatures>,
 }
 
 /// Audio analysis object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysis {
     pub bars: Vec<TimeInterval>,
@@ -57,7 +51,6 @@ pub struct AudioAnalysis {
 }
 
 /// Time interval object
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct TimeInterval {
     pub start: f32,
@@ -66,8 +59,6 @@ pub struct TimeInterval {
 }
 
 /// Audio analysis section object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisSection {
     #[serde(flatten)]
@@ -85,8 +76,6 @@ pub struct AudioAnalysisSection {
 }
 
 /// Audio analysis meta object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct AudioAnalysisMeta {
     pub analyzer_version: String,
@@ -99,8 +88,6 @@ pub struct AudioAnalysisMeta {
 }
 
 /// Audio analysis segment object
-///
-///[Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct AudioAnalysisSegment {
     #[serde(flatten)]
@@ -114,8 +101,6 @@ pub struct AudioAnalysisSegment {
 }
 
 /// Audio analysis track object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-audio-analysis)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AudioAnalysisTrack {
     pub num_samples: u32,

--- a/rspotify-model/src/category.rs
+++ b/rspotify-model/src/category.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 use crate::{Image, Page};
 
 /// Category object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Category {
     pub href: String,
@@ -16,8 +14,6 @@ pub struct Category {
 }
 
 /// Intermediate categories wrapped by page object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-categories)
 #[derive(Deserialize)]
 pub struct PageCategory {
     pub categories: Page<Category>,

--- a/rspotify-model/src/context.rs
+++ b/rspotify-model/src/context.rs
@@ -12,8 +12,6 @@ use crate::{
 };
 
 /// Context object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Context {
     /// The URI may be of any type, so it's not parsed into a [`crate::Id`]
@@ -25,8 +23,6 @@ pub struct Context {
 }
 
 /// Currently playing object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentlyPlayingContext {
     pub context: Option<Context>,
@@ -40,7 +36,7 @@ pub struct CurrentlyPlayingContext {
     pub currently_playing_type: CurrentlyPlayingType,
     pub actions: Actions,
 }
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-information-about-the-users-current-playback)
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CurrentPlaybackContext {
     pub device: Device,
@@ -59,8 +55,6 @@ pub struct CurrentPlaybackContext {
 }
 
 /// Actions object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, Default)]
 pub struct Actions {
     pub disallows: Vec<DisallowKey>,

--- a/rspotify-model/src/device.rs
+++ b/rspotify-model/src/device.rs
@@ -2,8 +2,6 @@ use crate::DeviceType;
 use serde::{Deserialize, Serialize};
 
 /// Device object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Device {
     pub id: Option<String>,
@@ -17,8 +15,6 @@ pub struct Device {
 }
 
 /// Intermediate device payload object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 #[derive(Deserialize)]
 pub struct DevicePayload {
     pub devices: Vec<Device>,

--- a/rspotify-model/src/enums/country.rs
+++ b/rspotify-model/src/enums/country.rs
@@ -3,8 +3,6 @@ use strum::AsRefStr;
 
 /// ISO 3166-1 alpha-2 country code, from
 /// [country-list](https://datahub.io/core/country-list)
-///
-/// [Reference](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 pub enum Country {
     #[strum(serialize = "AF")]

--- a/rspotify-model/src/enums/misc.rs
+++ b/rspotify-model/src/enums/misc.rs
@@ -7,8 +7,6 @@ use super::Country;
 /// Disallows object: `interrupting_playback`, `pausing`, `resuming`, `seeking`,
 /// `skipping_next`, `skipping_prev`, `toggling_repeat_context`,
 /// `toggling_shuffle`, `toggling_repeat_track`, `transferring_playback`.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-disallowsobject)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Hash, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -26,8 +24,6 @@ pub enum DisallowKey {
 }
 
 /// Time range: `long-term`, `medium-term`, `short-term`.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/personalization/get-users-top-artists-and-tracks/)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -38,8 +34,6 @@ pub enum TimeRange {
 }
 
 /// Repeat state: `track`, `context` or `off`.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/set-repeat-mode-on-users-playback/)
 #[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -50,8 +44,6 @@ pub enum RepeatState {
 }
 
 /// Type for include_external: `audio`.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-search)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -60,8 +52,6 @@ pub enum IncludeExternal {
 }
 
 /// Date precision: `year`, `month`, `day`.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/object-model/):
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -72,8 +62,6 @@ pub enum DatePrecision {
 }
 
 /// The reason for the restriction: `market`, `product`, `explicit`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-albumrestrictionobject)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -87,8 +75,6 @@ pub enum RestrictionReason {
 ///
 /// This field will contain a 0 for `minor`, a 1 for `major` or a -1 for `no
 /// result`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#objects-index)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 pub enum Modality {
     Minor = 0,
@@ -115,8 +101,6 @@ impl AsRef<str> for Market {
 }
 
 /// Time limits in miliseconds (unix timestamps)
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played)
 #[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 pub enum TimeLimits {
     Before(DateTime<Utc>),

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -3,8 +3,6 @@ use strum::{AsRefStr, Display, EnumString};
 
 /// Copyright type: `C` = the copyright, `P` = the sound recording (performance)
 /// copyright.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-copyrightobject)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 pub enum CopyrightType {
     #[strum(serialize = "P")]
@@ -16,8 +14,6 @@ pub enum CopyrightType {
 }
 
 /// Album type: `album`, `single`, `appears_on`, `compilation`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#objects-index)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -45,8 +41,6 @@ pub enum Type {
 }
 
 /// Additional typs: `track`, `episode`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -56,8 +50,6 @@ pub enum AdditionalType {
 }
 
 /// Currently playing type: `track`, `episode`, `ad`, `unknown`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -71,8 +63,6 @@ pub enum CurrentlyPlayingType {
 }
 
 /// Type for search: `artist`, `album`, `track`, `playlist`, `show`, `episode`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -88,8 +78,6 @@ pub enum SearchType {
 /// The user's Spotify subscription level: `premium`, `free`
 ///
 /// (The subscription level "open" can be considered the same as "free".)
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-current-users-profile)
 #[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -100,8 +88,6 @@ pub enum SubscriptionLevel {
 }
 
 /// Device Type: `computer`, `smartphone`, `speaker`, `TV`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-deviceobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum DeviceType {
@@ -121,8 +107,6 @@ pub enum DeviceType {
 }
 
 /// Recommendations seed type
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum RecommendationsSeedType {

--- a/rspotify-model/src/image.rs
+++ b/rspotify-model/src/image.rs
@@ -3,8 +3,6 @@
 use serde::{Deserialize, Serialize};
 
 /// Image object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-imageobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Image {
     pub height: Option<u32>,

--- a/rspotify-model/src/lib.rs
+++ b/rspotify-model/src/lib.rs
@@ -1,6 +1,6 @@
-//! All Spotify API endpoint response objects.
-//!
-//! [Reference](https://developer.spotify.com/documentation/web-api/reference/#objects-index)
+//! All Spotify API endpoint response objects. Please refer to the endpoints
+//! where they are used for a link to their reference in the Spotify API
+//! documentation.
 
 pub mod album;
 pub mod artist;
@@ -33,8 +33,6 @@ pub use {
 use serde::{Deserialize, Serialize};
 
 /// Followers object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-followersobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Followers {
     // This field will always set to null, as the Web API does not support it at the moment.
@@ -43,9 +41,6 @@ pub struct Followers {
 }
 
 /// A full track object or a full episode object
-///
-/// + [Reference to full track](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)
-/// + [Reference to full episode](https://developer.spotify.com/documentation/web-api/reference/#object-episodeobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum PlayableItem {

--- a/rspotify-model/src/offset.rs
+++ b/rspotify-model/src/offset.rs
@@ -1,8 +1,6 @@
 //! Offset object
 
 /// Offset object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Offset {
     Position(u32),

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -3,8 +3,6 @@
 use serde::{Deserialize, Serialize};
 
 /// Paging object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-pagingobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Page<T> {
     pub href: String,
@@ -17,8 +15,6 @@ pub struct Page<T> {
 }
 
 /// Cursor-based paging object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorpagingobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct CursorBasedPage<T> {
     pub href: String,
@@ -32,8 +28,6 @@ pub struct CursorBasedPage<T> {
 }
 
 /// Cursor object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-cursorobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Cursor {
     pub after: Option<String>,

--- a/rspotify-model/src/playing.rs
+++ b/rspotify-model/src/playing.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 use crate::{Context, FullTrack};
 
 /// Playing history object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playhistoryobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlayHistory {
     pub track: FullTrack,

--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -8,16 +8,12 @@ use std::collections::HashMap;
 use crate::{Followers, Image, Page, PlayableItem, PlaylistId, PublicUser};
 
 /// Playlist result object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistResult {
     pub snapshot_id: String,
 }
 
 /// Playlist Track Reference Object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttracksrefobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistTracksRef {
     pub href: String,
@@ -25,8 +21,6 @@ pub struct PlaylistTracksRef {
 }
 
 /// Simplified playlist object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedplaylistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedPlaylist {
     pub collaborative: bool,
@@ -42,8 +36,6 @@ pub struct SimplifiedPlaylist {
 }
 
 /// Full playlist object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlistobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullPlaylist {
     pub collaborative: bool,
@@ -61,8 +53,6 @@ pub struct FullPlaylist {
 }
 
 /// Playlist track object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-playlisttrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlaylistItem {
     pub added_at: Option<DateTime<Utc>>,
@@ -70,8 +60,8 @@ pub struct PlaylistItem {
     pub is_local: bool,
     pub track: Option<PlayableItem>,
 }
+
 /// Featured playlists object
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-featured-playlists)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FeaturedPlaylists {
     pub message: String,
@@ -79,8 +69,6 @@ pub struct FeaturedPlaylists {
 }
 
 /// Intermediate category playlists object wrapped by `Page`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-categories-playlists)
 #[derive(Deserialize)]
 pub struct CategoryPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -6,8 +6,6 @@ use strum::AsRefStr;
 use crate::{RecommendationsSeedType, SimplifiedTrack};
 
 /// Recommendations object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Recommendations {
     pub seeds: Vec<RecommendationsSeed>,
@@ -15,8 +13,6 @@ pub struct Recommendations {
 }
 
 /// Recommendations seed object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RecommendationsSeed {
     #[serde(rename = "afterFilteringSize")]
@@ -32,8 +28,6 @@ pub struct RecommendationsSeed {
 }
 
 /// The attributes for recommendations
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations)
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/rspotify-model/src/search.rs
+++ b/rspotify-model/src/search.rs
@@ -8,16 +8,12 @@ use crate::{
 };
 
 /// Search for playlists
-///
-///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search);
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,
 }
 
 /// Search for albums
-///
-///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SearchAlbums {
     pub albums: Page<SimplifiedAlbum>,
@@ -25,37 +21,30 @@ pub struct SearchAlbums {
 
 /// Search for artists
 ///
-///[Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchArtists {
     pub artists: Page<FullArtist>,
 }
 
-///[Search item](https://developer.spotify.com/documentation/web-api/reference/#category-search)
+/// Search item
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchTracks {
     pub tracks: Page<FullTrack>,
 }
 
 /// Search for shows
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchShows {
     pub shows: Page<SimplifiedShow>,
 }
 
 /// Search for episodes
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchEpisodes {
     pub episodes: Page<SimplifiedEpisode>,
 }
 
 /// Search result of any kind
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#category-search)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SearchResult {
     #[serde(rename = "playlists")]

--- a/rspotify-model/src/show.rs
+++ b/rspotify-model/src/show.rs
@@ -8,8 +8,6 @@ use crate::{
 };
 
 /// Copyright object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-copyrightobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Copyright {
     pub text: String,
@@ -18,8 +16,6 @@ pub struct Copyright {
 }
 
 /// Simplified show object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-showbase)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedShow {
     pub available_markets: Vec<String>,
@@ -38,16 +34,12 @@ pub struct SimplifiedShow {
 }
 
 /// SimplifiedShows wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-shows)
 #[derive(Deserialize)]
 pub struct SeversalSimplifiedShows {
     pub shows: Vec<SimplifiedShow>,
 }
 
 /// Saved show object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedshowobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Show {
     pub added_at: String,
@@ -55,8 +47,6 @@ pub struct Show {
 }
 
 /// Full show object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-showbase)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FullShow {
     pub available_markets: Vec<String>,
@@ -76,8 +66,6 @@ pub struct FullShow {
 }
 
 /// Simplified episode object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-episodebase)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedEpisode {
     pub audio_preview_url: Option<String>,
@@ -103,8 +91,6 @@ pub struct SimplifiedEpisode {
 }
 
 /// Full episode object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-episodebase)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullEpisode {
     pub audio_preview_url: Option<String>,
@@ -131,16 +117,12 @@ pub struct FullEpisode {
 }
 
 /// Intermediate episodes feature object wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-episodes)
 #[derive(Deserialize)]
 pub struct EpisodesPayload {
     pub episodes: Vec<FullEpisode>,
 }
 
 /// Resume point object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-resumepointobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ResumePoint {
     pub fully_played: bool,

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -10,8 +10,6 @@ use crate::{
 };
 
 /// Full track object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullTrack {
     pub album: SimplifiedAlbum,
@@ -41,8 +39,6 @@ pub struct FullTrack {
 }
 
 /// Track link object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-linkedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrackLink {
     pub external_urls: HashMap<String, String>,
@@ -51,8 +47,6 @@ pub struct TrackLink {
 }
 
 /// Intermediate full track wrapped by `Vec`
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
 #[derive(Deserialize)]
 pub struct FullTracks {
     pub tracks: Vec<FullTrack>,
@@ -62,8 +56,6 @@ pub struct FullTracks {
 ///
 /// `is_playable`, `linked_from` and `restrictions` will only be present when
 /// relinking is applied.
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedTrack {
     pub artists: Vec<SimplifiedArtist>,
@@ -86,8 +78,6 @@ pub struct SimplifiedTrack {
 }
 
 /// Saved track object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-savedtrackobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SavedTrack {
     pub added_at: DateTime<Utc>,

--- a/rspotify-model/src/user.rs
+++ b/rspotify-model/src/user.rs
@@ -7,8 +7,6 @@ use std::collections::HashMap;
 use crate::{Country, Followers, Image, SubscriptionLevel, UserId};
 
 /// Public user object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-publicuserobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PublicUser {
     pub display_name: Option<String>,
@@ -21,8 +19,6 @@ pub struct PublicUser {
 }
 
 /// Private user object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-privateuserobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrivateUser {
     pub country: Option<Country>,
@@ -38,8 +34,6 @@ pub struct PrivateUser {
 }
 
 /// Explicit content setting object
-///
-/// [Reference](https://developer.spotify.com/documentation/web-api/reference/#object-explicitcontentsettingsobject)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ExplicitContent {
     pub filter_enabled: bool,


### PR DESCRIPTION
## Description

This removes most references in the `rspotify-model` crate, since after the new update to the documentation site, their links have been removed.

## Motivation and Context

Closes #281 and we can release v0.11.3 now

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How has this been tested?

Tests work just fine

## Is this change properly documented?

Yes!
