### PR TITLE
#385 Multiple `AlbumType` for `BaseClient::artist_albums_manual` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - ([#375](https://github.com/ramsayleung/rspotify/pull/375)) We now use `chrono::Duration` in more places for consistency and usability: `start_uris_playback`, `start_context_playback`, `rspotify_model::Offset`, `resume_playback`, `seek_track`. Some of these fields have been renamed from `position_ms` to `position`.
 - ((#356)[https://github.com/ramsayleung/rspotify/pull/356]) We now support custom authentication base URLs. `Config::prefix` has been renamed to `Config::api_base_url`, and we've introduced `Config::auth_base_url`.
 - ([#384](https://github.com/ramsayleung/rspotify/pull/384)) Add STB alias for Stb device type, fix for `json parse error: unknown variant STB`.
+- ([#386](https://github.com/ramsayleung/rspotify/pull/386)) Support `BaseClient::artist_albums` with zero or more `AlbumType`.
 
 ## 0.11.6 (2022.12.14)
 

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -276,7 +276,7 @@ where
     fn artist_albums<'a>(
         &'a self,
         artist_id: ArtistId<'a>,
-        album_type: Option<AlbumType>,
+        album_types: &'a [AlbumType],
         market: Option<Market>,
     ) -> Paginator<'_, ClientResult<SimplifiedAlbum>> {
         paginate_with_ctx(
@@ -284,7 +284,7 @@ where
             move |(slf, artist_id), limit, offset| {
                 slf.artist_albums_manual(
                     artist_id.as_ref(),
-                    album_type,
+                    album_types,
                     market,
                     Some(limit),
                     Some(offset),
@@ -298,15 +298,21 @@ where
     async fn artist_albums_manual(
         &self,
         artist_id: ArtistId<'_>,
-        album_type: Option<AlbumType>,
+        album_types: &[AlbumType],
         market: Option<Market>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
+        let album_types = album_types.as_ref();
+        let album_types = album_types
+            .iter()
+            .map(|album_type| album_type.into())
+            .collect::<Vec<&'static str>>()
+            .join(",");
         let params = build_map([
-            ("album_type", album_type.map(Into::into)),
+            ("album_type", Some(album_types.as_str())),
             ("market", market.map(Into::into)),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -264,7 +264,7 @@ where
     ///
     /// Parameters:
     /// - artist_id - the artist ID, URI or URL
-    /// - include_groups - 'album', 'single', 'appears_on', 'compilation'
+    /// - include_groups -  a list of album type like 'album', 'single' that will be used to filter response. if not supplied, all album types will be returned. 
     /// - market - limit the response to one particular country.
     /// - limit  - the number of albums to return
     /// - offset - the index of the first album to return

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -312,7 +312,7 @@ where
             .collect::<Vec<&'static str>>()
             .join(",");
         let params = build_map([
-            ("album_type", Some(album_types.as_str())),
+            ("include_groups", Some(album_types.as_str())),
             ("market", market.map(Into::into)),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -264,7 +264,7 @@ where
     ///
     /// Parameters:
     /// - artist_id - the artist ID, URI or URL
-    /// - include_groups -  a list of album type like 'album', 'single' that will be used to filter response. if not supplied, all album types will be returned. 
+    /// - include_groups -  a list of album type like 'album', 'single' that will be used to filter response. if not supplied, all album types will be returned.
     /// - market - limit the response to one particular country.
     /// - limit  - the number of albums to return
     /// - offset - the index of the first album to return

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -305,18 +305,18 @@ where
     ) -> ClientResult<Page<SimplifiedAlbum>> {
         let limit = limit.map(|x| x.to_string());
         let offset = offset.map(|x| x.to_string());
-        let include_groups = include_groups
+        let include_groups_vec = include_groups
             .into_iter()
             .map(|t| t.into())
             .collect::<Vec<&'static str>>();
-        let include_groups = include_groups
+        let include_groups_opt = include_groups_vec
             .is_empty()
             .not()
-            .then_some(include_groups)
+            .then_some(include_groups_vec)
             .map(|t| t.join(","));
 
         let params = build_map([
-            ("include_groups", include_groups.as_deref()),
+            ("include_groups", include_groups_opt.as_deref()),
             ("market", market.map(Into::into)),
             ("limit", limit.as_deref()),
             ("offset", offset.as_deref()),

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -72,7 +72,12 @@ async fn test_artists_albums() {
         .await
         .artist_albums_manual(
             birdy_uri,
-            Some(AlbumType::Album),
+            &[
+                AlbumType::Album,
+                AlbumType::Single,
+                AlbumType::Compilation,
+                AlbumType::AppearsOn,
+            ],
             Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -104,6 +104,22 @@ async fn test_artists_albums_with_multiple_album_types() {
 }
 
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
+async fn test_artists_albums_with_zero_album_type() {
+    let birdy_uri = ArtistId::from_uri("spotify:artist:2WX2uTcsvV5OnS0inACecP").unwrap();
+    creds_client()
+        .await
+        .artist_albums_manual(
+            birdy_uri,
+            [],
+            Some(Market::Country(Country::UnitedStates)),
+            Some(10),
+            None,
+        )
+        .await
+        .unwrap();
+}
+
+#[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 async fn test_artists() {
     let artist_uris = [
         ArtistId::from_uri("spotify:artist:0oSGxfWSnnOXhD2fKuz2Gy").unwrap(),

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -72,12 +72,29 @@ async fn test_artists_albums() {
         .await
         .artist_albums_manual(
             birdy_uri,
-            &[
-                AlbumType::Album,
-                AlbumType::Single,
-                AlbumType::Compilation,
-                AlbumType::AppearsOn,
-            ],
+            Some(AlbumType::Album),
+            Some(Market::Country(Country::UnitedStates)),
+            Some(10),
+            None,
+        )
+        .await
+        .unwrap();
+}
+
+#[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
+async fn test_artists_albums_with_multiple_album_types() {
+    let birdy_uri = ArtistId::from_uri("spotify:artist:2WX2uTcsvV5OnS0inACecP").unwrap();
+    let include_groups = [
+        AlbumType::Album,
+        AlbumType::Single,
+        AlbumType::Compilation,
+        AlbumType::AppearsOn,
+    ];
+    creds_client()
+        .await
+        .artist_albums_manual(
+            birdy_uri,
+            include_groups,
             Some(Market::Country(Country::UnitedStates)),
             Some(10),
             None,


### PR DESCRIPTION
## Description

fixes: #385

This change will allow `BaseClient::artist_albums_manual` to be given more than one `AlbumType`.
And It rename `album_type` of query parameter name to `include_groups`.

## Motivation and Context

I want to get artist's albums by some `AlbumType`.

## Dependencies 

No changes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [x] Test A: test_artists_albums
  + My change doesnot break previous `BaseClient::artist_albums_manual` calls.
- [x] Test B: test_artists_albums_with_multiple_album_types
  + Add`BaseClient::artist_albums_manual` call by `AlbumType` array.


## Is this change properly documented?

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).

- [x] Added to changelog.