### PR TITLE
Enable token refreshing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Breaking changes**
 - ([#409](https://github.com/ramsayleung/rspotify/pull/409)) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
 - ([#421](https://github.com/ramsayleung/rspotify/issues/421)) Change type of `AudioFeaturesPayload.audio_features` from `Vec<AudioFeatures>` to `Vec<Option<AudioFeatures>>`
+- ([#429](https://github.com/ramsayleung/rspotify/pull/429)) Enable Token refreshing by default.
 
 **Bugfixes**
 - ([#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.

--- a/examples/with_auto_reauth.rs
+++ b/examples/with_auto_reauth.rs
@@ -113,7 +113,6 @@ async fn main() {
 
     // Enabling automatic token refreshing in the config
     let config = Config {
-        token_refreshing: true,
         ..Default::default()
     };
 

--- a/examples/with_token_callback_fn.rs
+++ b/examples/with_token_callback_fn.rs
@@ -23,7 +23,6 @@ async fn _with_pkce(creds: Credentials, oauth: OAuth) {
 
     // Enabling automatic token refreshing in the config
     let config = Config {
-        token_refreshing: true,
         token_callback_fn: Arc::new(Some(token_callback)),
         ..Default::default()
     };
@@ -48,7 +47,6 @@ async fn with_auth(creds: Credentials, oauth: OAuth) {
 
     // Enabling automatic token refreshing in the config
     let config = Config {
-        token_refreshing: true,
         token_callback_fn: Arc::new(Some(token_callback)),
         ..Default::default()
     };
@@ -74,7 +72,6 @@ async fn with_client_credentials(creds: Credentials) {
 
     // Enabling automatic token refreshing in the config
     let config = Config {
-        token_refreshing: true,
         token_callback_fn: Arc::new(Some(token_callback)),
         ..Default::default()
     };

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -120,8 +120,7 @@ mod test {
             refresh_token: Some("...".to_string()),
         };
 
-        let spotify = ClientCredsSpotify::from_token(tok);
-        let headers = spotify.auth_headers().await;
+        let headers = tok.auth_headers();
         assert_eq!(
             headers.get("authorization"),
             Some(&"Bearer test-access_token".to_owned())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl Default for Config {
             cache_path: PathBuf::from(DEFAULT_CACHE_PATH),
             pagination_chunks: DEFAULT_PAGINATION_CHUNKS,
             token_cached: false,
-            token_refreshing: false,
+            token_refreshing: true,
             token_callback_fn: Arc::new(None),
         }
     }


### PR DESCRIPTION
## Description

Enable token refreshing by default.

## Motivation and Context

https://github.com/ramsayleung/rspotify/issues/413

## Dependencies 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

`cargo run --example with_auto_reauth --features env-file,cli,client-reqwest`


## Is this change properly documented?

Yes
