### PR TITLE
Replace `build_json!` with a JSON builder API

### DIFF
--- a/rspotify-macros/src/lib.rs
+++ b/rspotify-macros/src/lib.rs
@@ -24,62 +24,9 @@ macro_rules! scopes {
     }};
 }
 
-/// Count items in a list of items within a macro, taken from here:
-/// https://danielkeep.github.io/tlborm/book/blk-counting.html
-#[doc(hidden)]
-#[macro_export]
-macro_rules! replace_expr {
-    ($_t:tt $sub:expr) => {
-        $sub
-    };
-}
-#[doc(hidden)]
-#[macro_export]
-macro_rules! count_items {
-    ($($item:expr),*) => {<[()]>::len(&[$($crate::replace_expr!($item ())),*])};
-}
-
-/// Refer to the [`build_map`] documentation; this is the same but for JSON
-/// maps.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! internal_build_json {
-    (/* required */, $map:ident, $key:expr, $val:expr) => {
-        $map.insert($key.to_string(), json!($val));
-    };
-    (optional, $map:ident, $key:expr, $val:expr) => {
-        if let Some(val) = $val {
-            $map.insert($key.to_string(), json!(val));
-        }
-    };
-}
-#[doc(hidden)]
-#[macro_export]
-macro_rules! build_json {
-    (
-        $(
-            $( $kind:ident )? $key:literal : $val:expr
-        ),+ $(,)?
-    ) => {{
-        let mut params = ::serde_json::map::Map::with_capacity(
-            $crate::count_items!($( $key ),*)
-        );
-        $(
-            $crate::internal_build_json!(
-                $( $kind )?,
-                params,
-                $key,
-                $val
-            );
-        )+
-        ::serde_json::Value::from(params)
-    }};
-}
-
 #[cfg(test)]
 mod test {
-    use crate::{build_json, scopes};
-    use serde_json::{json, Map, Value};
+    use crate::scopes;
 
     #[test]
     fn test_hashset() {
@@ -89,30 +36,5 @@ mod test {
         assert!(scopes.contains("world"));
         assert!(scopes.contains("foo"));
         assert!(scopes.contains("bar"));
-    }
-
-    #[test]
-    fn test_json_query() {
-        // Passed as parameters, for example.
-        let id = "Pink Lemonade";
-        let artist = Some("The Wombats");
-        let market: Option<i32> = None;
-
-        let with_macro = build_json! {
-            "id": id,
-            optional "artist": artist,
-            optional "market": market.map(|x| x.to_string()),
-        };
-
-        let mut manually = Map::with_capacity(3);
-        manually.insert("id".to_string(), json!(id));
-        if let Some(val) = artist.map(|x| json!(x)) {
-            manually.insert("artist".to_string(), val);
-        }
-        if let Some(val) = market.map(|x| x.to_string()).map(|x| json!(x)) {
-            manually.insert("market".to_string(), val);
-        }
-
-        assert_eq!(with_macro, Value::from(manually));
     }
 }

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -6,9 +6,9 @@ use crate::{
     },
     http::{BaseHttpClient, Form, Headers, HttpClient, Query},
     join_ids,
-    macros::build_map,
     model::*,
     sync::Mutex,
+    util::build_map,
     ClientResult, Config, Credentials, Token,
 };
 
@@ -263,9 +263,7 @@ where
         market: Option<&Market>,
     ) -> ClientResult<Vec<FullTrack>> {
         let ids = join_ids(track_ids);
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("market", market.map(|x| x.as_ref()))]);
 
         let url = format!("tracks/?ids={}", ids);
         let result = self.endpoint_get(&url, &params).await?;
@@ -339,12 +337,12 @@ where
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "album_type": album_type.map(|x| x.as_ref()),
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("album_type", album_type.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let url = format!("artists/{}/albums", artist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -364,9 +362,7 @@ where
         artist_id: &ArtistId,
         market: &Market,
     ) -> ClientResult<Vec<FullTrack>> {
-        let params = build_map! {
-            "market": market.as_ref()
-        };
+        let params = build_map([("market", Some(market.as_ref()))]);
 
         let url = format!("artists/{}/top-tracks", artist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -442,14 +438,14 @@ where
     ) -> ClientResult<SearchResult> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            "q": q,
-            "type": _type.as_ref(),
-            optional "market": market.map(|x| x.as_ref()),
-            optional "include_external": include_external.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("q", Some(q)),
+            ("type", Some(_type.as_ref())),
+            ("market", market.map(|x| x.as_ref())),
+            ("include_external", include_external.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("search", &params).await?;
         convert_result(&result)
@@ -485,10 +481,7 @@ where
     ) -> ClientResult<Page<SimplifiedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([("limit", limit.as_deref()), ("offset", offset.as_deref())]);
 
         let url = format!("albums/{}/tracks", album_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -520,10 +513,7 @@ where
         fields: Option<&str>,
         market: Option<&Market>,
     ) -> ClientResult<FullPlaylist> {
-        let params = build_map! {
-            optional "fields": fields,
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("fields", fields), ("market", market.map(|x| x.as_ref()))]);
 
         let url = format!("playlists/{}", playlist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -544,9 +534,7 @@ where
         playlist_id: Option<&PlaylistId>,
         fields: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
-        let params = build_map! {
-            optional "fields": fields,
-        };
+        let params = build_map([("fields", fields)]);
 
         let url = match playlist_id {
             Some(playlist_id) => format!("users/{}/playlists/{}", user_id.id(), playlist_id.id()),
@@ -596,9 +584,7 @@ where
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-show)
     async fn get_a_show(&self, id: &ShowId, market: Option<&Market>) -> ClientResult<FullShow> {
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("market", market.map(|x| x.as_ref()))]);
 
         let url = format!("shows/{}", id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -619,10 +605,7 @@ where
         market: Option<&Market>,
     ) -> ClientResult<Vec<SimplifiedShow>> {
         let ids = join_ids(ids);
-        let params = build_map! {
-            "ids": &ids,
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.as_ref()))]);
 
         let result = self.endpoint_get("shows", &params).await?;
         convert_result::<SeversalSimplifiedShows>(&result).map(|x| x.shows)
@@ -666,11 +649,11 @@ where
     ) -> ClientResult<Page<SimplifiedEpisode>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_ref(),
-            optional "offset": offset.as_ref(),
-        };
+        let params = build_map([
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let url = format!("shows/{}/episodes", id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -692,9 +675,7 @@ where
         market: Option<&Market>,
     ) -> ClientResult<FullEpisode> {
         let url = format!("episodes/{}", id.id());
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("market", market.map(|x| x.as_ref()))]);
 
         let result = self.endpoint_get(&url, &params).await?;
         convert_result(&result)
@@ -713,10 +694,7 @@ where
         market: Option<&Market>,
     ) -> ClientResult<Vec<FullEpisode>> {
         let ids = join_ids(ids);
-        let params = build_map! {
-            "ids": &ids,
-            optional "market": market.map(|x| x.as_ref()),
-        };
+        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.as_ref()))]);
 
         let result = self.endpoint_get("episodes", &params).await?;
         convert_result::<EpisodesPayload>(&result).map(|x| x.episodes)
@@ -803,12 +781,12 @@ where
     ) -> ClientResult<Page<Category>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "locale": locale,
-            optional "country": country.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("locale", locale),
+            ("country", country.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
         let result = self.endpoint_get("browse/categories", &params).await?;
         convert_result::<PageCategory>(&result).map(|x| x.categories)
     }
@@ -850,11 +828,11 @@ where
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "country": country.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("country", country.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let url = format!("browse/categories/{}/playlists", category_id);
         let result = self.endpoint_get(&url, &params).await?;
@@ -889,13 +867,13 @@ where
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let timestamp = timestamp.map(|x| x.to_rfc3339());
-        let params = build_map! {
-            optional "locale": locale,
-            optional "country": country.map(|x| x.as_ref()),
-            optional "timestamp": timestamp.as_deref(),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("locale", locale),
+            ("country", country.map(|x| x.as_ref())),
+            ("timestamp", timestamp.as_deref()),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self
             .endpoint_get("browse/featured-playlists", &params)
@@ -935,11 +913,11 @@ where
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "country": country.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("country", country.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("browse/new-releases", &params).await?;
         convert_result::<PageSimplifiedAlbums>(&result).map(|x| x.albums)
@@ -975,13 +953,13 @@ where
         let seed_genres = seed_genres.map(|x| x.into_iter().collect::<Vec<_>>().join(","));
         let seed_tracks = seed_tracks.map(join_ids);
         let limit = limit.map(|x| x.to_string());
-        let mut params = build_map! {
-            optional "seed_artists": seed_artists.as_deref(),
-            optional "seed_genres": seed_genres.as_deref(),
-            optional "seed_tracks": seed_tracks.as_deref(),
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-        };
+        let mut params = build_map([
+            ("seed_artists", seed_artists.as_deref()),
+            ("seed_genres", seed_genres.as_deref()),
+            ("seed_tracks", seed_tracks.as_deref()),
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+        ]);
 
         // First converting the attributes into owned `String`s
         let owned_attributes = attributes
@@ -1038,12 +1016,12 @@ where
     ) -> ClientResult<Page<PlaylistItem>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "fields": fields,
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("fields", fields),
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let url = format!("playlists/{}/tracks", playlist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -1080,10 +1058,7 @@ where
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([("limit", limit.as_deref()), ("offset", offset.as_deref())]);
 
         let url = format!("users/{}/playlists", user_id.id());
         let result = self.endpoint_get(&url, &params).await?;

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     http::Query,
     join_ids,
-    macros::{build_json, build_map},
+    macros::build_json,
     model::*,
+    util::build_map,
     ClientResult, OAuth, Token,
 };
 
@@ -204,10 +205,7 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([("limit", limit.as_deref()), ("offset", offset.as_deref())]);
 
         let result = self.endpoint_get("me/playlists", &params).await?;
         convert_result(&result)
@@ -540,11 +538,11 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<SavedAlbum>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/albums", &params).await?;
         convert_result(&result)
@@ -583,11 +581,11 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<SavedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("market", market.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/tracks", &params).await?;
         convert_result(&result)
@@ -606,11 +604,11 @@ pub trait OAuthClient: BaseClient {
         limit: Option<u32>,
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
-        let params = build_map! {
-            "type": Type::Artist.as_ref(),
-            optional "after": after,
-            optional "limit": limit.as_deref(),
-        };
+        let params = build_map([
+            ("type", Some(Type::Artist.as_ref())),
+            ("after", after),
+            ("limit", limit.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/following", &params).await?;
         convert_result::<CursorPageFullArtists>(&result).map(|x| x.artists)
@@ -696,11 +694,11 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
-        let params = build_map! {
-            optional "time_range": time_range.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("time_range", time_range.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/top/artists", &params).await?;
         convert_result(&result)
@@ -738,11 +736,11 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<FullTrack>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "time_range": time_range.map(|x| x.as_ref()),
-            optional "limit": limit.as_deref(),
-            optional "offset": offset.as_deref(),
-        };
+        let params = build_map([
+            ("time_range", time_range.map(|x| x.as_ref())),
+            ("limit", limit.as_deref()),
+            ("offset", offset.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/top/tracks", &params).await?;
         convert_result(&result)
@@ -762,9 +760,7 @@ pub trait OAuthClient: BaseClient {
         time_limit: Option<TimeLimits>,
     ) -> ClientResult<CursorBasedPage<PlayHistory>> {
         let limit = limit.map(|x| x.to_string());
-        let mut params = build_map! {
-            optional "limit": limit.as_deref(),
-        };
+        let mut params = build_map([("limit", limit.as_deref())]);
 
         let time_limit = match time_limit {
             Some(TimeLimits::Before(y)) => Some(("before", y.timestamp_millis().to_string())),
@@ -942,10 +938,10 @@ pub trait OAuthClient: BaseClient {
                 .collect::<Vec<_>>()
                 .join(",")
         });
-        let params = build_map! {
-            optional "country": country.map(|x| x.as_ref()),
-            optional "additional_types": additional_types.as_deref(),
-        };
+        let params = build_map([
+            ("country", country.map(|x| x.as_ref())),
+            ("additional_types", additional_types.as_deref()),
+        ]);
 
         let result = self.endpoint_get("me/player", &params).await?;
         if result.is_empty() {
@@ -975,10 +971,10 @@ pub trait OAuthClient: BaseClient {
                 .collect::<Vec<_>>()
                 .join(",")
         });
-        let params = build_map! {
-            optional "market": market.map(|x| x.as_ref()),
-            optional "additional_types": additional_types.as_ref(),
-        };
+        let params = build_map([
+            ("market", market.map(|x| x.as_ref())),
+            ("additional_types", additional_types.as_deref()),
+        ]);
 
         let result = self
             .endpoint_get("me/player/currently-playing", &params)
@@ -1274,10 +1270,7 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<Page<Show>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let params = build_map! {
-            optional "limit": limit.as_ref(),
-            optional "offset": offset.as_ref(),
-        };
+        let params = build_map([("limit", limit.as_deref()), ("offset", offset.as_deref())]);
 
         let result = self.endpoint_get("me/shows", &params).await?;
         convert_result(&result)
@@ -1294,9 +1287,7 @@ pub trait OAuthClient: BaseClient {
         ids: impl IntoIterator<Item = &'a ShowId> + Send + 'a,
     ) -> ClientResult<Vec<bool>> {
         let ids = join_ids(ids);
-        let params = build_map! {
-            "ids": &ids,
-        };
+        let params = build_map([("ids", Some(&ids))]);
         let result = self.endpoint_get("me/shows/contains", &params).await?;
         convert_result(&result)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ mod auth_code_pkce;
 mod client_creds;
 pub mod clients;
 pub mod sync;
+mod util;
 
 // Subcrate re-exports
 pub use rspotify_http as http;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use serde::Serialize;
+
 pub(crate) fn build_map<'key, 'value, const N: usize>(
     array: [(&'key str, Option<&'value str>); N],
 ) -> HashMap<&'key str, &'value str> {
@@ -12,4 +14,30 @@ pub(crate) fn build_map<'key, 'value, const N: usize>(
         }
     }
     map
+}
+
+pub(crate) fn json_builder() -> JsonBuilder {
+    JsonBuilder(serde_json::Map::new())
+}
+
+pub(crate) struct JsonBuilder(serde_json::Map<String, serde_json::Value>);
+
+impl JsonBuilder {
+    pub(crate) fn field(mut self, name: &str, value: impl Serialize) -> Self {
+        self.0
+            .insert(name.to_owned(), serde_json::to_value(value).unwrap());
+        self
+    }
+
+    pub(crate) fn optional_field(self, name: &str, value: Option<impl Serialize>) -> Self {
+        if let Some(value) = value {
+            self.field(name, value)
+        } else {
+            self
+        }
+    }
+
+    pub(crate) fn build(self) -> serde_json::Value {
+        serde_json::Value::Object(self.0)
+    }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,15 @@
+//! General internal utilities used across this crate.
+
+use std::collections::HashMap;
+
+pub(crate) fn build_map<'key, 'value, const N: usize>(
+    array: [(&'key str, Option<&'value str>); N],
+) -> HashMap<&'key str, &'value str> {
+    let mut map = HashMap::with_capacity(N);
+    for (key, value) in array {
+        if let Some(value) = value {
+            map.insert(key, value);
+        }
+    }
+    map
+}


### PR DESCRIPTION
## Description

Instead of:

```rs
build_json! {
    "a": b,
    optional "c": d,
}
```

we now use:

```rs
json_builder()
    .field("a", b)
    .optional_field("c", d)
    .build()
```

I would’ve used an array-based API like in #328 but that doesn’t really work well here because the field value types can be any type rather than just strings.

## Dependencies 

None.

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] Test A: `cargo test --features env-file`
