### PR TITLE
Update DeviceType to fix json parse error: unknown variant `STB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - ([#375](https://github.com/ramsayleung/rspotify/pull/375)) We now use `chrono::Duration` in more places for consistency and usability: `start_uris_playback`, `start_context_playback`, `rspotify_model::Offset`, `resume_playback`, `seek_track`. Some of these fields have been renamed from `position_ms` to `position`.
 - ((#356)[https://github.com/ramsayleung/rspotify/pull/356]) We now support custom authentication base URLs. `Config::prefix` has been renamed to `Config::api_base_url`, and we've introduced `Config::auth_base_url`.
+- ([#384](https://github.com/ramsayleung/rspotify/pull/384)) Add STB alias for Stb device type, fix for `json parse error: unknown variant STB`.
 
 ## 0.11.6 (2022.12.14)
 

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -103,6 +103,8 @@ pub enum DeviceType {
     /// Same as above, the Web API returns both 'AVR' and 'Avr' as the type.
     #[serde(alias = "AVR")]
     Avr,
+    /// Same as above, the Web API returns both 'STB' and 'Stb' as the type.
+    #[serde(alias = "STB")]
     Stb,
     AudioDongle,
     GameConsole,


### PR DESCRIPTION
## Description

Fix json parse error: unknown variant `STB` when calling device() method.

## Motivation and Context

Fixes #383

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I have device with Stb type, calling device() method from spotifyd returns error above. Adding lines from this pull request fixes the error. 

## Is this change properly documented?

No changes in documentation were made.