### PR TITLE
allow ureq to use native certificate store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - ((#356)[https://github.com/ramsayleung/rspotify/pull/356]) We now support custom authentication base URLs. `Config::prefix` has been renamed to `Config::api_base_url`, and we've introduced `Config::auth_base_url`.
 - ([#384](https://github.com/ramsayleung/rspotify/pull/384)) Add STB alias for Stb device type, fix for `json parse error: unknown variant STB`.
 - ([#386](https://github.com/ramsayleung/rspotify/pull/386)) Support `BaseClient::artist_albums` with zero or more `AlbumType`.
+- ([#393](https://github.com/ramsayleung/rspotify/pull/393)) Add `ureq-rustls-tls-native-certs` feature flag.
 
 ## 0.11.6 (2022.12.14)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ reqwest-native-tls = ["rspotify-http/reqwest-native-tls"]
 reqwest-native-tls-vendored = ["rspotify-http/reqwest-native-tls-vendored"]
 # Same for ureq.
 ureq-rustls-tls = ["rspotify-http/ureq-rustls-tls"]
+ureq-rustls-tls-native-certs = ["rspotify-http/ureq-rustls-tls-native-certs"]
 
 # Internal features for checking async or sync compilation
 __async = ["futures", "async-stream", "async-trait"]

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -46,6 +46,7 @@ reqwest-native-tls = ["reqwest/native-tls"]
 reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
 # Same for ureq.
 ureq-rustls-tls = ["ureq/tls"]
+ureq-rustls-tls-native-certs = ["ureq/tls", "ureq/native-certs"]
 
 # Internal features for checking async or sync compilation
 __async = ["async-trait"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! - [ureq][ureq-docs]: enabling `client-ureq`, TLS
 //!   available:
 //!     + `ureq-rustls-tls` (ureq's default)
+//!     + `ureq-rustls-tls-native-certs` (`rustls` with OS root certificates)
 //!
 //! If you want to use a different client or TLS than the default ones, you'll
 //! have to disable the default features and enable whichever you want. For


### PR DESCRIPTION
## Description

This introduces a passthrough of the `native-certs` feature flag of `ureq`, which allows the http client to load the OS certificate store.

## Motivation and Context

Currently, `rspotify` always uses the `webpki-roots` certificates, when used with `ureq`, which makes it impossible to use e.g. self-signed certificates.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How has this been tested?

I ran the non-modifying tests with a proxy sniffing the HTTPS traffic, which failed with `ureq-rustls-tls` and passed with `ureq-rustls-tls-native-certs` (since I added the used cert to the OS store).

## Is this change properly documented?

I added the feature flag to one place in the documentation. Are there ones that I missed?

## Additional notes

In theory, there's also a `native-tls` feature flag for `ureq`, but that requires creating a [`native-tls::TlsConnector`](https://docs.rs/native-tls/latest/native_tls/struct.TlsConnector.html). This can fail, which I don't know how to handle within the `Default` implementation, so I didn't do that for now. If you've got ideas how this could be done, I'll happily implement that.