### PR TITLE
add note for user_playlist_create endpoint

### DIFF
--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -218,7 +218,7 @@ pub trait OAuthClient: BaseClient {
     /// - name - the name of the playlist
     /// - public - is the created playlist public
     /// - description - the description of the playlist
-    /// - collaborative - if the playlist will be collaborative. Note: 
+    /// - collaborative - if the playlist will be collaborative. Note:
     /// to create a collaborative playlist you must also set public to false
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/create-playlist)

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -218,7 +218,8 @@ pub trait OAuthClient: BaseClient {
     /// - name - the name of the playlist
     /// - public - is the created playlist public
     /// - description - the description of the playlist
-    /// - collaborative - if the playlist will be collaborative
+    /// - collaborative - if the playlist will be collaborative. Note: 
+    /// to create a collaborative playlist you must also set public to false
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/create-playlist)
     async fn user_playlist_create(


### PR DESCRIPTION
## Description

Add note:

> to create a collaborative playlist you must also set public to false

## Motivation and Context

#349 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

## How has this been tested?

CI passes

## Is this change properly documented?

It's unnecessary.
