### PR TITLE
Deserialize Id types via an ephemeral string slice instead of one borrowed from the input

### DIFF
--- a/rspotify-model/src/idtypes.rs
+++ b/rspotify-model/src/idtypes.rs
@@ -342,6 +342,15 @@ macro_rules! define_impls {
                         }
 
                         #[inline]
+                        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
+                            $name::from_id_or_uri(value)
+                            .map_err(serde::de::Error::custom)
+                        }
+
+                        #[inline]
                         fn visit_newtype_struct<A>(
                             self,
                             deserializer: A,
@@ -349,9 +358,7 @@ macro_rules! define_impls {
                         where
                             A: serde::Deserializer<'de>,
                         {
-                            let field = <&str>::deserialize(deserializer)?;
-                            $name::from_id_or_uri(field)
-                                .map_err(serde::de::Error::custom)
+                            deserializer.deserialize_str(self)
                         }
 
                         #[inline]


### PR DESCRIPTION
## Description
Call deserialize_str instead of deserializing a &str directly
Closes #316

## Motivation and Context

Currently the id types can only be deserialized when they can be borrowed directly from the input, but they don't actually need to have a long lived borrow of the string. The ephemeral &str from deserialize_str is sufficient.

## Dependencies 

N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I added a function to `test_models.rs` which calls both serde_json::from_str and serde_json::from_reader and replaced the calls to serde_json::from_str with it. I was originally asserting the outputs were equal but `test_current_playback_context` and `test_currently_playing_context` consistently failed, possibly due to floating point imprecision?



## Is this change properly documented?

I'm not sure if this needs to be added to the changelog. It's relatively unlikely that anyone was hitting this issue in the first place.
