### PR TITLE
Update tracks_features data model to more accurately reflect API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bugfixes**
 - ([[#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.
+- ([[#421](https://github.com/ramsayleung/rspotify/issues/421)) Filter `null`s on `tracks_features` requests
 
 ## 0.11.7 (2023.04.26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Breaking changes**
 - ([#409](https://github.com/ramsayleung/rspotify/pull/409)) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
+- ([[#421](https://github.com/ramsayleung/rspotify/issues/421)) Change type of `AudioFeaturesPayload.audio_features` from `Vec<AudioFeatures>` to `Vec<Option<AudioFeatures>>`
 
 **Bugfixes**
 - ([[#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.

--- a/rspotify-model/src/audio.rs
+++ b/rspotify-model/src/audio.rs
@@ -35,7 +35,7 @@ pub struct AudioFeatures {
 /// Intermediate audio feature object wrapped by `Vec`
 #[derive(Deserialize)]
 pub struct AudioFeaturesPayload {
-    pub audio_features: Vec<AudioFeatures>,
+    pub audio_features: Vec<Option<AudioFeatures>>,
 }
 
 /// Audio analysis object

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -708,9 +708,11 @@ where
         let result = self.api_get(&url, &Query::new()).await?;
         if result.is_empty() {
             Ok(None)
+        } else if let Some(payload) = convert_result::<Option<AudioFeaturesPayload>>(&result)? {
+            let audio_features = payload.audio_features.into_iter().flatten().collect();
+            Ok(Some(audio_features))
         } else {
-            convert_result::<Option<AudioFeaturesPayload>>(&result)
-                .map(|option_payload| option_payload.map(|x| x.audio_features))
+            Ok(None)
         }
     }
 

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -157,6 +157,8 @@ async fn test_audios_features() {
     tracks_ids.push(track_id1);
     let track_id2 = TrackId::from_uri("spotify:track:24JygzOLM0EmRQeGtFcIcG").unwrap();
     tracks_ids.push(track_id2);
+    let track_id_no_features = TrackId::from_uri("spotify:track:6z99LwRS28wga9xc2u09Po").unwrap();
+    tracks_ids.push(track_id_no_features);
     creds_client()
         .await
         .tracks_features(tracks_ids)


### PR DESCRIPTION
## Description

When querying `tracks_features`, the Spotify API will sometimes return `null` instead of `AudioFeatures` for a track, resulting in a deserialization error. This PR updates the internal `AudioFeaturesPayload` type to be a `Vec<Option<AudioFeature>>` rather than a `Vec<AudioFeature>` to avoid breaking on deserialization.

## Motivation and Context

When getting audio features for several thousand tracks, I could consistently get rspotify to choke on a `null` result for one of the IDs (`6z99LwRS28wga9xc2u09Po`). Here's the response I get:

```json
{
  "audio_features": [
    {
      "danceability": 0.481,
      "energy": 0.0683,
      "key": 9,
      "loudness": -21.035,
      "mode": 0,
      "speechiness": 0.529,
      "acousticness": 0.903,
      "instrumentalness": 0.599,
      "liveness": 0.256,
      "valence": 0.519,
      "tempo": 81.948,
      "type": "audio_features",
      "id": "6Gx1aZp23xQStq1kAqexA1",
      "uri": "spotify:track:6Gx1aZp23xQStq1kAqexA1",
      "track_href": "https://api.spotify.com/v1/tracks/6Gx1aZp23xQStq1kAqexA1",
      "analysis_url": "https://api.spotify.com/v1/audio-analysis/6Gx1aZp23xQStq1kAqexA1",
      "duration_ms": 161971,
      "time_signature": 4
    },
    null,
    {
      "danceability": 0.603,
      "energy": 0.629,
      "key": 7,
      "loudness": -5.789,
      "mode": 0,
      "speechiness": 0.125,
      "acousticness": 0.707,
      "instrumentalness": 0,
      "liveness": 0.181,
      "valence": 0.389,
      "tempo": 82.078,
      "type": "audio_features",
      "id": "2pRU7Hr7vmSWT90NNOQiTd",
      "uri": "spotify:track:2pRU7Hr7vmSWT90NNOQiTd",
      "track_href": "https://api.spotify.com/v1/tracks/2pRU7Hr7vmSWT90NNOQiTd",
      "analysis_url": "https://api.spotify.com/v1/audio-analysis/2pRU7Hr7vmSWT90NNOQiTd",
      "duration_ms": 140000,
      "time_signature": 4
    }
  ]
}
```

I figured it'd be best to avoid breaking the `tracks_features` API by changing the return type from `Option<Vec<AudioFeature>>` to `Option<Vec<Option<AudioFeature>>>`, so there's now a flattening step in between receiving the API response and returning the list of audio features. This means that you won't be able to 1:1 map a result from `tracks_features` to the input tracks, but I don't think that was guaranteed anyway.

## Dependencies

None.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I added "spotify:track:6z99LwRS28wga9xc2u09Po" as a test case to `test_audios_features`, which is a spotify track (https://open.spotify.com/track/6z99LwRS28wga9xc2u09Po) that returns `null` when querying for audio features.

## Is this change properly documented?

I stuck it in the changelog, but I don't think there needs to be any doc updates.
