### PR TITLE
Add close stale issue and pr action

### DIFF
--- a/.github/workflows/close_stale.yaml
+++ b/.github/workflows/close_stale.yaml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
+          stale-pr-message: 'Message to comment on stale PRs. If none provided, will not mark PRs stale'


### PR DESCRIPTION
## Description

Add Github Action to automatically close stale Issues and PRs: https://github.com/marketplace/actions/close-stale-issues

## Motivation and Context

Warns and then closes issues and PRs that have had no activity for a specified amount of time.

## Dependencies 

Github Action Dependency: 
1. Close Stale Issues

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

This new GitHub Action is able to run and close stale issue and PR

## Is this change properly documented?

It's unnecessary.

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
