### PR TITLE
Add missing optional `market` field to some APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Breaking changes**
 - ([#409](https://github.com/ramsayleung/rspotify/pull/409)) Change type of `position` parameter in `playlist_add_items` endpoint from `Opinion<Duration>` to `Opinion<u32>`
 - ([#421](https://github.com/ramsayleung/rspotify/issues/421)) Change type of `AudioFeaturesPayload.audio_features` from `Vec<AudioFeatures>` to `Vec<Option<AudioFeatures>>`
+- ([#432](https://github.com/ramsayleung/rspotify/pull/432)) Add optional `market` field to `track`, `album`, `albums`, and `album_track[_manual]`. Make `market` field in `artist_top_tracks` optional.
 
 **Bugfixes**
 - ([#419](https://github.com/ramsayleung/rspotify/issues/419)) Base64url encode instead of plain base64 encode for PKCE challenge code.

--- a/examples/client_creds.rs
+++ b/examples/client_creds.rs
@@ -33,7 +33,7 @@ async fn main() {
 
     // Running the requests
     let birdy_uri = AlbumId::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap();
-    let albums = spotify.album(birdy_uri).await;
+    let albums = spotify.album(birdy_uri, None).await;
 
     println!("Response: {albums:#?}");
 }

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -28,7 +28,7 @@ async fn main() {
         let spotify = Arc::clone(&spotify);
         let wr = wr.clone();
         let handle = task::spawn(async move {
-            let albums = spotify.album(id).await.unwrap();
+            let albums = spotify.album(id, None).await.unwrap();
             wr.send(albums).unwrap();
         });
 

--- a/examples/ureq/threading.rs
+++ b/examples/ureq/threading.rs
@@ -29,7 +29,7 @@ fn main() {
         let spotify = Arc::clone(&spotify);
         let wr = wr.clone();
         let handle = thread::spawn(move || {
-            let albums = spotify.album(id).unwrap();
+            let albums = spotify.album(id, None).unwrap();
             wr.send(albums).unwrap();
         });
 

--- a/examples/with_auto_reauth.rs
+++ b/examples/with_auto_reauth.rs
@@ -45,7 +45,7 @@ async fn auth_code_do_things(spotify: &AuthCodeSpotify) {
 async fn client_creds_do_things(spotify: &ClientCredsSpotify) {
     // Running the requests
     let birdy_uri = AlbumId::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap();
-    let albums = spotify.album(birdy_uri).await;
+    let albums = spotify.album(birdy_uri, None).await;
     println!("Get albums: {}", albums.unwrap().id);
 }
 

--- a/examples/with_auto_reauth.rs
+++ b/examples/with_auto_reauth.rs
@@ -52,7 +52,7 @@ async fn client_creds_do_things(spotify: &ClientCredsSpotify) {
 async fn expire_token<S: BaseClient>(spotify: &S) {
     let token_mutex = spotify.get_token();
     let mut token = token_mutex.lock().await.unwrap();
-    let mut token = token.as_mut().expect("Token can't be empty as this point");
+    let token = token.as_mut().expect("Token can't be empty as this point");
     // In a regular case, the token would expire with time. Here we just do
     // it manually.
     let now = Utc::now().checked_sub_signed(Duration::seconds(10));

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -344,9 +344,9 @@ where
     async fn artist_top_tracks(
         &self,
         artist_id: ArtistId<'_>,
-        market: Market,
+        market: Option<Market>,
     ) -> ClientResult<Vec<FullTrack>> {
-        let params = build_map([("market", Some(market.into()))]);
+        let params = build_map([("market", market.map(Into::into))]);
 
         let url = format!("artists/{}/top-tracks", artist_id.id());
         let result = self.api_get(&url, &params).await?;

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -133,7 +133,7 @@ async fn test_artist_top_tracks() {
     let birdy_uri = ArtistId::from_uri("spotify:artist:2WX2uTcsvV5OnS0inACecP").unwrap();
     creds_client()
         .await
-        .artist_top_tracks(birdy_uri, Market::Country(Country::UnitedStates))
+        .artist_top_tracks(birdy_uri, Some(Market::Country(Country::UnitedStates)))
         .await
         .unwrap();
 }

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -230,7 +230,7 @@ mod test_pagination {
         let album = AlbumId::from_uri(ALBUM).unwrap();
 
         let names = client
-            .album_track(album)
+            .album_track(album, None)
             .map(|track| track.unwrap().name)
             .collect::<Vec<_>>();
 

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -26,7 +26,7 @@ pub async fn creds_client() -> ClientCredsSpotify {
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 async fn test_album() {
     let birdy_uri = AlbumId::from_uri("spotify:album:0sNOF9WDwhWunNAHPD3Baj").unwrap();
-    creds_client().await.album(birdy_uri).await.unwrap();
+    creds_client().await.album(birdy_uri, None).await.unwrap();
 }
 
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
@@ -36,7 +36,7 @@ async fn test_albums() {
         AlbumId::from_uri("spotify:album:6JWc4iAiJ9FjyK0B59ABb4").unwrap(),
         AlbumId::from_uri("spotify:album:6UXCm6bOO4gFlDQZV5yL37").unwrap(),
     ];
-    creds_client().await.albums(track_uris).await.unwrap();
+    creds_client().await.albums(track_uris, None).await.unwrap();
 }
 
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
@@ -44,7 +44,7 @@ async fn test_album_tracks() {
     let birdy_uri = AlbumId::from_uri("spotify:album:6akEvsycLGftJxYudPjmqK").unwrap();
     creds_client()
         .await
-        .album_track_manual(birdy_uri, Some(2), None)
+        .album_track_manual(birdy_uri, None, Some(2), None)
         .await
         .unwrap();
 }
@@ -175,7 +175,7 @@ async fn test_user() {
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
 async fn test_track() {
     let birdy_uri = TrackId::from_uri("spotify:track:6rqhFgbbKwnb9MLmUQDhG6").unwrap();
-    creds_client().await.track(birdy_uri).await.unwrap();
+    creds_client().await.track(birdy_uri, None).await.unwrap();
 }
 
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]
@@ -248,7 +248,7 @@ mod test_pagination {
         let album = AlbumId::from_uri(ALBUM).unwrap();
 
         let names = client
-            .album_track(album)
+            .album_track(album, None)
             .map(|track| track.unwrap().name)
             .collect::<Vec<_>>()
             .await;


### PR DESCRIPTION
## Description

Resolves #423

- added missing optional `market` field to following APIs:
  - `track`
  - `album`
  - `albums`
  - `album_track`
  - `album_track_manual`
- made `market` field in `artist_top_tracks` API optional instead of required

## Context

Required for https://github.com/aome510/spotify-player/pull/207

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update