### PR TITLE
Avoid accepting references to `Copy` types

### DIFF
--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -436,7 +436,7 @@ where
         q: &str,
         _type: &SearchType,
         market: Option<&Market>,
-        include_external: Option<&IncludeExternal>,
+        include_external: Option<IncludeExternal>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<SearchResult> {
@@ -446,7 +446,7 @@ where
             "q": q,
             "type": _type.as_ref(),
             optional "market": market.map(|x| x.as_ref()),
-            optional "include_external": include_external.map(|x| x.as_ref()),
+            optional "include_external": include_external.as_ref().map(|x| x.as_ref()),
             optional "limit": limit.as_deref(),
             optional "offset": offset.as_deref(),
         };
@@ -882,7 +882,7 @@ where
         &self,
         locale: Option<&str>,
         country: Option<&Market>,
-        timestamp: Option<&chrono::DateTime<chrono::Utc>>,
+        timestamp: Option<chrono::DateTime<chrono::Utc>>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<FeaturedPlaylists> {

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -675,9 +675,9 @@ pub trait OAuthClient: BaseClient {
     /// version of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks)
-    fn current_user_top_artists<'a>(
-        &'a self,
-        time_range: Option<&'a TimeRange>,
+    fn current_user_top_artists(
+        &self,
+        time_range: Option<TimeRange>,
     ) -> Paginator<'_, ClientResult<FullArtist>> {
         paginate(
             move |limit, offset| {
@@ -690,14 +690,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_top_artists`].
     async fn current_user_top_artists_manual(
         &self,
-        time_range: Option<&TimeRange>,
+        time_range: Option<TimeRange>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map! {
-            optional "time_range": time_range.map(|x| x.as_ref()),
+            optional "time_range": time_range.as_ref().map(|x| x.as_ref()),
             optional "limit": limit.as_deref(),
             optional "offset": offset.as_deref(),
         };
@@ -717,9 +717,9 @@ pub trait OAuthClient: BaseClient {
     /// version of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks)
-    fn current_user_top_tracks<'a>(
-        &'a self,
-        time_range: Option<&'a TimeRange>,
+    fn current_user_top_tracks(
+        &self,
+        time_range: Option<TimeRange>,
     ) -> Paginator<'_, ClientResult<FullTrack>> {
         paginate(
             move |limit, offset| {
@@ -732,14 +732,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_top_tracks`].
     async fn current_user_top_tracks_manual(
         &self,
-        time_range: Option<&TimeRange>,
+        time_range: Option<TimeRange>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<FullTrack>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map! {
-            optional "time_range": time_range.map(|x| x.as_ref()),
+            optional "time_range": time_range.as_ref().map(|x| x.as_ref()),
             optional "limit": limit.as_deref(),
             optional "offset": offset.as_deref(),
         };

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -267,7 +267,7 @@ async fn test_current_user_saved_tracks_add() {
 async fn test_current_user_top_artists() {
     oauth_client()
         .await
-        .current_user_top_artists_manual(Some(&TimeRange::ShortTerm), Some(10), Some(0))
+        .current_user_top_artists_manual(Some(TimeRange::ShortTerm), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -277,7 +277,7 @@ async fn test_current_user_top_artists() {
 async fn test_current_user_top_tracks() {
     oauth_client()
         .await
-        .current_user_top_tracks_manual(Some(&TimeRange::ShortTerm), Some(10), Some(0))
+        .current_user_top_tracks_manual(Some(TimeRange::ShortTerm), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -288,7 +288,7 @@ async fn test_featured_playlists() {
     let now: DateTime<Utc> = Utc::now();
     oauth_client()
         .await
-        .featured_playlists(None, None, Some(&now), Some(10), Some(0))
+        .featured_playlists(None, None, Some(now), Some(10), Some(0))
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

- `search` accepts `Option<IncludeExternal>` instead of `Option<&IncludeExternal>`
- `featured_playlists` accepts `Option<chrono::DateTime<chrono::Utc>>` instead of `Option<&chrono::DateTime<chrono::Utc>>`
- `current_user_top_artists[_manual]` and `current_user_top_tracks[_manual]` accept `Option<TimeRange>` instead of `Option<&TimeRange>`

I didn’t do the same for `Market` parameters because they’re not `Copy` (although they could be) — I’ll leave it to a separate PR.

## Motivation and Context

Accepting a reference to a `Copy` type is usually counterproductive, since you can just take it by value. For most types this makes the size of the parameters smaller, for the `Option<chrono::DateTime<chrono::Utc>>` it increases it from 8 bytes to 16 bytes but I think that’s acceptable.

## Dependencies 

None.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- [x] Test A: `cargo test --features env-file`
