### PR TITLE
Remove rustc-serialize feature from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rspotify-http = { path = "rspotify-http", version = "0.11.6", default-features =
 async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }
 base64 = "0.20.0"
-chrono = { version = "0.4.19", features = ["serde", "rustc-serialize"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 dotenv = { version = "0.15.0", optional = true }
 futures = { version = "0.3.17", optional = true }
 getrandom = "0.2.3"

--- a/rspotify-http/src/common.rs
+++ b/rspotify-http/src/common.rs
@@ -37,11 +37,11 @@ pub trait BaseHttpClient: Send + Default + Clone + fmt::Debug {
         payload: &Value,
     ) -> Result<String, Self::Error>;
 
-    async fn post_form<'a>(
+    async fn post_form(
         &self,
         url: &str,
         headers: Option<&Headers>,
-        payload: &Form<'a>,
+        payload: &Form<'_>,
     ) -> Result<String, Self::Error>;
 
     async fn put(

--- a/rspotify-http/src/reqwest.rs
+++ b/rspotify-http/src/reqwest.rs
@@ -124,11 +124,11 @@ impl BaseHttpClient for ReqwestClient {
     }
 
     #[inline]
-    async fn post_form<'a>(
+    async fn post_form(
         &self,
         url: &str,
         headers: Option<&Headers>,
-        payload: &Form<'a>,
+        payload: &Form<'_>,
     ) -> Result<String, Self::Error> {
         self.request(Method::POST, url, headers, |req| req.form(payload))
             .await

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -124,11 +124,11 @@ impl BaseHttpClient for UreqClient {
     }
 
     #[inline]
-    fn post_form<'a>(
+    fn post_form(
         &self,
         url: &str,
         headers: Option<&Headers>,
-        payload: &Form<'a>,
+        payload: &Form<'_>,
     ) -> Result<String, Self::Error> {
         let request = ureq::post(url);
         let sender = |req: Request| {

--- a/rspotify-model/Cargo.toml
+++ b/rspotify-model/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 readme = "../README.md"
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde", "rustc-serialize"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 enum_dispatch = "0.3.8"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.67"

--- a/rspotify-model/src/custom_serde.rs
+++ b/rspotify-model/src/custom_serde.rs
@@ -78,7 +78,7 @@ pub mod millisecond_timestamp {
             // so it would be safe to convert it i64.
             match NaiveDateTime::from_timestamp_opt(second as i64, nanosecond) {
                 Some(ndt) => Ok(DateTime::<Utc>::from_utc(ndt, Utc)),
-                None => Err(E::custom(format!("v is invalid second: {}", v))),
+                None => Err(E::custom(format!("v is invalid second: {v}"))),
             }
         }
     }


### PR DESCRIPTION
Because rustc-serialize is considered insecured, and is using constructor that will be not compiled in future rustc, chrono dropped rustc-serialize in the main branch (future 0.5 release)

This patch remove this feature, to avoid the current compiler warning and prepare the work for the new chrono release.

Fix #387

Signed-off-by: Alberto Planas <aplanas@suse.com>