### PR TITLE
Remove undocumented modules containing one item

### DIFF
--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,6 +1,6 @@
-pub mod base;
+mod base;
 pub mod mutex;
-pub mod oauth;
+mod oauth;
 pub mod pagination;
 
 pub use base::BaseClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,9 @@
 //! [spotify-auth-code-pkce]: https://developer.spotify.com/documentation/general/guides/authorization/code-flow
 //! [spotify-implicit-grant]: https://developer.spotify.com/documentation/general/guides/authorization/implicit-grant
 
-pub mod auth_code;
-pub mod auth_code_pkce;
-pub mod client_creds;
+mod auth_code;
+mod auth_code_pkce;
+mod client_creds;
 pub mod clients;
 
 // Subcrate re-exports


### PR DESCRIPTION
## Description

This removes the modules `auth_code`, `auth_code_pkce`, `client_creds`, `clients::base` and `clients::oauth` from the public API surface.

## Motivation and Context

These modules are unnecessary because they only export a single item which has the same name as the module itself anyway. Documentation is easier to navigate if they’re not present.

## Dependencies 

None.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] Test A: `cargo test --features env-file`

## Is this change properly documented?

- [ ] Will add a changelog entry once I have a PR number.