### PR TITLE
Update rspotify to v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.3 (unreleased)
+## 0.11.3 (2021.11.29)
 
 - ([#281](https://github.com/ramsayleung/rspotify/issues/281)) The documentation website for the Spotify API has been changed, so the links in the `rspotify` crate have been updated. Unfortunately, the object model section has been removed, so we've had to delete most reference links in `rspotify-model`. From now on, you should refer to the endpoints where they are used to see their definition.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify"
-version = "0.11.2"
+version = "0.11.3"
 license = "MIT"
 readme = "README.md"
 description = "Spotify API wrapper"
@@ -27,9 +27,9 @@ exclude = [
 resolver = "2"
 
 [dependencies]
-rspotify-macros = { path = "rspotify-macros", version = "0.11.2" }
-rspotify-model = { path = "rspotify-model", version = "0.11.2" }
-rspotify-http = { path = "rspotify-http", version = "0.11.2", default-features = false }
+rspotify-macros = { path = "rspotify-macros", version = "0.11.3" }
+rspotify-model = { path = "rspotify-model", version = "0.11.3" }
+rspotify-http = { path = "rspotify-http", version = "0.11.3", default-features = false }
 
 async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify-http"
-version = "0.11.2"
+version = "0.11.3"
 license = "MIT"
 description = "HTTP compatibility layer for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"
@@ -28,7 +28,7 @@ ureq = { version = "2.2.0", default-features = false, features = ["json", "cooki
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
-rspotify-model = { path = "../rspotify-model", version = "0.11.2" }
+rspotify-model = { path = "../rspotify-model", version = "0.11.3" }
 
 [features]
 default = ["client-reqwest", "reqwest-default-tls"]

--- a/rspotify-macros/Cargo.toml
+++ b/rspotify-macros/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
-version = "0.11.2"
+version = "0.11.3"
 license = "MIT"
 description = "Macros for Rspotify"
 homepage = "https://github.com/ramsayleung/rspotify"

--- a/rspotify-model/Cargo.toml
+++ b/rspotify-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspotify-model"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"


### PR DESCRIPTION
## Description

This updates `rspotify` to v0.11.3 with some bugs fixed and document updated.

## Motivation and Context

To fix bugs and update document.

## Dependencies 

None

## Type of change

- [x] This change requires a documentation update

## How has this been tested?
Not yet, the CI should run after creating a new tag named `v0.11.3`

## Is this change properly documented?
Yes
