### PR TITLE
Add `collection` variant to `Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.5 (unreleased)
+
+**Breaking changes**:
+- ([#306](https://github.com/ramsayleung/rspotify/pull/306)) The `collection` variant has been added to `Type`
+
 ## 0.11.4 (2022.03.08)
 
 - ([#295](https://github.com/ramsayleung/rspotify/pull/295)) The `Tv` variant in `DeviceType` is actually case insensitive.

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -38,6 +38,7 @@ pub enum Type {
     User,
     Show,
     Episode,
+    Collection,
 }
 
 /// Additional typs: `track`, `episode`


### PR DESCRIPTION
## Description

This simply adds a `Collection` variant to `Type`

## Motivation and Context

See https://github.com/ramsayleung/rspotify/issues/218#issuecomment-1066061035

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

CI still passes

## Is this change properly documented?

Yes