### PR TITLE
Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - ([#295](https://github.com/ramsayleung/rspotify/pull/295)) The `Tv` variant in `DeviceType` is actually case insensitive.
 - ([#296](https://github.com/ramsayleung/rspotify/pull/296)) The `Avr` variant in `DeviceType` is actually case insensitive.
+- ([#302](https://github.com/ramsayleung/rspotify/pull/302)) Added undocumented `label` field to `FullAlbum`.
 
 ## 0.11.3 (2021.11.29)
 

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -51,7 +51,7 @@ pub struct FullAlbum {
     pub release_date_precision: DatePrecision,
     pub tracks: Page<SimplifiedTrack>,
     /// Not documented in official Spotify docs, however most albums do contain this field
-    pub label: Option<String>
+    pub label: Option<String>,
 }
 
 /// Intermediate full Albums wrapped by Vec object

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -30,6 +30,8 @@ pub struct SimplifiedAlbum {
     pub release_date_precision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restrictions: Option<Restriction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>
 }
 
 /// Full Album Object

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -50,6 +50,7 @@ pub struct FullAlbum {
     pub release_date: String,
     pub release_date_precision: DatePrecision,
     pub tracks: Page<SimplifiedTrack>,
+    /// Not documented in official Spotify docs, however most albums do contain this field
     pub label: Option<String>
 }
 

--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -30,8 +30,6 @@ pub struct SimplifiedAlbum {
     pub release_date_precision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restrictions: Option<Restriction>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>
 }
 
 /// Full Album Object
@@ -52,6 +50,7 @@ pub struct FullAlbum {
     pub release_date: String,
     pub release_date_precision: DatePrecision,
     pub tracks: Page<SimplifiedTrack>,
+    pub label: Option<String>
 }
 
 /// Intermediate full Albums wrapped by Vec object


### PR DESCRIPTION
## Description

There is a label field missing in the `FullAlbum` struct. I know it's not in the documentation, but most albums do have label in the response from Spotify.

Example album ids:
```
40bmDCrlJYB1pEDNPcelol
5sIfNTG9Yp5bzYPcWxgEWo
0sNOF9WDwhWunNAHPD3Baj
```

## Motivation and Context
Missing label field in Album response.

## Dependencies 
None

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

You can just run the `client_creds` (unmodified) and the example album will have label.
```
cargo run --example client_creds --features="env-file cli client-reqwest" 
```

## Is this change properly documented?

Very minor change, let me know if I should add to CHANGELOG.