### PR TITLE
Update DeviceType to fix json parse error: unknown variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1 (Unreleased)
+**Bugfixes**
+- ([#440](https://github.com/ramsayleung/rspotify/issues/440)) Add Smartwatch device type, fix for json parse error: unknown variant Smartwatch.
+
 ## 0.12.0 (2023.08.26)
 **New features**
 - ([#390](https://github.com/ramsayleung/rspotify/pull/390)) The `scopes!` macro supports to split the scope by whitespace.

--- a/rspotify-model/src/custom_serde.rs
+++ b/rspotify-model/src/custom_serde.rs
@@ -77,7 +77,7 @@ pub mod millisecond_timestamp {
             // The maximum value of i64 is large enough to hold milliseconds,
             // so it would be safe to convert it i64.
             match NaiveDateTime::from_timestamp_opt(second as i64, nanosecond) {
-                Some(ndt) => Ok(DateTime::<Utc>::from_utc(ndt, Utc)),
+                Some(ndt) => Ok(DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc)),
                 None => Err(E::custom(format!("v is invalid second: {v}"))),
             }
         }

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -96,6 +96,7 @@ pub enum DeviceType {
     Computer,
     Tablet,
     Smartphone,
+    Smartwatch,
     Speaker,
     /// Though undocumented, it has been reported that the Web API returns both
     /// 'Tv' and 'TV' as the type.

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -730,7 +730,7 @@ fn test_currently_playing_context() {
     let timestamp = 1607769168429;
     let second: i64 = (timestamp - timestamp % 1000) / 1000;
     let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
+    let dt = DateTime::<Utc>::from_naive_utc_and_offset(
         NaiveDateTime::from_timestamp_opt(second, nanosecond as u32).unwrap(),
         Utc,
     );
@@ -845,7 +845,7 @@ fn test_current_playback_context() {
     let timestamp = 1607774342714;
     let second: i64 = (timestamp - timestamp % 1000) / 1000;
     let nanosecond = (timestamp % 1000) * 1000000;
-    let dt = DateTime::<Utc>::from_utc(
+    let dt = DateTime::<Utc>::from_naive_utc_and_offset(
         NaiveDateTime::from_timestamp_opt(second, nanosecond as u32).unwrap(),
         Utc,
     );


### PR DESCRIPTION
## Description

Fix json parse error: unknown variant `Smartwatch` when calling device() method.

## Motivation and Context

Fixes https://github.com/ramsayleung/rspotify/issues/440

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I have device with Smartwatch type, calling device() method from my app using rspotify returns error above.
Changes from this pull request stop the error occurring and allow the device type 'Smartwatch' to be returned.
![image](https://github.com/ramsayleung/rspotify/assets/20409659/43e83536-5bd6-477a-a3b0-81c5b5a3fd40)

## Is this change properly documented?

No changes in docs were made.
CHANGELOG entry has been added under bug fix for 12.0.1
