### PR TITLE
Add image cover

### DIFF
--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -574,6 +574,24 @@ where
         convert_result(&result)
     }
 
+    /// Get cover image of a playlist.
+    ///
+    /// Parameters:
+    /// - playlist_id - the playlist ID, URI or URL
+    /// [reference](https://developer.spotify.com/documentation/web-api/reference/get-playlist-cover)
+    async fn playlist_cover_image(
+        &self,
+        playlist_id: PlaylistId<'_>,
+    ) -> ClientResult<Option<Image>> {
+        let url = format!("playlists/{}/images", playlist_id);
+        let result = self.api_get(&url, &Query::new()).await?;
+        if result.is_empty() {
+            Ok(None)
+        } else {
+            convert_result(&result)
+        }
+    }
+
     /// Get Spotify catalog information for a single show identified by its unique Spotify ID.
     ///
     /// Path Parameters:

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -248,7 +248,7 @@ pub trait OAuthClient: BaseClient {
     }
 
     /// Replace the image used to represent a specific playlist
-    /// 
+    ///
     /// Parameters:
     /// - playlist_id - the id of the playlist
     /// - image - Base64 encoded JPEG image data, maximum payload size is 256 KB.
@@ -261,21 +261,6 @@ pub trait OAuthClient: BaseClient {
         let url = format!("playlists/{}/images", playlist_id.id());
         let params = JsonBuilder::new().required("image", image).build();
         self.api_put(&url, &params).await
-    }
-
-
-        /// Get cover image of a playlist.
-        /// 
-        /// Parameters:
-        /// - playlist_id - the playlist ID, URI or URL
-    async fn playlist_cover_image(&self, playlist_id: PlaylistId<'_>)-> ClientResult<Option<Image>>{
-        let url = format!("playlists/{}/images" , playlist_id);
-        let result = self.api_get(&url, &Query::new()).await?;
-        if result.is_empty() {
-            Ok(None)
-        } else {
-            convert_result(&result)
-        }
     }
 
     /// Changes a playlist's name and/or public/private state.

--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -247,6 +247,37 @@ pub trait OAuthClient: BaseClient {
         convert_result(&result)
     }
 
+    /// Replace the image used to represent a specific playlist
+    /// 
+    /// Parameters:
+    /// - playlist_id - the id of the playlist
+    /// - image - Base64 encoded JPEG image data, maximum payload size is 256 KB.
+    /// [Reference] (https://developer.spotify.com/documentation/web-api/reference/upload-custom-playlist-cover)
+    async fn playlist_upload_cover_image(
+        &self,
+        playlist_id: PlaylistId<'_>,
+        image: &str,
+    ) -> ClientResult<String> {
+        let url = format!("playlists/{}/images", playlist_id.id());
+        let params = JsonBuilder::new().required("image", image).build();
+        self.api_put(&url, &params).await
+    }
+
+
+        /// Get cover image of a playlist.
+        /// 
+        /// Parameters:
+        /// - playlist_id - the playlist ID, URI or URL
+    async fn playlist_cover_image(&self, playlist_id: PlaylistId<'_>)-> ClientResult<Option<Image>>{
+        let url = format!("playlists/{}/images" , playlist_id);
+        let result = self.api_get(&url, &Query::new()).await?;
+        if result.is_empty() {
+            Ok(None)
+        } else {
+            convert_result(&result)
+        }
+    }
+
     /// Changes a playlist's name and/or public/private state.
     ///
     /// Parameters:

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -641,6 +641,23 @@ async fn check_playlist_create(client: &AuthCodeSpotify) -> FullPlaylist {
 }
 
 #[maybe_async]
+async fn check_playlist_cover(client: &AuthCodeSpotify, playlist_id: PlaylistId<'_>) {
+    // add playlist cover image
+    let image = "/9j/2wCEABoZGSccJz4lJT5CLy8vQkc9Ozs9R0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0cBHCcnMyYzPSYmPUc9Mj1HR0dEREdHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR//dAAQAAf/uAA5BZG9iZQBkwAAAAAH/wAARCAABAAEDACIAAREBAhEB/8QASwABAQAAAAAAAAAAAAAAAAAAAAYBAQAAAAAAAAAAAAAAAAAAAAAQAQAAAAAAAAAAAAAAAAAAAAARAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwAAARECEQA/AJgAH//Z";
+    client
+        .playlist_upload_cover_image(playlist_id.as_ref(), image)
+        .await
+        .unwrap();
+
+    // check cover image
+    let cover_res = client
+        .playlist_cover_image(playlist_id.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(cover_res.unwrap().url, image);
+}
+
+#[maybe_async]
 async fn check_num_tracks(client: &AuthCodeSpotify, playlist_id: PlaylistId<'_>, num: i32) {
     let fetched_tracks = fetch_all(client.playlist_items(playlist_id, None, None)).await;
     assert_eq!(fetched_tracks.len() as i32, num);
@@ -769,6 +786,7 @@ async fn test_playlist() {
     let playlist = check_playlist_create(&client).await;
     check_playlist_tracks(&client, &playlist).await;
     check_playlist_follow(&client, &playlist).await;
+    check_playlist_cover(&client, playlist.id).await;
 }
 
 #[maybe_async::test(feature = "__sync", async(feature = "__async", tokio::test))]


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed
Getter and setter for playlist cover are missing as mentioned here #377 and #438

## Motivation and Context

Please also include relevant motivation and context. 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

I am yet trying to test both function under test_with_oauth.rs by creating a playlist, adding a cover, retrieving it and comparing both.
However I need guidance on how to test it as I am not able to figure out how to oauth for the tests. I am not sure what are the variable values required in the .env and even if I put a wrong value, it doesn't seem like the value is being read.

## Is this change properly documented?

yes
