### PR TITLE
Optional cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - ([#295](https://github.com/ramsayleung/rspotify/pull/295)) The `Tv` variant in `DeviceType` is actually case insensitive.
 - ([#296](https://github.com/ramsayleung/rspotify/pull/296)) The `Avr` variant in `DeviceType` is actually case insensitive.
+- ([#303](https://github.com/ramsayleung/rspotify/pull/303)) The `cursors` field in `CursorBasedPage` is now optional.
 
 ## 0.11.3 (2021.11.29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 - ([#295](https://github.com/ramsayleung/rspotify/pull/295)) The `Tv` variant in `DeviceType` is actually case insensitive.
 - ([#296](https://github.com/ramsayleung/rspotify/pull/296)) The `Avr` variant in `DeviceType` is actually case insensitive.
-- ([#303](https://github.com/ramsayleung/rspotify/pull/303)) The `cursors` field in `CursorBasedPage` is now optional.
 - ([#302](https://github.com/ramsayleung/rspotify/pull/302)) Added undocumented `label` field to `FullAlbum`.
+
+**Breaking changes:**
+- ([#303](https://github.com/ramsayleung/rspotify/pull/303)) The `cursors` field in `CursorBasedPage` is now optional.
 
 ## 0.11.3 (2021.11.29)
 

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -21,7 +21,7 @@ pub struct CursorBasedPage<T> {
     pub items: Vec<T>,
     pub limit: u32,
     pub next: Option<String>,
-    pub cursors: Cursor,
+    pub cursors: Option<Cursor>,
     /// Absent if it has read all data items. This field doesn't match what
     /// Spotify document says
     pub total: Option<u32>,

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -164,7 +164,7 @@ async fn test_fake_playlist() {
         .await
         .playlist(&playlist_id, None, None)
         .await;
-    assert!(!playlist.is_ok());
+    assert!(playlist.is_err());
 }
 
 mod test_pagination {

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -217,9 +217,7 @@ async fn test_current_user_saved_albums() {
         .map(|a| a.album.id)
         .collect::<Vec<_>>();
     assert!(
-        album_ids
-            .iter()
-            .all(|item| all_uris.contains(&(*item).to_owned())),
+        album_ids.iter().all(|item| all_uris.contains(item)),
         "couldn't find the new saved albums"
     );
 


### PR DESCRIPTION
## Description

This makes the `cursors` field optional. It also fixes a couple new clippy warnings.

## Motivation and Context

See #301

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

See #301. Furthermore, all tests continue to pass.

## Is this change properly documented?
Yes