### PR TITLE
enable / standardize client request timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - ([#384](https://github.com/ramsayleung/rspotify/pull/384)) Add STB alias for Stb device type, fix for `json parse error: unknown variant STB`.
 - ([#386](https://github.com/ramsayleung/rspotify/pull/386)) Support `BaseClient::artist_albums` with zero or more `AlbumType`.
 
+**Bugfixes**
+- ([#394](https://github.com/ramsayleung/rspotify/pull/394)) Set a common 10 second timeout for both http clients.
+
 ## 0.11.6 (2022.12.14)
 
 - ([#331](https://github.com/ramsayleung/rspotify/pull/331)) `Market` is now `Copy`

--- a/rspotify-http/src/reqwest.rs
+++ b/rspotify-http/src/reqwest.rs
@@ -4,6 +4,7 @@
 use super::{BaseHttpClient, Form, Headers, Query};
 
 use std::convert::TryInto;
+use std::time::Duration;
 
 use maybe_async::async_impl;
 use reqwest::{Method, RequestBuilder};
@@ -49,10 +50,21 @@ pub enum ReqwestError {
     StatusCode(reqwest::Response),
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ReqwestClient {
     /// reqwest needs an instance of its client to perform requests.
     client: reqwest::Client,
+}
+
+impl Default for ReqwestClient {
+    fn default() -> Self {
+        let client = reqwest::ClientBuilder::new()
+            .timeout(Duration::from_secs(10))
+            .build()
+            // building with these options cannot fail
+            .unwrap();
+        Self { client }
+    }
 }
 
 impl ReqwestClient {

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -50,8 +50,18 @@ pub enum UreqError {
     StatusCode(ureq::Response),
 }
 
-#[derive(Default, Debug, Clone)]
-pub struct UreqClient {}
+#[derive(Debug, Clone)]
+pub struct UreqClient {
+    agent: ureq::Agent,
+}
+
+impl Default for UreqClient {
+    fn default() -> Self {
+        Self {
+            agent: ureq::agent(),
+        }
+    }
+}
 
 impl UreqClient {
     /// The request handling in ureq is split in three parts:
@@ -101,7 +111,7 @@ impl BaseHttpClient for UreqClient {
         headers: Option<&Headers>,
         payload: &Query,
     ) -> Result<String, Self::Error> {
-        let request = ureq::get(url);
+        let request = self.agent.get(url);
         let sender = |mut req: Request| {
             for (key, val) in payload.iter() {
                 req = req.query(key, val);
@@ -118,7 +128,7 @@ impl BaseHttpClient for UreqClient {
         headers: Option<&Headers>,
         payload: &Value,
     ) -> Result<String, Self::Error> {
-        let request = ureq::post(url);
+        let request = self.agent.post(url);
         let sender = |req: Request| req.send_json(payload.clone());
         self.request(request, headers, sender)
     }
@@ -130,7 +140,7 @@ impl BaseHttpClient for UreqClient {
         headers: Option<&Headers>,
         payload: &Form<'_>,
     ) -> Result<String, Self::Error> {
-        let request = ureq::post(url);
+        let request = self.agent.post(url);
         let sender = |req: Request| {
             let payload = payload
                 .iter()
@@ -150,7 +160,7 @@ impl BaseHttpClient for UreqClient {
         headers: Option<&Headers>,
         payload: &Value,
     ) -> Result<String, Self::Error> {
-        let request = ureq::put(url);
+        let request = self.agent.put(url);
         let sender = |req: Request| req.send_json(payload.clone());
         self.request(request, headers, sender)
     }
@@ -162,7 +172,7 @@ impl BaseHttpClient for UreqClient {
         headers: Option<&Headers>,
         payload: &Value,
     ) -> Result<String, Self::Error> {
-        let request = ureq::delete(url);
+        let request = self.agent.delete(url);
         let sender = |req: Request| req.send_json(payload.clone());
         self.request(request, headers, sender)
     }

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -2,7 +2,7 @@
 
 use super::{BaseHttpClient, Form, Headers, Query};
 
-use std::io;
+use std::{io, time::Duration};
 
 use maybe_async::sync_impl;
 use serde_json::Value;
@@ -57,9 +57,10 @@ pub struct UreqClient {
 
 impl Default for UreqClient {
     fn default() -> Self {
-        Self {
-            agent: ureq::agent(),
-        }
+        let agent = ureq::AgentBuilder::new()
+            .timeout(Duration::from_secs(10))
+            .build();
+        Self { agent }
     }
 }
 


### PR DESCRIPTION
## Description

This sets the same timeout duration for `reqwest` and `ureq` http clients.


## Motivation and Context

https://github.com/ramsayleung/rspotify/blob/6d304de632a84f79c35cb9ff4a0e66be238cf205/rspotify-model/src/auth.rs#L79-L80

This mentions a maximum request time of 10 seconds, but AFAICT, these timeouts aren't specified anywhere. By default, `reqwest` does not have a timeout at all, `ureq` has a 30 second `connect` timeout.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

The provided non-modifying tests.

## Is this change properly documented?

I hope so. :) Please point me to additional documentation changes that are necessary, if there are any.
