### PR TITLE
Add debug_assert for mistake in playlist creation

### DIFF
--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -229,6 +229,12 @@ pub trait OAuthClient: BaseClient {
         collaborative: Option<bool>,
         description: Option<&str>,
     ) -> ClientResult<FullPlaylist> {
+        debug_assert!(
+            !(collaborative.unwrap_or(false) && public.unwrap_or(false)),
+            "To create a collaborative playlist you must also set public to \
+            false. See the reference for more information."
+        );
+
         let params = build_json! {
             "name": name,
             optional "public": public,


### PR DESCRIPTION
## Description

There's a simple invariant we don't check in `playlist_create`: we must have that `!(collaborative && public)`.

## Motivation and Context

See #349

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

CI passes

## Is this change properly documented?

No need.