### PR TITLE
Add ureq-native-tls feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ([#384](https://github.com/ramsayleung/rspotify/pull/384)) Add STB alias for Stb device type, fix for `json parse error: unknown variant STB`.
 - ([#386](https://github.com/ramsayleung/rspotify/pull/386)) Support `BaseClient::artist_albums` with zero or more `AlbumType`.
 - ([#393](https://github.com/ramsayleung/rspotify/pull/393)) Add `ureq-rustls-tls-native-certs` feature flag.
+- ([#402](https://github.com/ramsayleung/rspotify/pull/402)) Add `ureq-native-tls` feature flag.
 
 **Bugfixes**
 - ([#394](https://github.com/ramsayleung/rspotify/pull/394)) Set a common 10 second timeout for both http clients.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ reqwest-native-tls-vendored = ["rspotify-http/reqwest-native-tls-vendored"]
 # Same for ureq.
 ureq-rustls-tls = ["rspotify-http/ureq-rustls-tls"]
 ureq-rustls-tls-native-certs = ["rspotify-http/ureq-rustls-tls-native-certs"]
+ureq-native-tls = ["rspotify-http/ureq-native-tls"]
 
 # Internal features for checking async or sync compilation
 __async = ["futures", "async-stream", "async-trait"]

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -47,6 +47,7 @@ reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
 # Same for ureq.
 ureq-rustls-tls = ["ureq/tls"]
 ureq-rustls-tls-native-certs = ["ureq/tls", "ureq/native-certs"]
+ureq-native-tls = ["ureq/native-tls"]
 
 # Internal features for checking async or sync compilation
 __async = ["async-trait"]


### PR DESCRIPTION
## Description

Allow building with ureq client and native-tls (i.e. without rustls).

## Motivation and Context

I’m an Alpine Linux developer and I want to build [ncspot](https://github.com/hrkfdn/ncspot) with native TLS instead of rustls.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

```sh
cargo test --no-default-features --features client-ureq,ureq-native-tls
```

## Is this change properly documented?

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
