### PR TITLE
Fix a broken link in struct AuthCodeSpotify

### DIFF
--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use maybe_async::maybe_async;
 use url::Url;
 
-/// The [Authorization Code Flow](reference) client for the Spotify API.
+/// The [Authorization Code Flow][reference] client for the Spotify API.
 ///
 /// This includes user authorization, and thus has access to endpoints related
 /// to user private data, unlike the [Client Credentials

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -58,7 +58,7 @@ use url::Url;
 /// `http://localhost:8888/callback` for example, which will also have the code
 /// appended like so: `http://localhost/?code=...`.
 ///
-/// [reference]: https://developer.spotify.com/documentation/general/guides/authorization/code-flow
+/// [reference]: https://developer.spotify.com/documentation/web-api/tutorials/code-flow
 /// [example-main]: https://github.com/ramsayleung/rspotify/blob/master/examples/auth_code.rs
 /// [example-webapp]: https://github.com/ramsayleung/rspotify/tree/master/examples/webapp
 /// [example-refresh-token]: https://github.com/ramsayleung/rspotify/blob/master/examples/with_refresh_token.rs


### PR DESCRIPTION

## Description

This commit fixes the link to point to the correct  Spotify developer docs.

## Motivation and Context

The documentation for AuthCodeSpotify struct contained a broken link.

## Dependencies 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Please also list any relevant details for your test configuration

- [ ] Test A: xxx
- [ ] Test B: xxx

## Is this change properly documented?

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
