### PR TITLE
feat: add endpoint for return playlist image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+**New features**
+- ([377](https://github.com/ramsayleung/rspotify/pull/408)) add endpoint for get playlist image
+
 ## 0.11.7 (2023.04.26)
 
 - ([#399](https://github.com/ramsayleung/rspotify/pull/399)) Add a new variant `Collectionyourepisodes` for `Type` enum.

--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -73,3 +73,10 @@ pub struct FeaturedPlaylists {
 pub struct CategoryPlaylists {
     pub playlists: Page<SimplifiedPlaylist>,
 }
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PlaylistCover {
+    pub url: String,
+    pub height: Option<u32>,
+    pub width: Option<u32>,
+}

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -1013,14 +1013,17 @@ where
         let result = self.api_get(&url, &params).await?;
         convert_result(&result)
     }
-    
+
     /// Get the current image associated with a specific playlist.
     ///
     /// Parameters:
-    /// - playlist_id - the id of the playlist 
+    /// - playlist_id - the id of the playlist
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/get-playlist-cover)
-    async fn playlist_cover(&self, playlist_id: PlaylistId<'_>) -> ClientResult<Vec<PlaylistCover>> {
+    async fn playlist_cover(
+        &self,
+        playlist_id: PlaylistId<'_>,
+    ) -> ClientResult<Vec<PlaylistCover>> {
         let url = format!("playlists/{}/images", playlist_id.id());
         let result = self.api_get(&url, &Query::new()).await?;
 

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -1013,11 +1013,24 @@ where
         let result = self.api_get(&url, &params).await?;
         convert_result(&result)
     }
+    
+    /// Get the current image associated with a specific playlist.
+    ///
+    /// Parameters:
+    /// - playlist_id - the id of the playlist 
+    ///
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/get-playlist-cover)
+    async fn playlist_cover(&self, playlist_id: PlaylistId<'_>) -> ClientResult<Vec<PlaylistCover>> {
+        let url = format!("playlists/{}/images", playlist_id.id());
+        let result = self.api_get(&url, &Query::new()).await?;
+
+        convert_result(&result)
+    }
 
     /// Gets playlists of a user.
     ///
     /// Parameters:
-    /// - user_id - the id of the usr
+    /// - user_id - the id of the user
     /// - limit  - the number of items to return
     /// - offset - the index of the first item to return
     ///


### PR DESCRIPTION
## Description

Added endpoint for return playlist image, requested by issue #377 

## Motivation and Context

adding endpoint that was missing of the spotify api

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

## How has this been tested?

was used to test the example that was in the examples/webapp, was created a new endpoint to request this new implementation

## Is this change properly documented?

The documentation follows the same example for others implementations in code



Obs:
the endpoint to update the image on SpotifyAPI is not yet in this PR, as the adjustments have not yet been tested, so I have not sent it