### PR TITLE
Make Paginator Send to enable scheduling onto a multithreaded runtime

### DIFF
--- a/src/clients/pagination/stream.rs
+++ b/src/clients/pagination/stream.rs
@@ -7,25 +7,26 @@ use std::pin::Pin;
 use futures::{future::Future, stream::Stream};
 
 /// Alias for `futures::stream::Stream<Item = T>`, since async mode is enabled.
-pub type Paginator<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
+pub type Paginator<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a + Send>>;
 
-pub type RequestFuture<'a, T> = Pin<Box<dyn 'a + Future<Output = ClientResult<Page<T>>>>>;
+pub type RequestFuture<'a, T> = Pin<Box<dyn 'a + Future<Output = ClientResult<Page<T>>> + Send>>;
 
 /// This is used to handle paginated requests automatically.
-pub fn paginate_with_ctx<'a, Ctx: 'a, T, Request>(
+pub fn paginate_with_ctx<'a, Ctx: 'a + Send, T, Request>(
     ctx: Ctx,
     req: Request,
     page_size: u32,
 ) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin,
-    Request: 'a + for<'ctx> Fn(&'ctx Ctx, u32, u32) -> RequestFuture<'ctx, T>,
+    T: 'a + Unpin + Send,
+    Request: 'a + for<'ctx> Fn(&'ctx Ctx, u32, u32) -> RequestFuture<'ctx, T> + Send,
 {
     use async_stream::stream;
     let mut offset = 0;
     Box::pin(stream! {
         loop {
-            let page = req(&ctx, page_size, offset).await?;
+            let request = req(&ctx, page_size, offset);
+            let page = request.await?;
             offset += page.items.len() as u32;
             for item in page.items {
                 yield Ok(item);
@@ -39,15 +40,16 @@ where
 
 pub fn paginate<'a, T, Fut, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin,
-    Fut: Future<Output = ClientResult<Page<T>>>,
-    Request: 'a + Fn(u32, u32) -> Fut,
+    T: 'a + Unpin + Send,
+    Fut: Future<Output = ClientResult<Page<T>>> + Send,
+    Request: 'a + Fn(u32, u32) -> Fut + Send,
 {
     use async_stream::stream;
     let mut offset = 0;
     Box::pin(stream! {
         loop {
-            let page = req(page_size, offset).await?;
+            let request = req(page_size, offset);
+            let page = request.await?;
             offset += page.items.len() as u32;
             for item in page.items {
                 yield Ok(item);


### PR DESCRIPTION
## Description

Paginator is in fact a boxed trait object. However, it doesn't implement Send which is a requirement when scheduling onto a async multithreaded scheduler.

## Motivation and Context

Using a Paginator which is not Send will also make the enclosing Future not Send. Therefore , when using tokio with the default scheduler, this will only work in the main thread.

## Dependencies 

None.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

The first commit adds a test that sets `Sync`, which multithreaded async schedulers usually have. This test will not compile without modifying the code, just like if you try to schedule a future using a Paginator without a Send bound.

Please also list any relevant details for your test configuration

- Using a Future enclosing an (async) Paginator, scheduled onto the tokio multithreaded scheduler.

## Is this change properly documented?

Since this change only relaxes requirements for the user of the Paginator, no documentation change was made.