### PR TITLE
Change type of `position` parameter for `playlist_add_item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12 (unreleased )
+- ([]()) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
+
 ## 0.11.7 (2023.04.26)
 
 - ([#399](https://github.com/ramsayleung/rspotify/pull/399)) Add a new variant `Collectionyourepisodes` for `Type` enum.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.12 (unreleased )
-- ([]()) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
+**Breaking changes**
+- ([#409](https://github.com/ramsayleung/rspotify/pull/409)) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
 
 ## 0.11.7 (2023.04.26)
 

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -294,7 +294,7 @@ pub trait OAuthClient: BaseClient {
     /// Parameters:
     /// - playlist_id - the id of the playlist
     /// - track_ids - a list of track URIs, URLs or IDs
-    /// - position - the position to add the tracks
+    /// - position - the position to add the items, a zero-based index 
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/add-tracks-to-playlist)
     async fn playlist_add_items<'a>(

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -301,12 +301,12 @@ pub trait OAuthClient: BaseClient {
         &self,
         playlist_id: PlaylistId<'_>,
         items: impl IntoIterator<Item = PlayableId<'a>> + Send + 'a,
-        position: Option<chrono::Duration>,
+        position: Option<u32>,
     ) -> ClientResult<PlaylistResult> {
         let uris = items.into_iter().map(|id| id.uri()).collect::<Vec<_>>();
         let params = JsonBuilder::new()
             .required("uris", uris)
-            .optional("position", position.map(|p| p.num_milliseconds()))
+            .optional("position", position)
             .build();
 
         let url = format!("playlists/{}/tracks", playlist_id.id());

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -294,7 +294,7 @@ pub trait OAuthClient: BaseClient {
     /// Parameters:
     /// - playlist_id - the id of the playlist
     /// - track_ids - a list of track URIs, URLs or IDs
-    /// - position - the position to add the items, a zero-based index 
+    /// - position - the position to add the items, a zero-based index
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/add-tracks-to-playlist)
     async fn playlist_add_items<'a>(


### PR DESCRIPTION
## Description

Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`

## Motivation and Context

#407 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

- [x] `check_playlist_tracks`

## Is this change properly documented?
Yes