### PR TITLE
The scopes macro supports to split scope by whitespace

### DIFF
--- a/rspotify-macros/src/lib.rs
+++ b/rspotify-macros/src/lib.rs
@@ -13,12 +13,26 @@
 /// manually.insert("playlist-read-collaborative".to_owned());
 /// assert_eq!(with_macro, manually);
 /// ```
+/// Note: the scopes! macro also support to split the word by whitespace
+/// so the scope can't contain any whitespace
+/// ```
+/// use rspotify_macros::scopes;
+/// use std::collections::HashSet;
+///
+/// let macro_with_whitespace = scopes!("playlist-read-private playlist-read-collaborative");
+/// let mut manually = HashSet::new();
+/// manually.insert("playlist-read-private".to_owned());
+/// manually.insert("playlist-read-collaborative".to_owned());
+/// assert_eq!(macro_with_whitespace, manually);
+/// ```
 #[macro_export]
 macro_rules! scopes {
     ($($key:expr),*) => {{
         let mut container = ::std::collections::HashSet::new();
         $(
-            container.insert($key.to_owned());
+            for scope in $key.split_whitespace(){
+            container.insert(scope);
+            }
         )*
         container
     }};
@@ -31,6 +45,17 @@ mod test {
     #[test]
     fn test_hashset() {
         let scopes = scopes!("hello", "world", "foo", "bar");
+        assert_eq!(scopes.len(), 4);
+        assert!(scopes.contains("hello"));
+        assert!(scopes.contains("world"));
+        assert!(scopes.contains("foo"));
+        assert!(scopes.contains("bar"));
+    }
+
+    #[test]
+    fn test_scopes_with_whitespace() {
+        let scopes = scopes!("      hello world foo bar");
+
         assert_eq!(scopes.len(), 4);
         assert!(scopes.contains("hello"));
         assert!(scopes.contains("world"));


### PR DESCRIPTION
## Description

The `scopes!` macro supports to split scope by whitespace

## Motivation and Context

https://github.com/ramsayleung/rspotify/issues/389

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- [x] test_scopes_with_whitespace

## Is this change properly documented?

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
