### PR TITLE
Fix double referenced types in paginated endpoints

### DIFF
--- a/rspotify-model/src/album.rs
+++ b/rspotify-model/src/album.rs
@@ -33,7 +33,7 @@ pub struct SimplifiedAlbum {
 }
 
 /// Full Album Object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullAlbum {
     pub artists: Vec<SimplifiedArtist>,
     pub album_type: AlbumType,
@@ -67,7 +67,7 @@ pub struct PageSimplifiedAlbums {
 }
 
 /// Saved Album object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SavedAlbum {
     pub added_at: DateTime<Utc>,
     pub album: FullAlbum,

--- a/rspotify-model/src/lib.rs
+++ b/rspotify-model/src/lib.rs
@@ -7,7 +7,7 @@ pub mod audio;
 pub mod auth;
 pub mod category;
 pub mod context;
-pub(in crate) mod custom_serde;
+pub(crate) mod custom_serde;
 pub mod device;
 pub mod enums;
 pub mod error;

--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -36,7 +36,7 @@ pub struct SimplifiedPlaylist {
 }
 
 /// Full playlist object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullPlaylist {
     pub collaborative: bool,
     pub description: Option<String>,
@@ -62,7 +62,7 @@ pub struct PlaylistItem {
 }
 
 /// Featured playlists object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeaturedPlaylists {
     pub message: String,
     pub playlists: Page<SimplifiedPlaylist>,

--- a/rspotify-model/src/show.rs
+++ b/rspotify-model/src/show.rs
@@ -47,7 +47,7 @@ pub struct Show {
 }
 
 /// Full show object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullShow {
     pub available_markets: Vec<String>,
     pub copyrights: Vec<Copyright>,

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -68,7 +68,7 @@ pub struct AuthCodeSpotify {
     pub oauth: OAuth,
     pub config: Config,
     pub token: Arc<Mutex<Option<Token>>>,
-    pub(in crate) http: HttpClient,
+    pub(crate) http: HttpClient,
 }
 
 /// This client has access to the base methods.

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -38,7 +38,7 @@ pub struct AuthCodePkceSpotify {
     pub token: Arc<Mutex<Option<Token>>>,
     /// The code verifier for the authentication process
     pub verifier: Option<String>,
-    pub(in crate) http: HttpClient,
+    pub(crate) http: HttpClient,
 }
 
 /// This client has access to the base methods.

--- a/src/client_creds.rs
+++ b/src/client_creds.rs
@@ -26,7 +26,7 @@ pub struct ClientCredsSpotify {
     pub config: Config,
     pub creds: Credentials,
     pub token: Arc<Mutex<Option<Token>>>,
-    pub(in crate) http: HttpClient,
+    pub(crate) http: HttpClient,
 }
 
 /// This client has access to the base methods.

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -12,12 +12,12 @@ use std::fmt::Write as _;
 use serde::Deserialize;
 
 /// Converts a JSON response from Spotify into its model.
-pub(in crate) fn convert_result<'a, T: Deserialize<'a>>(input: &'a str) -> ClientResult<T> {
+pub(crate) fn convert_result<'a, T: Deserialize<'a>>(input: &'a str) -> ClientResult<T> {
     serde_json::from_str::<T>(input).map_err(Into::into)
 }
 
 /// Append device ID to an API path.
-pub(in crate) fn append_device_id(path: &str, device_id: Option<&str>) -> String {
+pub(crate) fn append_device_id(path: &str, device_id: Option<&str>) -> String {
     let mut new_path = path.to_string();
     if let Some(device_id) = device_id {
         if path.contains('?') {

--- a/src/clients/pagination/iter.rs
+++ b/src/clients/pagination/iter.rs
@@ -5,6 +5,17 @@ use crate::{model::Page, ClientError, ClientResult};
 /// Alias for `Iterator<Item = T>`, since sync mode is enabled.
 pub type Paginator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
 
+pub fn paginate_with_ctx<'a, Ctx: 'a, T: 'a, Request: 'a>(
+    ctx: Ctx,
+    req: Request,
+    page_size: u32,
+) -> Paginator<'a, ClientResult<T>>
+where
+    Request: Fn(&Ctx, u32, u32) -> ClientResult<Page<T>>,
+{
+    paginate(move |limit, offset| req(&ctx, limit, offset), page_size)
+}
+
 /// This is used to handle paginated requests automatically.
 pub fn paginate<'a, T: 'a, Request: 'a>(
     req: Request,

--- a/src/clients/pagination/mod.rs
+++ b/src/clients/pagination/mod.rs
@@ -7,6 +7,10 @@
 //! * A `Paginator` struct which wraps the iterable of items
 //! * A `paginate` function, which returns a `Paginator` based on a request that
 //!   may be repeated in order to return a continuous sequence of `Page`s
+//! * A `paginate_with_ctx` function that does the same as the `paginate`
+//!   function, but accepts a generic context that works around lifetime issues
+//!   in the async version due to restrictions in HRTBs
+//!   (<https://kevincox.ca/2022/04/16/rust-generic-closure-lifetimes/>)
 //!
 //! Note that `Paginator` should actually be a trait so that a dynamic
 //! allocation can be avoided when returning it with `-> impl Iterator<T>`, as
@@ -25,6 +29,6 @@ mod iter;
 mod stream;
 
 #[cfg(feature = "__sync")]
-pub use iter::{paginate, Paginator};
+pub use iter::{paginate, paginate_with_ctx, Paginator};
 #[cfg(feature = "__async")]
-pub use stream::{paginate, Paginator};
+pub use stream::{paginate, paginate_with_ctx, Paginator};

--- a/src/clients/pagination/stream.rs
+++ b/src/clients/pagination/stream.rs
@@ -9,7 +9,34 @@ use futures::{future::Future, stream::Stream};
 /// Alias for `futures::stream::Stream<Item = T>`, since async mode is enabled.
 pub type Paginator<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
 
+pub type RequestFuture<'a, T> = Pin<Box<dyn 'a + Future<Output = ClientResult<Page<T>>>>>;
+
 /// This is used to handle paginated requests automatically.
+pub fn paginate_with_ctx<'a, Ctx: 'a, T, Request>(
+    ctx: Ctx,
+    req: Request,
+    page_size: u32,
+) -> Paginator<'a, ClientResult<T>>
+where
+    T: 'a + Unpin,
+    Request: 'a + for<'ctx> Fn(&'ctx Ctx, u32, u32) -> RequestFuture<'ctx, T>,
+{
+    use async_stream::stream;
+    let mut offset = 0;
+    Box::pin(stream! {
+        loop {
+            let page = req(&ctx, page_size, offset).await?;
+            offset += page.items.len() as u32;
+            for item in page.items {
+                yield Ok(item);
+            }
+            if page.next.is_none() {
+                break;
+            }
+        }
+    })
+}
+
 pub fn paginate<'a, T, Fut, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
 where
     T: 'a + Unpin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub mod prelude {
 }
 
 /// Common headers as constants.
-pub(in crate) mod params {
+pub(crate) mod params {
     pub const CLIENT_ID: &str = "client_id";
     pub const CODE: &str = "code";
     pub const GRANT_TYPE: &str = "grant_type";
@@ -177,14 +177,14 @@ pub(in crate) mod params {
 }
 
 /// Common alphabets for random number generation and similars
-pub(in crate) mod alphabets {
+pub(crate) mod alphabets {
     pub const ALPHANUM: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     /// From <https://datatracker.ietf.org/doc/html/rfc7636#section-4.1>
     pub const PKCE_CODE_VERIFIER: &[u8] =
         b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
 }
 
-pub(in crate) mod auth_urls {
+pub(crate) mod auth_urls {
     pub const AUTHORIZE: &str = "https://accounts.spotify.com/authorize";
     pub const TOKEN: &str = "https://accounts.spotify.com/api/token";
 }
@@ -276,7 +276,7 @@ impl Default for Config {
 ///
 /// It is assumed that system always provides high-quality cryptographically
 /// secure random data, ideally backed by hardware entropy sources.
-pub(in crate) fn generate_random_string(length: usize, alphabet: &[u8]) -> String {
+pub(crate) fn generate_random_string(length: usize, alphabet: &[u8]) -> String {
     let mut buf = vec![0u8; length];
     getrandom(&mut buf).unwrap();
     let range = alphabet.len();
@@ -287,13 +287,13 @@ pub(in crate) fn generate_random_string(length: usize, alphabet: &[u8]) -> Strin
 }
 
 #[inline]
-pub(in crate) fn join_ids<'a, T: Id + 'a>(ids: impl IntoIterator<Item = T>) -> String {
+pub(crate) fn join_ids<'a, T: Id + 'a>(ids: impl IntoIterator<Item = T>) -> String {
     let ids = ids.into_iter().collect::<Vec<_>>();
     ids.iter().map(Id::id).collect::<Vec<_>>().join(",")
 }
 
 #[inline]
-pub(in crate) fn join_scopes(scopes: &HashSet<String>) -> String {
+pub(crate) fn join_scopes(scopes: &HashSet<String>) -> String {
     scopes
         .iter()
         .map(String::as_str)

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -44,7 +44,7 @@ async fn test_album_tracks() {
     let birdy_uri = AlbumId::from_uri("spotify:album:6akEvsycLGftJxYudPjmqK").unwrap();
     creds_client()
         .await
-        .album_track_manual(&birdy_uri, Some(2), None)
+        .album_track_manual(birdy_uri, Some(2), None)
         .await
         .unwrap();
 }
@@ -71,7 +71,7 @@ async fn test_artists_albums() {
     creds_client()
         .await
         .artist_albums_manual(
-            &birdy_uri,
+            birdy_uri,
             Some(AlbumType::Album),
             Some(Market::Country(Country::UnitedStates)),
             Some(10),
@@ -190,7 +190,7 @@ mod test_pagination {
         let album = AlbumId::from_uri(ALBUM).unwrap();
 
         let names = client
-            .album_track(&album)
+            .album_track(album)
             .map(|track| track.unwrap().name)
             .collect::<Vec<_>>();
 
@@ -208,7 +208,7 @@ mod test_pagination {
         let album = AlbumId::from_uri(ALBUM).unwrap();
 
         let names = client
-            .album_track(&album)
+            .album_track(album)
             .map(|track| track.unwrap().name)
             .collect::<Vec<_>>()
             .await;

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -619,7 +619,7 @@ async fn check_playlist_create(client: &AuthCodeSpotify) -> FullPlaylist {
         .await
         .unwrap();
     assert_eq!(playlist.id, fetched_playlist.id);
-    let user_playlists = fetch_all(client.user_playlists(&user.id)).await;
+    let user_playlists = fetch_all(client.user_playlists(user.id)).await;
     let current_user_playlists = fetch_all(client.current_user_playlists()).await;
     assert_eq!(user_playlists.len(), current_user_playlists.len());
 
@@ -642,7 +642,7 @@ async fn check_playlist_create(client: &AuthCodeSpotify) -> FullPlaylist {
 
 #[maybe_async]
 async fn check_num_tracks(client: &AuthCodeSpotify, playlist_id: PlaylistId<'_>, num: i32) {
-    let fetched_tracks = fetch_all(client.playlist_items(&playlist_id.as_ref(), None, None)).await;
+    let fetched_tracks = fetch_all(client.playlist_items(playlist_id, None, None)).await;
     assert_eq!(fetched_tracks.len() as i32, num);
 }
 


### PR DESCRIPTION
## Description

This removes the potential double reference to Id types (&'a Id<'_>)
which was previously required due to limitations in the async variant of
the `paginate` function.
Due to limitations in HRTBs (see
https://kevincox.ca/2022/04/16/rust-generic-closure-lifetimes/) it is
not possible, to write something like `Req: for<'a> Fn(&'a) ->
('a + Future<...>)`. The sync version remains almost unchanged.

## Motivation and Context

See #305

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

CI passes

## Is this change properly documented?

No need, it's an internal change