### PR TITLE
Rename Rspotify to RSpotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ## 0.11 (2021.10.14)
 
-This release contains *lots* of breaking changes. These were necessary to continue Rspotify's development, and this shouldn't happen again. From now on we'll work on getting closer to the first stable release. Lots of internal code was rewritten to make Rspotify more flexible, performant and easier to use. Sorry for the inconvenience!
+This release contains *lots* of breaking changes. These were necessary to continue RSpotify's development, and this shouldn't happen again. From now on we'll work on getting closer to the first stable release. Lots of internal code was rewritten to make RSpotify more flexible, performant and easier to use. Sorry for the inconvenience!
 
 If we missed any change or there's something you'd like to discuss about this version, please open a new issue and let us know.
 
@@ -54,7 +54,7 @@ This guide should make it easier to upgrade your code, rather than checking out 
     * [Client Credentials Flow](https://developer.spotify.com/documentation/general/guides/authorization/client-credentials/): see `ClientCredsSpotify`.
     * [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization/code-flow): see `AuthCodeSpotify`.
     * [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](https://developer.spotify.com/documentation/general/guides/authorization/code-flow): see `AuthCodePkceSpotify`. This is new! You might be interested in using PKCE for your app if you don't want to expose your client secret.
-    * [Implicit Grant Flow](https://developer.spotify.com/documentation/general/guides/authorization/implicit-grant): unimplemented, as Rspotify has not been tested on a browser yet. If you'd like support for it, let us know in an issue!
+    * [Implicit Grant Flow](https://developer.spotify.com/documentation/general/guides/authorization/implicit-grant): unimplemented, as RSpotify has not been tested on a browser yet. If you'd like support for it, let us know in an issue!
 * There's now support for (both sync and async) **automatic pagination**! Make sure you upgrade to these after checking out the [`pagination_async.rs`](https://github.com/ramsayleung/rspotify/blob/auth-rewrite-part4/examples/pagination_async.rs) and [`pagination_sync.rs`](https://github.com/ramsayleung/rspotify/blob/auth-rewrite-part4/examples/pagination_sync.rs) examples. You can use the `_manual`-suffixed endpoints for the previous pagination style.
 * We've **renamed** a few structs and endpoints. The new names are quite similar, so the Rust compiler should suggest you what to change after an error. The only one you might not notice is the **environmental variables**: they're now `RSPOTIFY_CLIENT_ID`, `RSPOTIFY_CLIENT_SECRET` and `RSPOTIFY_REDIRECT_URI` to avoid collisions with other libraries.
 * We always use **`Option<T>`** for optional parameters now. This means that you might have to add `Some(...)` to some of your parameters. We were using both `Into<Option<T>>` and `Option<T>` but decided that either of these would be best as long as it's *consistent*. `Option<T>` has less magic, so we went for that one.
@@ -131,14 +131,14 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
 
 ### Full changelog
 
-- Rewritten documentation in hopes that it's easier to get started with Rspotify.
+- Rewritten documentation in hopes that it's easier to get started with RSpotify.
 - Reduced the number of examples. Instead of having an example for each endpoint, which is repetitive and unhelpful for newcomers, some real-life examples are now included. If you'd like to add your own example, please do! ([#113](https://github.com/ramsayleung/rspotify/pull/113))
-- Rspotify now uses macros internally to make the endpoints as concise as possible and nice to read.
+- RSpotify now uses macros internally to make the endpoints as concise as possible and nice to read.
 - Add `add_item_to_queue` endpoint.
 - Add `category_playlists` endpoint ([#153](https://github.com/ramsayleung/rspotify/pull/153)).
 - Add `resume_playback` endpoint.
 - Fix race condition when using a single client from multiple threads ([#114](https://github.com/ramsayleung/rspotify/pull/114)).
-- Rspotify should now be considerably lighter and less bloated ([discussion in #108](https://github.com/ramsayleung/rspotify/issues/108)):
+- RSpotify should now be considerably lighter and less bloated ([discussion in #108](https://github.com/ramsayleung/rspotify/issues/108)):
   + Remove unused dependencies: `base64`, `env_logger`, `random`, `url`.
   + Remove `itertools` dependency by using the standard library.
   + Remove `rand` in place of `getrandom` to [reduce total dependencies and compile times](https://github.com/ramsayleung/rspotify/issues/108#issuecomment-673587185).
@@ -212,20 +212,20 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
   + Fix broken model links refering to Spotify documentation
 - ([#188](https://github.com/ramsayleung/rspotify/pull/188)) Replace html links with intra-documentation links
 - ([#189](https://github.com/ramsayleung/rspotify/pull/189)) Add `scopes!` macro to generate scopes for `Token` from string literal
-- Rspotify has now been split up into independent crates, so that it can be used without the client. See `rspotify-macros` and `rspotify-model`.
+- RSpotify has now been split up into independent crates, so that it can be used without the client. See `rspotify-macros` and `rspotify-model`.
 - ([#128](https://github.com/ramsayleung/rspotify/pull/128)) Reexport `model` module to allow user to write `rspotify::model::FullAlbum` instead of  `rspotify::model::album::FullAlbum`.
 - ([#246](https://github.com/ramsayleung/rspotify/pull/246)) Add support for PKCE, see `AuthCodePkceSpotify`.
 - ([#257](https://github.com/ramsayleung/rspotify/pull/257)) `parse_response_code` now checks that the state is the same in the request and in the callback.
 
 **Breaking changes:**
-- ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Rspotify now consistently uses `Option<T>` for optional parameters. Those generic over `Into<Option<T>>` have been changed, which makes calling endpoints a bit ugiler but more consistent and simpler.
+- ([#202](https://github.com/ramsayleung/rspotify/pull/202)) RSpotify now consistently uses `Option<T>` for optional parameters. Those generic over `Into<Option<T>>` have been changed, which makes calling endpoints a bit ugiler but more consistent and simpler.
 - `SpotifyClientCredentials` has been renamed to `Credentials` ([#129](https://github.com/ramsayleung/rspotify/pull/129)), and its members `client_id` and `client_secret` to `id` and `secret`, respectively.
 - `TokenInfo` has been renamed to `Token`. It no longer has the `token_type` member, as it's always `Bearer` for now ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
 - `SpotifyOAuth` has been renamed to `OAuth`. It only contains the necessary parameters for OAuth authorization instead of repeating the items from `Credentials` and `Spotify`, so `client_id`, `client_secret` and `cache_path` are no longer in `OAuth` ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
 - `TokenBuilder` and `OAuthBuilder` will only read from environment variables when `from_env` is used, instead of `default`.
 - `dotenv` support is now optional. You can enable it with the `env-file` feature to have the same behavior as before ([#108](https://github.com/ramsayleung/rspotify/issues/108)). It may be used with `from_env` as well.
 - Renamed environmental variables to `RSPOTIFY_CLIENT_ID`, `RSPOTIFY_CLIENT_SECRET` and `RSPOTIFY_REDIRECT_URI` to avoid name collisions with other libraries that use OAuth2 ([#118](https://github.com/ramsayleung/rspotify/issues/118)).
-- The `blocking` module has been removed, since Rspotify is able to use multiple HTTP clients now. `reqwest` and `ureq` are currently supported, meaning that you can still use blocking code by enabling the `client-ureq` feature and a TLS like `ureq-rustls-tls`. Read the docs for more information ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
+- The `blocking` module has been removed, since RSpotify is able to use multiple HTTP clients now. `reqwest` and `ureq` are currently supported, meaning that you can still use blocking code by enabling the `client-ureq` feature and a TLS like `ureq-rustls-tls`. Read the docs for more information ([#129](https://github.com/ramsayleung/rspotify/pull/129)).
 - The `Spotify` client has been split up by authorization flows (`ClientCredsSpotify`, `AuthCodeSpotify`, `AuthCodePkceSpotify`), which allows us to remove the builder pattern. The authentication process has been rewritten. ([#216](https://github.com/ramsayleung/rspotify/pull/216)).
 - Fix typo in `user_playlist_remove_specific_occurrenes_of_tracks`, now it's `user_playlist_remove_specific_occurrences_of_tracks`.
 - ([#123](https://github.com/ramsayleung/rspotify/pull/123)) All fallible calls in the client return a `ClientError` rather than using `failure`.
@@ -333,7 +333,7 @@ More in the [`examples` directory](https://github.com/ramsayleung/rspotify/tree/
   As a side effect, some methods now take references instead of values (so that they can be used multiple times when querying), and the parameters have been reordered so that the `limit` and `offset` are consistently the last two.
 
   The pagination chunk size can be configured with the `Spotify::pagination_chunks` field, which is set to 50 items by default.
-- No default values are set from Rspotify now, they will be left to the Spotify API.
+- No default values are set from RSpotify now, they will be left to the Spotify API.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `collaborative` parameter to `user_playlist_create`.
 - ([#202](https://github.com/ramsayleung/rspotify/pull/202)) Add a `uris` parameter to `playlist_reorder_tracks`.
 - ([#206](https://github.com/ramsayleung/rspotify/pull/206)) Update the endpoint signatures to pass parameters by reference, affected endpoint list:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Crates.io](https://img.shields.io/crates/v/rspotify.svg)](https://crates.io/crates/rspotify)
 [![Docs](https://docs.rs/rspotify/badge.svg)](https://docs.rs/crate/rspotify/)
 
-# Rspotify
+# RSpotify
 
-Rspotify is a wrapper for the [Spotify Web API](https://developer.spotify.com/documentation/web-api/), inspired by [spotipy](https://github.com/plamere/spotipy). It includes support for all the [authorization flows](https://developer.spotify.com/documentation/general/guides/authorization/), and helper functions for [all endpoints](https://developer.spotify.com/documentation/web-api/reference/).
+RSpotify is a wrapper for the [Spotify Web API](https://developer.spotify.com/documentation/web-api/), inspired by [spotipy](https://github.com/plamere/spotipy). It includes support for all the [authorization flows](https://developer.spotify.com/documentation/general/guides/authorization/), and helper functions for [all endpoints](https://developer.spotify.com/documentation/web-api/reference/).
 
-To learn how to use Rspotify, please refer to the [documentation](https://docs.rs/crate/rspotify/). There are some [examples that may be useful](./examples) as well.
+To learn how to use RSpotify, please refer to the [documentation](https://docs.rs/crate/rspotify/). There are some [examples that may be useful](./examples) as well.
 
 ## Changelog
 
@@ -31,7 +31,7 @@ We use GitHub Actions to make sure the codebase is consistent (`cargo fmt`) and 
 
 ## Building
 
-Rspotify uses [`maybe_async`](https://docs.rs/maybe-async/0.2.0/maybe_async/) to switch between async and blocking clients, which is triggered inside `Cargo.toml`. So that must be taken into account when building `rspotify`. Read the Configuration section in the docs for more information about how to build with custom TLS implementations, and more.
+RSpotify uses [`maybe_async`](https://docs.rs/maybe-async/0.2.0/maybe_async/) to switch between async and blocking clients, which is triggered inside `Cargo.toml`. So that must be taken into account when building `rspotify`. Read the Configuration section in the docs for more information about how to build with custom TLS implementations, and more.
 
 `client-reqwest` is used by default. It should be as easy as
 
@@ -39,7 +39,7 @@ Rspotify uses [`maybe_async`](https://docs.rs/maybe-async/0.2.0/maybe_async/) to
 $ cargo build
 ```
 
-`client-ureq` is also available as the `blocking` interface, which compiles Rspotify with [`ureq`](https://docs.rs/ureq/) (a TLS has to be specified as well):
+`client-ureq` is also available as the `blocking` interface, which compiles RSpotify with [`ureq`](https://docs.rs/ureq/) (a TLS has to be specified as well):
 
 ```sh
 $ cargo build --no-default-features --features client-ureq,ureq-rustls-tls

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,4 +1,4 @@
-//! This example showcases how the Rspotify client can be used to perform
+//! This example showcases how the RSpotify client can be used to perform
 //! multithreaded requests as well.
 
 use rspotify::{model::AlbumId, prelude::*, ClientCredsSpotify, Credentials};

--- a/examples/ureq/threading.rs
+++ b/examples/ureq/threading.rs
@@ -1,4 +1,4 @@
-//! This example showcases how the Rspotify client can be used to perform
+//! This example showcases how the RSpotify client can be used to perform
 //! multithreaded requests as well.
 
 use rspotify::{model::AlbumId, prelude::*, ClientCredsSpotify, Credentials};

--- a/rspotify-model/src/enums/mod.rs
+++ b/rspotify-model/src/enums/mod.rs
@@ -1,4 +1,4 @@
-//! All Enums for Rspotify's model types
+//! All Enums for RSpotify's model types
 
 pub mod country;
 pub mod misc;

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -97,7 +97,7 @@ where
             .await
             .expect("Failed to acquire lock")
             .as_ref()
-            .expect("Rspotify not authenticated")
+            .expect("RSpotify not authenticated")
             .auth_headers()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Rspotify is a wrapper for the [Spotify Web API][spotify-main], inspired by
+//! RSpotify is a wrapper for the [Spotify Web API][spotify-main], inspired by
 //! [spotipy][spotipy-github]. It includes support for all the [authorization
 //! flows][spotify-auth-flows], and helper methods for [all available
 //! endpoints][spotify-reference].
@@ -7,7 +7,7 @@
 //!
 //! ### HTTP Client
 //!
-//! By default, Rspotify uses the [reqwest][reqwest-docs] asynchronous HTTP
+//! By default, RSpotify uses the [reqwest][reqwest-docs] asynchronous HTTP
 //! client with its default TLS, but you can customize both the HTTP client and
 //! the TLS with the following features:
 //!
@@ -23,7 +23,7 @@
 //!
 //! If you want to use a different client or TLS than the default ones, you'll
 //! have to disable the default features and enable whichever you want. For
-//! example, this would compile Rspotify with `reqwest` and the native TLS:
+//! example, this would compile RSpotify with `reqwest` and the native TLS:
 //!
 //! ```toml
 //! [dependencies]
@@ -34,7 +34,7 @@
 //! }
 //! ```
 //!
-//! [`maybe_async`] internally enables Rspotify to  use both synchronous and
+//! [`maybe_async`] internally enables RSpotify to  use both synchronous and
 //! asynchronous HTTP clients. You can also use `ureq`, a synchronous client,
 //! like so:
 //!
@@ -55,7 +55,7 @@
 //!
 //! ### Environmental variables
 //!
-//! Rspotify supports the [`dotenv`] crate, which allows you to save credentials
+//! RSpotify supports the [`dotenv`] crate, which allows you to save credentials
 //! in a `.env` file. These will then be automatically available as
 //! environmental values when using methods like [`Credentials::from_env`].
 //!
@@ -66,7 +66,7 @@
 //!
 //! ### CLI utilities
 //!
-//! Rspotify includes basic support for Cli apps to obtain access tokens by
+//! RSpotify includes basic support for Cli apps to obtain access tokens by
 //! prompting the user, after enabling the `cli` feature. See the
 //! [Authorization](#authorization) section for more information.
 //!
@@ -81,7 +81,7 @@
 //! explanation of the different authorization flows
 //! available][spotify-auth-flows].
 //!
-//! Rspotify has a different client for each of the available authentication
+//! RSpotify has a different client for each of the available authentication
 //! flows. They may implement the endpoints in
 //! [`BaseClient`](crate::clients::BaseClient) or
 //! [`OAuthClient`](crate::clients::OAuthClient) according to what kind of
@@ -92,7 +92,7 @@
 //! * [Authorization Code Flow][spotify-auth-code]: see [`AuthCodeSpotify`].
 //! * [Authorization Code Flow with Proof Key for Code Exchange
 //!   (PKCE)][spotify-auth-code-pkce]: see [`AuthCodePkceSpotify`].
-//! * [Implicit Grant Flow][spotify-implicit-grant]: unimplemented, as Rspotify
+//! * [Implicit Grant Flow][spotify-implicit-grant]: unimplemented, as RSpotify
 //!   has not been tested on a browser yet. If you'd like support for it, let us
 //!   know in an issue!
 //!


### PR DESCRIPTION
## Description

This renames `Rspotify` to `RSpotify` by using:

* `find . -type f -name '*.rs' -exec sed -i 's/Rspotify/RSpotify/g' {} \;`
* `find . -type f -name '*.md' -exec sed -i 's/Rspotify/RSpotify/g' {} \;`

## Motivation and Context

https://github.com/ramsayleung/rspotify/issues/323#issuecomment-1153879748

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
CI still passes
## Is this change properly documented?
No need