### PR TITLE
Remove unnecessary mutable references in clients

### DIFF
--- a/examples/auth_code.rs
+++ b/examples/auth_code.rs
@@ -35,7 +35,7 @@ async fn main() {
     // ```
     let oauth = OAuth::from_env(scopes!("user-read-currently-playing")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/client_creds.rs
+++ b/examples/client_creds.rs
@@ -24,7 +24,7 @@ async fn main() {
     // ```
     let creds = Credentials::from_env().unwrap();
 
-    let mut spotify = ClientCredsSpotify::new(creds);
+    let spotify = ClientCredsSpotify::new(creds);
 
     // Obtaining the access token. Requires to be mutable because the internal
     // token will be modified. We don't need OAuth for this specific endpoint,

--- a/examples/oauth_tokens.rs
+++ b/examples/oauth_tokens.rs
@@ -38,7 +38,7 @@ async fn main() {
     );
     let oauth = OAuth::from_env(scopes).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     let url = spotify.get_authorize_url(false).unwrap();
     // This function requires the `cli` feature enabled.

--- a/examples/pagination_async.rs
+++ b/examples/pagination_async.rs
@@ -20,7 +20,7 @@ async fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-library-read")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/pagination_manual.rs
+++ b/examples/pagination_manual.rs
@@ -13,7 +13,7 @@ async fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-library-read")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/pagination_sync.rs
+++ b/examples/pagination_sync.rs
@@ -20,7 +20,7 @@ fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-library-read")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -11,7 +11,7 @@ async fn main() {
     // aren't configured manually.
     let creds = Credentials::from_env().unwrap();
 
-    let mut spotify = ClientCredsSpotify::new(creds);
+    let spotify = ClientCredsSpotify::new(creds);
     let ids = [
         AlbumId::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap(),
         AlbumId::from_uri("spotify:album:5EBb7SSkPgxO9Lmt8NjAPT").unwrap(),

--- a/examples/ureq/device.rs
+++ b/examples/ureq/device.rs
@@ -9,7 +9,7 @@ fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-read-playback-state")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/ureq/me.rs
+++ b/examples/ureq/me.rs
@@ -9,7 +9,7 @@ fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-read-playback-state")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/ureq/search.rs
+++ b/examples/ureq/search.rs
@@ -11,7 +11,7 @@ fn main() {
     // May require the `env-file` feature enabled if the environment variables
     // aren't configured manually.
     let creds = Credentials::from_env().unwrap();
-    let mut spotify = ClientCredsSpotify::new(creds);
+    let spotify = ClientCredsSpotify::new(creds);
 
     // Obtaining the access token
     spotify.request_token().unwrap();

--- a/examples/ureq/seek_track.rs
+++ b/examples/ureq/seek_track.rs
@@ -9,7 +9,7 @@ fn main() {
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-read-playback-state")).unwrap();
 
-    let mut spotify = AuthCodeSpotify::new(creds, oauth);
+    let spotify = AuthCodeSpotify::new(creds, oauth);
 
     // Obtaining the access token
     let url = spotify.get_authorize_url(false).unwrap();

--- a/examples/ureq/threading.rs
+++ b/examples/ureq/threading.rs
@@ -12,7 +12,7 @@ fn main() {
     // aren't configured manually.
     let creds = Credentials::from_env().unwrap();
 
-    let mut spotify = ClientCredsSpotify::new(creds);
+    let spotify = ClientCredsSpotify::new(creds);
     let ids = [
         AlbumId::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap(),
         AlbumId::from_uri("spotify:album:5EBb7SSkPgxO9Lmt8NjAPT").unwrap(),

--- a/examples/webapp/src/main.rs
+++ b/examples/webapp/src/main.rs
@@ -103,7 +103,7 @@ fn init_spotify(cookies: &Cookies) -> AuthCodeSpotify {
 
 #[get("/callback?<code>")]
 fn callback(cookies: Cookies, code: String) -> AppResponse {
-    let mut spotify = init_spotify(&cookies);
+    let spotify = init_spotify(&cookies);
 
     match spotify.request_token(&code) {
         Ok(_) => {
@@ -163,7 +163,7 @@ fn sign_out(cookies: Cookies) -> AppResponse {
 
 #[get("/playlists")]
 fn playlist(cookies: Cookies) -> AppResponse {
-    let mut spotify = init_spotify(&cookies);
+    let spotify = init_spotify(&cookies);
     if !spotify.config.cache_path.exists() {
         return AppResponse::Redirect(Redirect::to("/"));
     }
@@ -184,7 +184,7 @@ fn playlist(cookies: Cookies) -> AppResponse {
 
 #[get("/me")]
 fn me(cookies: Cookies) -> AppResponse {
-    let mut spotify = init_spotify(&cookies);
+    let spotify = init_spotify(&cookies);
     if !spotify.config.cache_path.exists() {
         return AppResponse::Redirect(Redirect::to("/"));
     }

--- a/examples/with_auto_reauth.rs
+++ b/examples/with_auto_reauth.rs
@@ -66,7 +66,7 @@ async fn with_auth(creds: Credentials, oauth: OAuth, config: Config) {
     // In the first session of the application we authenticate and obtain the
     // refresh token.
     println!(">>> Session one, obtaining refresh token and running some requests:");
-    let mut spotify = AuthCodeSpotify::with_config(creds.clone(), oauth, config.clone());
+    let spotify = AuthCodeSpotify::with_config(creds.clone(), oauth, config.clone());
     let url = spotify.get_authorize_url(false).unwrap();
     // This function requires the `cli` feature enabled.
     spotify
@@ -91,7 +91,7 @@ async fn with_auth(creds: Credentials, oauth: OAuth, config: Config) {
 async fn with_client_credentials(creds: Credentials, config: Config) {
     // Same with client-credential based spotify client
     println!(">>> New Session one from ClientCredsSpotify, obtaining token and doing things");
-    let mut spotify = ClientCredsSpotify::with_config(creds, config);
+    let spotify = ClientCredsSpotify::with_config(creds, config);
     spotify.request_token().await.unwrap();
 
     // We can now perform requests

--- a/examples/with_refresh_token.rs
+++ b/examples/with_refresh_token.rs
@@ -57,7 +57,7 @@ async fn main() {
     // aren't configured manually.
     let creds = Credentials::from_env().unwrap();
     let oauth = OAuth::from_env(scopes!("user-follow-read user-follow-modify")).unwrap();
-    let mut spotify = AuthCodeSpotify::new(creds.clone(), oauth.clone());
+    let spotify = AuthCodeSpotify::new(creds.clone(), oauth.clone());
 
     // In the first session of the application we authenticate and obtain the
     // refresh token. We can also do some requests here.

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -123,7 +123,7 @@ impl OAuthClient for AuthCodeSpotify {
 
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
-    async fn request_token(&mut self, code: &str) -> ClientResult<()> {
+    async fn request_token(&self, code: &str) -> ClientResult<()> {
         log::info!("Requesting Auth Code token");
 
         let scopes = join_scopes(&self.oauth.scopes);

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -88,7 +88,7 @@ impl OAuthClient for AuthCodePkceSpotify {
     /// Note that the code verifier must be set at this point, either manually
     /// or with [`Self::get_authorize_url`]. Otherwise, this function will
     /// panic.
-    async fn request_token(&mut self, code: &str) -> ClientResult<()> {
+    async fn request_token(&self, code: &str) -> ClientResult<()> {
         log::info!("Requesting PKCE Auth Code token");
 
         let verifier = self.verifier.as_ref().expect(

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -127,7 +127,7 @@ impl ClientCredsSpotify {
     /// Obtains the client access token for the app. The resulting token will be
     /// saved internally.
     #[maybe_async]
-    pub async fn request_token(&mut self) -> ClientResult<()> {
+    pub async fn request_token(&self) -> ClientResult<()> {
         log::info!("Requesting Client Credentials token");
 
         *self.token.lock().await.unwrap() = Some(self.fetch_token().await?);

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -33,7 +33,7 @@ pub trait OAuthClient: BaseClient {
 
     /// Obtains a user access token given a code, as part of the OAuth
     /// authentication. The access token will be saved internally.
-    async fn request_token(&mut self, code: &str) -> ClientResult<()>;
+    async fn request_token(&self, code: &str) -> ClientResult<()>;
 
     /// Tries to read the cache file's token.
     ///
@@ -56,7 +56,7 @@ pub trait OAuthClient: BaseClient {
     /// the application re-authenticate.
     ///
     /// [`ClientCredsSpotify::read_token_cache`]: crate::client_creds::ClientCredsSpotify::read_token_cache
-    async fn read_token_cache(&mut self, allow_expired: bool) -> ClientResult<Option<Token>> {
+    async fn read_token_cache(&self, allow_expired: bool) -> ClientResult<Option<Token>> {
         if !self.get_config().token_cached {
             log::info!("Auth token cache read ignored (not configured)");
             return Ok(None);
@@ -144,7 +144,7 @@ pub trait OAuthClient: BaseClient {
     /// [`Config::token_cached`]: crate::Config::token_cached
     #[cfg(feature = "cli")]
     #[maybe_async]
-    async fn prompt_for_token(&mut self, url: &str) -> ClientResult<()> {
+    async fn prompt_for_token(&self, url: &str) -> ClientResult<()> {
         match self.read_token_cache(true).await {
             Ok(Some(new_token)) => {
                 let expired = new_token.is_expired();

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -18,7 +18,7 @@ pub async fn creds_client() -> ClientCredsSpotify {
         )
     });
 
-    let mut spotify = ClientCredsSpotify::new(creds);
+    let spotify = ClientCredsSpotify::new(creds);
     spotify.request_token().await.unwrap();
     spotify
 }


### PR DESCRIPTION
## Description

`OAuthClient::request_token` takes self as `&mut`, yet all of its implementors are designed for an async environment, where inner mutability for their fields is required through `Arc<Mutex<_>>`, as is the case for the token fields, thus self doesn't actually have to be a mutable reference. By making the reference immutable, it is much more comfortable to use the clients in application code, since there's no need to wrap them in e.g. a Mutex or an RwLock only for the one case where a mutable self is needlessly required.

However, `AuthCodePkceSpotify::get_authorize_url` is still left as is to take self as `&mut` since it has to set its `verifier` field, and converting that field to `Arc<Mutex<_>>` and converting the function into `async` would be a breaking change, hence I've left it out of this PR.

## Motivation and Context

I've been using the library recently and ran into this ergonomics issue.

## Dependencies 

None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

The crate test suite ran succesfully. I removed one unneeded `mut` in `tests/test_with_credential.rs`.

## Is this change properly documented?

I'm unsure if this is a breaking change, since existing application code will still work, it would just be beneficial for them to adapt to not requiring mutability anymore. If someone has implemented `OAuthClient` for their own type, though, it will be a breaking change since the trait signature has changed.
