### PR TITLE
Bug Fix: Set refresh token to new access token before `callback_fn` is called

### DIFF
--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -108,11 +108,12 @@ impl BaseClient for AuthCodeSpotify {
                     .expect("No client secret set in the credentials.");
                 let mut token = self.fetch_access_token(&data, Some(&headers)).await?;
 
+                token.refresh_token = Some(refresh_token.to_string());
+
                 if let Some(callback_fn) = &*self.get_config().token_callback_fn.clone() {
                     callback_fn.0(token.clone())?;
                 }
 
-                token.refresh_token = Some(refresh_token.to_string());
                 Ok(Some(token))
             }
             _ => Ok(None),


### PR DESCRIPTION
## Description

`callback_fn` was not returning the refresh token in `AuthCodeSpotify`, so I simply moved the `token.refresh_token = Some(refresh_token.to_string());` above the `callback_fn` directive to solve this problem.

## Motivation and Context

Refresh token was not being returned after `refetch_token` was called.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I used it in my project and it does work. It is a two line 

## Is this change properly documented?

I figure this can be done once the PR is in.

Thanks for the great library!
