### PR TITLE
Fix pkce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 **Breaking changes**
 - ([#409](https://github.com/ramsayleung/rspotify/pull/409)) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
 
+**Bugfixes**
+- ([[#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.
+
 ## 0.11.7 (2023.04.26)
 
 - ([#399](https://github.com/ramsayleung/rspotify/pull/399)) Add a new variant `Collectionyourepisodes` for `Type` enum.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rspotify-http = { path = "rspotify-http", version = "0.11.7", default-features =
 
 async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }
-base64 = "0.20.0"
+base64 = "0.21.2"
 chrono = { version = "0.4.19", features = ["serde"] }
 dotenv = { version = "0.15.0", optional = true }
 futures = { version = "0.3.17", optional = true }

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -8,6 +8,8 @@ use crate::{
     ClientResult, Config, Credentials, OAuth, Token,
 };
 
+use base64::{engine::general_purpose, Engine as _};
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -167,7 +169,7 @@ impl AuthCodePkceSpotify {
         hasher.update(verifier.as_bytes());
         let challenge = hasher.finalize();
 
-        let challenge = base64::encode(challenge);
+        let challenge = general_purpose::URL_SAFE_NO_PAD.encode(challenge);
 
         (verifier, challenge)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ use std::{
     path::PathBuf,
 };
 
+use base64::{engine::general_purpose, Engine as _};
 use getrandom::getrandom;
 use thiserror::Error;
 
@@ -358,7 +359,7 @@ impl Credentials {
     pub fn auth_headers(&self) -> Option<HashMap<String, String>> {
         let auth = "authorization".to_owned();
         let value = format!("{}:{}", self.id, self.secret.as_ref()?);
-        let value = format!("Basic {}", base64::encode(value));
+        let value = format!("Basic {}", general_purpose::STANDARD_NO_PAD.encode(value));
 
         let mut headers = HashMap::new();
         headers.insert(auth, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ impl Credentials {
     pub fn auth_headers(&self) -> Option<HashMap<String, String>> {
         let auth = "authorization".to_owned();
         let value = format!("{}:{}", self.id, self.secret.as_ref()?);
-        let value = format!("Basic {}", general_purpose::STANDARD_NO_PAD.encode(value));
+        let value = format!("Basic {}", general_purpose::STANDARD.encode(value));
 
         let mut headers = HashMap::new();
         headers.insert(auth, value);


### PR DESCRIPTION
## Description

This PR fixes the PKCE auth flow panicking during `prompt_for_token`. The issue was the challenge code was being base64 encoded in a url-unsafe manner. This PR simply changes the base64 encoding logic to be url safe.

I also bumped the base64 crate version and updated lib.rs to avoid using a deprecated base64 encode API.

#419

## Motivation and Context

I wanted to use PKCE auth.

## Dependencies 

No dependencies added. base64 bumped from 0.20.0 to 0.21.2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I didn't do any automated testing, I just ran the auth_code_pkce example to check if my changes worked. On version 0.11.7 this example panics. With my patch, the example functions as expected.

## Is this change properly documented?

I added an entry to the changelog. I don't believe further documentation is needed.
