### PR TITLE
Implement `Into<&'static str>` for all enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) All enums now implement `Into<&'static str>` as well as `AsRef<str>`
+- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) `Market` is now `Copy`
+
 **Breaking changes**:
 - ([#325](https://github.com/ramsayleung/rspotify/pull/325)) The `auth_code`, `auth_code_pkce`, `client_creds`, `clients::base` and `clients::oauth` modules have been removed from the public API; you should access the same types from their parent modules instead
 - ([#326](https://github.com/ramsayleung/rspotify/pull/326)) The `rspotify::clients::mutex` module has been renamed to `rspotify::sync`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Unreleased
 
-- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) All enums now implement `Into<&'static str>` as well as `AsRef<str>`
 - ([#331](https://github.com/ramsayleung/rspotify/pull/331)) `Market` is now `Copy`
 
 **Bugfixes**:
@@ -12,7 +11,7 @@
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `search` now accepts `Option<IncludeExternal>` instead of `Option<&IncludeExternal>`
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `featured_playlists` now accepts `Option<chrono::DateTime<chrono::Utc>>` instead of `Option<&chrono::DateTime<chrono::Utc>>`
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `current_user_top_artists[_manual]` and `current_user_top_tracks[_manual]` now accept `Option<TimeRange>` instead of `Option<&TimeRange>`
-- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) Enums no longer implement `AsRef<str>`
+- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) All enums now implement `Into<&'static str>` instead of `AsRef<str>`
 - ([#331](https://github.com/ramsayleung/rspotify/pull/331)) `Option<&Market>` parameters have been changed to `Option<Market>`
 
 ## 0.11.5 (2022.03.28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `search` now accepts `Option<IncludeExternal>` instead of `Option<&IncludeExternal>`
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `featured_playlists` now accepts `Option<chrono::DateTime<chrono::Utc>>` instead of `Option<&chrono::DateTime<chrono::Utc>>`
 - ([#330](https://github.com/ramsayleung/rspotify/pull/330)) `current_user_top_artists[_manual]` and `current_user_top_tracks[_manual]` now accept `Option<TimeRange>` instead of `Option<&TimeRange>`
+- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) Enums no longer implement `AsRef<str>`
+- ([#331](https://github.com/ramsayleung/rspotify/pull/331)) `Option<&Market>` parameters have been changed to `Option<Market>`
 
 ## 0.11.5 (2022.03.28)
 

--- a/examples/auth_code.rs
+++ b/examples/auth_code.rs
@@ -46,7 +46,7 @@ async fn main() {
     let market = Market::Country(Country::Spain);
     let additional_types = [AdditionalType::Episode];
     let artists = spotify
-        .current_playing(Some(&market), Some(&additional_types))
+        .current_playing(Some(market), Some(&additional_types))
         .await;
 
     println!("Response: {:?}", artists);

--- a/examples/ureq/search.rs
+++ b/examples/ureq/search.rs
@@ -17,7 +17,7 @@ fn main() {
     spotify.request_token().unwrap();
 
     let album_query = "album:arrival artist:abba";
-    let result = spotify.search(album_query, &SearchType::Album, None, None, Some(10), None);
+    let result = spotify.search(album_query, SearchType::Album, None, None, Some(10), None);
     match result {
         Ok(album) => println!("searched album:{:?}", album),
         Err(err) => println!("search error!{:?}", err),
@@ -26,8 +26,8 @@ fn main() {
     let artist_query = "tania bowra";
     let result = spotify.search(
         artist_query,
-        &SearchType::Artist,
-        Some(&Market::Country(Country::UnitedStates)),
+        SearchType::Artist,
+        Some(Market::Country(Country::UnitedStates)),
         None,
         Some(10),
         None,
@@ -40,8 +40,8 @@ fn main() {
     let playlist_query = "\"doom metal\"";
     let result = spotify.search(
         playlist_query,
-        &SearchType::Playlist,
-        Some(&Market::Country(Country::UnitedStates)),
+        SearchType::Playlist,
+        Some(Market::Country(Country::UnitedStates)),
         None,
         Some(10),
         None,
@@ -54,8 +54,8 @@ fn main() {
     let track_query = "abba";
     let result = spotify.search(
         track_query,
-        &SearchType::Track,
-        Some(&Market::Country(Country::UnitedStates)),
+        SearchType::Track,
+        Some(Market::Country(Country::UnitedStates)),
         None,
         Some(10),
         None,
@@ -66,7 +66,7 @@ fn main() {
     }
 
     let show_query = "love";
-    let result = spotify.search(show_query, &SearchType::Show, None, None, Some(10), None);
+    let result = spotify.search(show_query, SearchType::Show, None, None, Some(10), None);
     match result {
         Ok(show) => println!("searched show:{:?}", show),
         Err(err) => println!("search error!{:?}", err),
@@ -75,7 +75,7 @@ fn main() {
     let episode_query = "love";
     let result = spotify.search(
         episode_query,
-        &SearchType::Episode,
+        SearchType::Episode,
         None,
         None,
         Some(10),

--- a/rspotify-model/src/enums/country.rs
+++ b/rspotify-model/src/enums/country.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, IntoStaticStr};
+use strum::IntoStaticStr;
 
 /// ISO 3166-1 alpha-2 country code, from
 /// [country-list](https://datahub.io/core/country-list)
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 pub enum Country {
     #[strum(serialize = "AF")]
     #[serde(rename = "AF")]

--- a/rspotify-model/src/enums/country.rs
+++ b/rspotify-model/src/enums/country.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use strum::AsRefStr;
+use strum::{AsRefStr, IntoStaticStr};
 
 /// ISO 3166-1 alpha-2 country code, from
 /// [country-list](https://datahub.io/core/country-list)
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 pub enum Country {
     #[strum(serialize = "AF")]
     #[serde(rename = "AF")]

--- a/rspotify-model/src/enums/misc.rs
+++ b/rspotify-model/src/enums/misc.rs
@@ -1,15 +1,13 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, IntoStaticStr};
+use strum::IntoStaticStr;
 
 use super::Country;
 
 /// Disallows object: `interrupting_playback`, `pausing`, `resuming`, `seeking`,
 /// `skipping_next`, `skipping_prev`, `toggling_repeat_context`,
 /// `toggling_shuffle`, `toggling_repeat_track`, `transferring_playback`.
-#[derive(
-    Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Hash, AsRefStr, IntoStaticStr,
-)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Hash, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum DisallowKey {
@@ -26,7 +24,7 @@ pub enum DisallowKey {
 }
 
 /// Time range: `long-term`, `medium-term`, `short-term`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum TimeRange {
@@ -36,7 +34,7 @@ pub enum TimeRange {
 }
 
 /// Repeat state: `track`, `context` or `off`.
-#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RepeatState {
@@ -46,7 +44,7 @@ pub enum RepeatState {
 }
 
 /// Type for include_external: `audio`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum IncludeExternal {
@@ -54,7 +52,7 @@ pub enum IncludeExternal {
 }
 
 /// Date precision: `year`, `month`, `day`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum DatePrecision {
@@ -64,7 +62,7 @@ pub enum DatePrecision {
 }
 
 /// The reason for the restriction: `market`, `product`, `explicit`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RestrictionReason {
@@ -77,7 +75,7 @@ pub enum RestrictionReason {
 ///
 /// This field will contain a 0 for `minor`, a 1 for `major` or a -1 for `no
 /// result`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 pub enum Modality {
     Minor = 0,
     Major = 1,
@@ -91,12 +89,6 @@ pub enum Modality {
 pub enum Market {
     Country(Country),
     FromToken,
-}
-
-impl AsRef<str> for Market {
-    fn as_ref(&self) -> &str {
-        (*self).into()
-    }
 }
 
 impl From<Market> for &'static str {

--- a/rspotify-model/src/enums/misc.rs
+++ b/rspotify-model/src/enums/misc.rs
@@ -1,13 +1,15 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use strum::AsRefStr;
+use strum::{AsRefStr, IntoStaticStr};
 
 use super::Country;
 
 /// Disallows object: `interrupting_playback`, `pausing`, `resuming`, `seeking`,
 /// `skipping_next`, `skipping_prev`, `toggling_repeat_context`,
 /// `toggling_shuffle`, `toggling_repeat_track`, `transferring_playback`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Hash, AsRefStr)]
+#[derive(
+    Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Hash, AsRefStr, IntoStaticStr,
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum DisallowKey {
@@ -24,7 +26,7 @@ pub enum DisallowKey {
 }
 
 /// Time range: `long-term`, `medium-term`, `short-term`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum TimeRange {
@@ -34,7 +36,7 @@ pub enum TimeRange {
 }
 
 /// Repeat state: `track`, `context` or `off`.
-#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
+#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RepeatState {
@@ -44,7 +46,7 @@ pub enum RepeatState {
 }
 
 /// Type for include_external: `audio`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum IncludeExternal {
@@ -52,7 +54,7 @@ pub enum IncludeExternal {
 }
 
 /// Date precision: `year`, `month`, `day`.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum DatePrecision {
@@ -62,7 +64,7 @@ pub enum DatePrecision {
 }
 
 /// The reason for the restriction: `market`, `product`, `explicit`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RestrictionReason {
@@ -75,7 +77,7 @@ pub enum RestrictionReason {
 ///
 /// This field will contain a 0 for `minor`, a 1 for `major` or a -1 for `no
 /// result`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 pub enum Modality {
     Minor = 0,
     Major = 1,
@@ -85,7 +87,7 @@ pub enum Modality {
 /// Limit the response to a particular market
 ///
 /// FromToken is the same thing as setting the market parameter to the user's country.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Market {
     Country(Country),
     FromToken,
@@ -93,8 +95,14 @@ pub enum Market {
 
 impl AsRef<str> for Market {
     fn as_ref(&self) -> &str {
-        match self {
-            Market::Country(country) => country.as_ref(),
+        (*self).into()
+    }
+}
+
+impl From<Market> for &'static str {
+    fn from(market: Market) -> Self {
+        match market {
+            Market::Country(country) => country.into(),
             Market::FromToken => "from_token",
         }
     }

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString, IntoStaticStr};
 
 /// Copyright type: `C` = the copyright, `P` = the sound recording (performance)
 /// copyright.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 pub enum CopyrightType {
     #[strum(serialize = "P")]
     #[serde(rename = "P")]
@@ -14,7 +14,7 @@ pub enum CopyrightType {
 }
 
 /// Album type: `album`, `single`, `appears_on`, `compilation`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AlbumType {
@@ -26,7 +26,17 @@ pub enum AlbumType {
 
 /// Type: `artist`, `album`, `track`, `playlist`, `show` or `episode`
 #[derive(
-    Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Display, EnumString, AsRefStr,
+    Clone,
+    Serialize,
+    Deserialize,
+    Copy,
+    PartialEq,
+    Eq,
+    Debug,
+    Display,
+    EnumString,
+    AsRefStr,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -42,7 +52,7 @@ pub enum Type {
 }
 
 /// Additional typs: `track`, `episode`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AdditionalType {
@@ -51,7 +61,7 @@ pub enum AdditionalType {
 }
 
 /// Currently playing type: `track`, `episode`, `ad`, `unknown`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum CurrentlyPlayingType {
@@ -64,7 +74,7 @@ pub enum CurrentlyPlayingType {
 }
 
 /// Type for search: `artist`, `album`, `track`, `playlist`, `show`, `episode`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SearchType {
@@ -79,7 +89,7 @@ pub enum SearchType {
 /// The user's Spotify subscription level: `premium`, `free`
 ///
 /// (The subscription level "open" can be considered the same as "free".)
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SubscriptionLevel {
@@ -89,7 +99,7 @@ pub enum SubscriptionLevel {
 }
 
 /// Device Type: `computer`, `smartphone`, `speaker`, `TV`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum DeviceType {
     Computer,
@@ -113,7 +123,7 @@ pub enum DeviceType {
 }
 
 /// Recommendations seed type
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum RecommendationsSeedType {
     Artist,

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, Display, EnumString, IntoStaticStr};
+use strum::{Display, EnumString, IntoStaticStr};
 
 /// Copyright type: `C` = the copyright, `P` = the sound recording (performance)
 /// copyright.
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 pub enum CopyrightType {
     #[strum(serialize = "P")]
     #[serde(rename = "P")]
@@ -14,7 +14,7 @@ pub enum CopyrightType {
 }
 
 /// Album type: `album`, `single`, `appears_on`, `compilation`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AlbumType {
@@ -26,17 +26,7 @@ pub enum AlbumType {
 
 /// Type: `artist`, `album`, `track`, `playlist`, `show` or `episode`
 #[derive(
-    Clone,
-    Serialize,
-    Deserialize,
-    Copy,
-    PartialEq,
-    Eq,
-    Debug,
-    Display,
-    EnumString,
-    AsRefStr,
-    IntoStaticStr,
+    Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Display, EnumString, IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -52,7 +42,7 @@ pub enum Type {
 }
 
 /// Additional typs: `track`, `episode`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AdditionalType {
@@ -61,7 +51,7 @@ pub enum AdditionalType {
 }
 
 /// Currently playing type: `track`, `episode`, `ad`, `unknown`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum CurrentlyPlayingType {
@@ -74,7 +64,7 @@ pub enum CurrentlyPlayingType {
 }
 
 /// Type for search: `artist`, `album`, `track`, `playlist`, `show`, `episode`
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SearchType {
@@ -89,7 +79,7 @@ pub enum SearchType {
 /// The user's Spotify subscription level: `premium`, `free`
 ///
 /// (The subscription level "open" can be considered the same as "free".)
-#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SubscriptionLevel {
@@ -99,7 +89,7 @@ pub enum SubscriptionLevel {
 }
 
 /// Device Type: `computer`, `smartphone`, `speaker`, `TV`
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum DeviceType {
     Computer,
@@ -123,7 +113,7 @@ pub enum DeviceType {
 }
 
 /// Recommendations seed type
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, IntoStaticStr)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum RecommendationsSeedType {
     Artist,

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -1,7 +1,7 @@
 //! All objects related to recommendation
 
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, IntoStaticStr};
+use strum::IntoStaticStr;
 
 use crate::{RecommendationsSeedType, SimplifiedTrack};
 
@@ -28,7 +28,7 @@ pub struct RecommendationsSeed {
 }
 
 /// The attributes for recommendations
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr, IntoStaticStr)]
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RecommendationsAttribute {

--- a/rspotify-model/src/recommend.rs
+++ b/rspotify-model/src/recommend.rs
@@ -1,7 +1,7 @@
 //! All objects related to recommendation
 
 use serde::{Deserialize, Serialize};
-use strum::AsRefStr;
+use strum::{AsRefStr, IntoStaticStr};
 
 use crate::{RecommendationsSeedType, SimplifiedTrack};
 
@@ -28,7 +28,7 @@ pub struct RecommendationsSeed {
 }
 
 /// The attributes for recommendations
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr)]
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr, IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RecommendationsAttribute {

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -260,10 +260,10 @@ where
     async fn tracks<'a>(
         &self,
         track_ids: impl IntoIterator<Item = &'a TrackId> + Send + 'a,
-        market: Option<&Market>,
+        market: Option<Market>,
     ) -> ClientResult<Vec<FullTrack>> {
         let ids = join_ids(track_ids);
-        let params = build_map([("market", market.map(|x| x.as_ref()))]);
+        let params = build_map([("market", market.map(|x| x.into()))]);
 
         let url = format!("tracks/?ids={}", ids);
         let result = self.endpoint_get(&url, &params).await?;
@@ -315,8 +315,8 @@ where
     fn artist_albums<'a>(
         &'a self,
         artist_id: &'a ArtistId,
-        album_type: Option<&'a AlbumType>,
-        market: Option<&'a Market>,
+        album_type: Option<AlbumType>,
+        market: Option<Market>,
     ) -> Paginator<'_, ClientResult<SimplifiedAlbum>> {
         paginate(
             move |limit, offset| {
@@ -330,16 +330,16 @@ where
     async fn artist_albums_manual(
         &self,
         artist_id: &ArtistId,
-        album_type: Option<&AlbumType>,
-        market: Option<&Market>,
+        album_type: Option<AlbumType>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
-            ("album_type", album_type.map(|x| x.as_ref())),
-            ("market", market.map(|x| x.as_ref())),
+            ("album_type", album_type.map(|x| x.into())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -360,9 +360,9 @@ where
     async fn artist_top_tracks(
         &self,
         artist_id: &ArtistId,
-        market: &Market,
+        market: Market,
     ) -> ClientResult<Vec<FullTrack>> {
-        let params = build_map([("market", Some(market.as_ref()))]);
+        let params = build_map([("market", Some(market.into()))]);
 
         let url = format!("artists/{}/top-tracks", artist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -430,8 +430,8 @@ where
     async fn search(
         &self,
         q: &str,
-        _type: &SearchType,
-        market: Option<&Market>,
+        _type: SearchType,
+        market: Option<Market>,
         include_external: Option<IncludeExternal>,
         limit: Option<u32>,
         offset: Option<u32>,
@@ -440,12 +440,9 @@ where
         let offset = offset.map(|s| s.to_string());
         let params = build_map([
             ("q", Some(q)),
-            ("type", Some(_type.as_ref())),
-            ("market", market.map(|x| x.as_ref())),
-            (
-                "include_external",
-                include_external.as_ref().map(|x| x.as_ref()),
-            ),
+            ("type", Some(_type.into())),
+            ("market", market.map(|x| x.into())),
+            ("include_external", include_external.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -514,9 +511,9 @@ where
         &self,
         playlist_id: &PlaylistId,
         fields: Option<&str>,
-        market: Option<&Market>,
+        market: Option<Market>,
     ) -> ClientResult<FullPlaylist> {
-        let params = build_map([("fields", fields), ("market", market.map(|x| x.as_ref()))]);
+        let params = build_map([("fields", fields), ("market", market.map(|x| x.into()))]);
 
         let url = format!("playlists/{}", playlist_id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -586,8 +583,8 @@ where
     /// - market(Optional): An ISO 3166-1 alpha-2 country code or the string from_token.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-show)
-    async fn get_a_show(&self, id: &ShowId, market: Option<&Market>) -> ClientResult<FullShow> {
-        let params = build_map([("market", market.map(|x| x.as_ref()))]);
+    async fn get_a_show(&self, id: &ShowId, market: Option<Market>) -> ClientResult<FullShow> {
+        let params = build_map([("market", market.map(|x| x.into()))]);
 
         let url = format!("shows/{}", id.id());
         let result = self.endpoint_get(&url, &params).await?;
@@ -605,10 +602,10 @@ where
     async fn get_several_shows<'a>(
         &self,
         ids: impl IntoIterator<Item = &'a ShowId> + Send + 'a,
-        market: Option<&Market>,
+        market: Option<Market>,
     ) -> ClientResult<Vec<SimplifiedShow>> {
         let ids = join_ids(ids);
-        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.as_ref()))]);
+        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.into()))]);
 
         let result = self.endpoint_get("shows", &params).await?;
         convert_result::<SeversalSimplifiedShows>(&result).map(|x| x.shows)
@@ -632,7 +629,7 @@ where
     fn get_shows_episodes<'a>(
         &'a self,
         id: &'a ShowId,
-        market: Option<&'a Market>,
+        market: Option<Market>,
     ) -> Paginator<'_, ClientResult<SimplifiedEpisode>> {
         paginate(
             move |limit, offset| {
@@ -646,14 +643,14 @@ where
     async fn get_shows_episodes_manual(
         &self,
         id: &ShowId,
-        market: Option<&Market>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedEpisode>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -675,10 +672,10 @@ where
     async fn get_an_episode(
         &self,
         id: &EpisodeId,
-        market: Option<&Market>,
+        market: Option<Market>,
     ) -> ClientResult<FullEpisode> {
         let url = format!("episodes/{}", id.id());
-        let params = build_map([("market", market.map(|x| x.as_ref()))]);
+        let params = build_map([("market", market.map(|x| x.into()))]);
 
         let result = self.endpoint_get(&url, &params).await?;
         convert_result(&result)
@@ -694,10 +691,10 @@ where
     async fn get_several_episodes<'a>(
         &self,
         ids: impl IntoIterator<Item = &'a EpisodeId> + Send + 'a,
-        market: Option<&Market>,
+        market: Option<Market>,
     ) -> ClientResult<Vec<FullEpisode>> {
         let ids = join_ids(ids);
-        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.as_ref()))]);
+        let params = build_map([("ids", Some(&ids)), ("market", market.map(|x| x.into()))]);
 
         let result = self.endpoint_get("episodes", &params).await?;
         convert_result::<EpisodesPayload>(&result).map(|x| x.episodes)
@@ -766,7 +763,7 @@ where
     fn categories<'a>(
         &'a self,
         locale: Option<&'a str>,
-        country: Option<&'a Market>,
+        country: Option<Market>,
     ) -> Paginator<'_, ClientResult<Category>> {
         paginate(
             move |limit, offset| self.categories_manual(locale, country, Some(limit), Some(offset)),
@@ -778,7 +775,7 @@ where
     async fn categories_manual(
         &self,
         locale: Option<&str>,
-        country: Option<&Market>,
+        country: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<Category>> {
@@ -786,7 +783,7 @@ where
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
             ("locale", locale),
-            ("country", country.map(|x| x.as_ref())),
+            ("country", country.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -811,7 +808,7 @@ where
     fn category_playlists<'a>(
         &'a self,
         category_id: &'a str,
-        country: Option<&'a Market>,
+        country: Option<Market>,
     ) -> Paginator<'_, ClientResult<SimplifiedPlaylist>> {
         paginate(
             move |limit, offset| {
@@ -825,14 +822,14 @@ where
     async fn category_playlists_manual(
         &self,
         category_id: &str,
-        country: Option<&Market>,
+        country: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedPlaylist>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
-            ("country", country.map(|x| x.as_ref())),
+            ("country", country.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -862,7 +859,7 @@ where
     async fn featured_playlists(
         &self,
         locale: Option<&str>,
-        country: Option<&Market>,
+        country: Option<Market>,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
         limit: Option<u32>,
         offset: Option<u32>,
@@ -872,7 +869,7 @@ where
         let timestamp = timestamp.map(|x| x.to_rfc3339());
         let params = build_map([
             ("locale", locale),
-            ("country", country.map(|x| x.as_ref())),
+            ("country", country.map(|x| x.into())),
             ("timestamp", timestamp.as_deref()),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
@@ -897,9 +894,9 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-new-releases)
-    fn new_releases<'a>(
-        &'a self,
-        country: Option<&'a Market>,
+    fn new_releases(
+        &self,
+        country: Option<Market>,
     ) -> Paginator<'_, ClientResult<SimplifiedAlbum>> {
         paginate(
             move |limit, offset| self.new_releases_manual(country, Some(limit), Some(offset)),
@@ -910,14 +907,14 @@ where
     /// The manually paginated version of [`Self::new_releases`].
     async fn new_releases_manual(
         &self,
-        country: Option<&Market>,
+        country: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
-            ("country", country.map(|x| x.as_ref())),
+            ("country", country.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -949,7 +946,7 @@ where
         seed_artists: Option<impl IntoIterator<Item = &'a ArtistId> + Send + 'a>,
         seed_genres: Option<impl IntoIterator<Item = &'a str> + Send + 'a>,
         seed_tracks: Option<impl IntoIterator<Item = &'a TrackId> + Send + 'a>,
-        market: Option<&Market>,
+        market: Option<Market>,
         limit: Option<u32>,
     ) -> ClientResult<Recommendations> {
         let seed_artists = seed_artists.map(join_ids);
@@ -960,14 +957,14 @@ where
             ("seed_artists", seed_artists.as_deref()),
             ("seed_genres", seed_genres.as_deref()),
             ("seed_tracks", seed_tracks.as_deref()),
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
         ]);
 
         // First converting the attributes into owned `String`s
         let owned_attributes = attributes
             .into_iter()
-            .map(|attr| (attr.as_ref().to_owned(), attr.value_string()))
+            .map(|attr| (<&str>::from(attr).to_owned(), attr.value_string()))
             .collect::<HashMap<_, _>>();
         // Afterwards converting the values into `&str`s; otherwise they
         // wouldn't live long enough
@@ -998,7 +995,7 @@ where
         &'a self,
         playlist_id: &'a PlaylistId,
         fields: Option<&'a str>,
-        market: Option<&'a Market>,
+        market: Option<Market>,
     ) -> Paginator<'_, ClientResult<PlaylistItem>> {
         paginate(
             move |limit, offset| {
@@ -1013,7 +1010,7 @@ where
         &self,
         playlist_id: &PlaylistId,
         fields: Option<&str>,
-        market: Option<&Market>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<PlaylistItem>> {
@@ -1021,7 +1018,7 @@ where
         let offset = offset.map(|s| s.to_string());
         let params = build_map([
             ("fields", fields),
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -517,10 +517,10 @@ pub trait OAuthClient: BaseClient {
     /// of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-saved-albums)
-    fn current_user_saved_albums<'a>(
-        &'a self,
-        market: Option<&'a Market>,
-    ) -> Paginator<'a, ClientResult<SavedAlbum>> {
+    fn current_user_saved_albums(
+        &self,
+        market: Option<Market>,
+    ) -> Paginator<'_, ClientResult<SavedAlbum>> {
         paginate(
             move |limit, offset| {
                 self.current_user_saved_albums_manual(market, Some(limit), Some(offset))
@@ -532,14 +532,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_saved_albums`].
     async fn current_user_saved_albums_manual(
         &self,
-        market: Option<&Market>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SavedAlbum>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map([
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -560,10 +560,10 @@ pub trait OAuthClient: BaseClient {
     /// version of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-saved-tracks)
-    fn current_user_saved_tracks<'a>(
-        &'a self,
-        market: Option<&'a Market>,
-    ) -> Paginator<'a, ClientResult<SavedTrack>> {
+    fn current_user_saved_tracks(
+        &self,
+        market: Option<Market>,
+    ) -> Paginator<'_, ClientResult<SavedTrack>> {
         paginate(
             move |limit, offset| {
                 self.current_user_saved_tracks_manual(market, Some(limit), Some(offset))
@@ -575,14 +575,14 @@ pub trait OAuthClient: BaseClient {
     /// The manually paginated version of [`Self::current_user_saved_tracks`].
     async fn current_user_saved_tracks_manual(
         &self,
-        market: Option<&Market>,
+        market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SavedTrack>> {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map([
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -605,7 +605,7 @@ pub trait OAuthClient: BaseClient {
     ) -> ClientResult<CursorBasedPage<FullArtist>> {
         let limit = limit.map(|s| s.to_string());
         let params = build_map([
-            ("type", Some(Type::Artist.as_ref())),
+            ("type", Some(Type::Artist.into())),
             ("after", after),
             ("limit", limit.as_deref()),
         ]);
@@ -695,7 +695,7 @@ pub trait OAuthClient: BaseClient {
         let limit = limit.map(|s| s.to_string());
         let offset = offset.map(|s| s.to_string());
         let params = build_map([
-            ("time_range", time_range.as_ref().map(|x| x.as_ref())),
+            ("time_range", time_range.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -737,7 +737,7 @@ pub trait OAuthClient: BaseClient {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
         let params = build_map([
-            ("time_range", time_range.as_ref().map(|x| x.as_ref())),
+            ("time_range", time_range.map(|x| x.into())),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),
         ]);
@@ -929,17 +929,17 @@ pub trait OAuthClient: BaseClient {
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-information-about-the-users-current-playback)
     async fn current_playback<'a>(
         &self,
-        country: Option<&Market>,
+        country: Option<Market>,
         additional_types: Option<impl IntoIterator<Item = &'a AdditionalType> + Send + 'a>,
     ) -> ClientResult<Option<CurrentPlaybackContext>> {
         let additional_types = additional_types.map(|x| {
             x.into_iter()
-                .map(|x| x.as_ref())
-                .collect::<Vec<_>>()
+                .map(|x| x.into())
+                .collect::<Vec<&'static str>>()
                 .join(",")
         });
         let params = build_map([
-            ("country", country.map(|x| x.as_ref())),
+            ("country", country.map(|x| x.into())),
             ("additional_types", additional_types.as_deref()),
         ]);
 
@@ -961,18 +961,18 @@ pub trait OAuthClient: BaseClient {
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recently-played)
     async fn current_playing<'a>(
-        &self,
-        market: Option<&'a Market>,
+        &'a self,
+        market: Option<Market>,
         additional_types: Option<impl IntoIterator<Item = &'a AdditionalType> + Send + 'a>,
     ) -> ClientResult<Option<CurrentlyPlayingContext>> {
         let additional_types = additional_types.map(|x| {
             x.into_iter()
-                .map(|x| x.as_ref())
-                .collect::<Vec<_>>()
+                .map(|x| x.into())
+                .collect::<Vec<&'static str>>()
                 .join(",")
         });
         let params = build_map([
-            ("market", market.map(|x| x.as_ref())),
+            ("market", market.map(|x| x.into())),
             ("additional_types", additional_types.as_deref()),
         ]);
 
@@ -1160,9 +1160,9 @@ pub trait OAuthClient: BaseClient {
     /// - device_id - device target for playback
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/set-repeat-mode-on-users-playback)
-    async fn repeat(&self, state: &RepeatState, device_id: Option<&str>) -> ClientResult<()> {
+    async fn repeat(&self, state: RepeatState, device_id: Option<&str>) -> ClientResult<()> {
         let url = append_device_id(
-            &format!("me/player/repeat?state={}", state.as_ref()),
+            &format!("me/player/repeat?state={}", <&str>::from(state)),
             device_id,
         );
         self.endpoint_put(&url, &json!({})).await?;
@@ -1303,11 +1303,11 @@ pub trait OAuthClient: BaseClient {
     async fn remove_users_saved_shows<'a>(
         &self,
         show_ids: impl IntoIterator<Item = &'a ShowId> + Send + 'a,
-        country: Option<&Market>,
+        country: Option<Market>,
     ) -> ClientResult<()> {
         let url = format!("me/shows?ids={}", join_ids(show_ids));
         let params = build_json! {
-            optional "country": country.map(|x| x.as_ref())
+            optional "country": country.map(<&str>::from)
         };
         self.endpoint_delete(&url, &params).await?;
 

--- a/tests/test_enums.rs
+++ b/tests/test_enums.rs
@@ -3,71 +3,71 @@ use rspotify::model::*;
 #[test]
 fn test_include_external() {
     let audio = IncludeExternal::Audio;
-    assert_eq!("audio", audio.as_ref());
+    assert_eq!("audio", <&str>::from(audio));
 }
 
 #[test]
 fn test_repeat_state() {
     let context = RepeatState::Context;
-    assert_eq!(context.as_ref(), "context");
+    assert_eq!(<&str>::from(context), "context");
 }
 
 #[test]
 fn test_disallow_key() {
     let toggling_shuffle = DisallowKey::TogglingShuffle;
-    assert_eq!(toggling_shuffle.as_ref(), "toggling_shuffle");
+    assert_eq!(<&str>::from(toggling_shuffle), "toggling_shuffle");
 }
 
 #[test]
 fn test_time_range() {
     let medium_range = TimeRange::MediumTerm;
-    assert_eq!(medium_range.as_ref(), "medium_term");
+    assert_eq!(<&str>::from(medium_range), "medium_term");
 }
 
 #[test]
 fn test_date_precision() {
     let month = DatePrecision::Month;
-    assert_eq!(month.as_ref(), "month");
+    assert_eq!(<&str>::from(month), "month");
 }
 
 #[test]
 fn test_album_type_convert_from_str() {
     let appears_on = AlbumType::AppearsOn;
-    assert_eq!("appears_on", appears_on.as_ref());
+    assert_eq!("appears_on", <&str>::from(appears_on));
 }
 
 #[test]
 fn test_convert_search_type_from_str() {
     let search_type = SearchType::Artist;
-    assert_eq!("artist", search_type.as_ref());
+    assert_eq!("artist", <&str>::from(search_type));
 }
 
 #[test]
 fn test_type_convert_from_str() {
     let artist = Type::Artist;
-    assert_eq!(artist.as_ref(), "artist");
+    assert_eq!(<&str>::from(artist), "artist");
 }
 
 #[test]
 fn test_additional_type() {
     let episode = AdditionalType::Episode;
-    assert_eq!(episode.as_ref(), "episode");
+    assert_eq!(<&str>::from(episode), "episode");
 }
 
 #[test]
 fn test_current_playing_type() {
     let ad = CurrentlyPlayingType::Advertisement;
-    assert_eq!(ad.as_ref(), "ad");
+    assert_eq!(<&str>::from(ad), "ad");
 }
 
 #[test]
 fn test_search_type() {
     let episode = SearchType::Episode;
-    assert_eq!(episode.as_ref(), "episode");
+    assert_eq!(<&str>::from(episode), "episode");
 }
 
 #[test]
 fn test_convert_country_from_str() {
     let zimbabwe = Country::Zimbabwe;
-    assert_eq!(zimbabwe.as_ref(), "ZW");
+    assert_eq!(<&str>::from(zimbabwe), "ZW");
 }

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -72,8 +72,8 @@ async fn test_artists_albums() {
         .await
         .artist_albums_manual(
             &birdy_uri,
-            Some(&AlbumType::Album),
-            Some(&Market::Country(Country::UnitedStates)),
+            Some(AlbumType::Album),
+            Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,
         )
@@ -95,7 +95,7 @@ async fn test_artist_top_tracks() {
     let birdy_uri = ArtistId::from_uri("spotify:artist:2WX2uTcsvV5OnS0inACecP").unwrap();
     creds_client()
         .await
-        .artist_top_tracks(&birdy_uri, &Market::Country(Country::UnitedStates))
+        .artist_top_tracks(&birdy_uri, Market::Country(Country::UnitedStates))
         .await
         .unwrap();
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -117,7 +117,7 @@ async fn test_categories() {
         .await
         .categories_manual(
             None,
-            Some(&Market::Country(Country::UnitedStates)),
+            Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,
         )
@@ -132,7 +132,7 @@ async fn test_category_playlists() {
         .await
         .category_playlists_manual(
             "pop",
-            Some(&Market::Country(Country::UnitedStates)),
+            Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,
         )
@@ -211,7 +211,7 @@ async fn test_current_user_saved_albums() {
     let all_albums = fetch_all(client.current_user_saved_albums(None)).await;
     // Can handle albums without available_market
     let _albums_from_token =
-        fetch_all(client.current_user_saved_albums(Some(&Market::FromToken))).await;
+        fetch_all(client.current_user_saved_albums(Some(Market::FromToken))).await;
     let all_uris = all_albums
         .into_iter()
         .map(|a| a.album.id)
@@ -304,7 +304,7 @@ async fn test_me() {
 async fn test_new_releases() {
     oauth_client()
         .await
-        .new_releases_manual(Some(&Market::Country(Country::Sweden)), Some(10), Some(0))
+        .new_releases_manual(Some(Market::Country(Country::Sweden)), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -314,7 +314,7 @@ async fn test_new_releases() {
 async fn test_new_releases_with_from_token() {
     oauth_client()
         .await
-        .new_releases_manual(Some(&Market::FromToken), Some(10), Some(0))
+        .new_releases_manual(Some(Market::FromToken), Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -414,7 +414,7 @@ async fn test_recommendations() {
             Some(seed_artists),
             None::<Vec<&str>>,
             Some(seed_tracks),
-            Some(&Market::Country(Country::UnitedStates)),
+            Some(Market::Country(Country::UnitedStates)),
             Some(10),
         )
         .await
@@ -429,10 +429,10 @@ async fn test_repeat() {
     // Saving the previous state to restore it later
     let backup = client.current_playback(None, None::<&[_]>).await.unwrap();
 
-    client.repeat(&RepeatState::Off, None).await.unwrap();
+    client.repeat(RepeatState::Off, None).await.unwrap();
 
     if let Some(backup) = backup {
-        client.repeat(&backup.repeat_state, None).await.unwrap()
+        client.repeat(backup.repeat_state, None).await.unwrap()
     }
 }
 
@@ -442,7 +442,7 @@ async fn test_search_album() {
     let query = "album:arrival artist:abba";
     oauth_client()
         .await
-        .search(query, &SearchType::Album, None, None, Some(10), Some(0))
+        .search(query, SearchType::Album, None, None, Some(10), Some(0))
         .await
         .unwrap();
 }
@@ -455,8 +455,8 @@ async fn test_search_artist() {
         .await
         .search(
             query,
-            &SearchType::Artist,
-            Some(&Market::Country(Country::UnitedStates)),
+            SearchType::Artist,
+            Some(Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -473,8 +473,8 @@ async fn test_search_playlist() {
         .await
         .search(
             query,
-            &SearchType::Playlist,
-            Some(&Market::Country(Country::UnitedStates)),
+            SearchType::Playlist,
+            Some(Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -491,8 +491,8 @@ async fn test_search_track() {
         .await
         .search(
             query,
-            &SearchType::Track,
-            Some(&Market::Country(Country::UnitedStates)),
+            SearchType::Track,
+            Some(Market::Country(Country::UnitedStates)),
             None,
             Some(10),
             Some(0),
@@ -509,7 +509,7 @@ async fn test_search_show() {
     let query = "99% invisible";
     oauth_client()
         .await
-        .search(query, &SearchType::Show, None, None, None, Some(0))
+        .search(query, SearchType::Show, None, None, None, Some(0))
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description

Derives both `AsRef<str>` and `Into<&'static str>` (via `From<{the enum}> for &'static str`) for all the enums.

Note: there’s a `#[derive]` in here that `rustfmt` explodes on to 13 lines. I don’t really like it but I also can’t separate the derives into two lines because rustfmt just merges them together again 😄

Also makes `Market` `Copy`, just so I can avoid code duplication between `AsRef<str>` and `From<Market> for &'static str`.

## Motivation and Context

This makes the enums useful in more places, since the lifetime of the string is not actually tied to the lifetime of the enum.

## Dependencies 

None.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] Test A: `cargo test -p rspotify-model`