### PR TITLE
fix PKCE url in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - ([#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.
 - ([#421](https://github.com/ramsayleung/rspotify/issues/421)) Filter `null`s on `tracks_features` requests
 - ([#424](https://github.com/ramsayleung/rspotify/pull/424)) Fix PKCE refresh token invalid error
+- ([#428](https://github.com/ramsayleung/rspotify/pull/428)) Fix PKCE url in doc
 
 ## 0.11.7 (2023.04.26)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! [spotify-register-app]: https://developer.spotify.com/dashboard/applications
 //! [spotify-client-creds]: https://developer.spotify.com/documentation/general/guides/authorization/client-credentials/
 //! [spotify-auth-code]: https://developer.spotify.com/documentation/general/guides/authorization/code-flow
-//! [spotify-auth-code-pkce]: https://developer.spotify.com/documentation/general/guides/authorization/code-flow
+//! [spotify-auth-code-pkce]: https://developer.spotify.com/documentation/web-api/tutorials/code-pkce-flow
 //! [spotify-implicit-grant]: https://developer.spotify.com/documentation/general/guides/authorization/implicit-grant
 
 mod auth_code;


### PR DESCRIPTION
## Description

fix pkce url in doc

## Motivation and Context

Opening links in https://docs.rs/rspotify/latest/rspotify/ redirect twice to the same page, instead of 2 different ones

## Dependencies 



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Opened a that link in firefox.

Before: got a "Authorization Code Flow" page
After: got a "Authorization Code with PKCE Flow" page

## Is this change properly documented?

yes
