### PR TITLE
[docs] Add comment explaining required deps

### DIFF
--- a/examples/pagination_async.rs
+++ b/examples/pagination_async.rs
@@ -1,6 +1,9 @@
 //! This example showcases how streams can be used for asynchronous automatic
 //! pagination.
 //!
+//! You'll need to run `cargo add futures futures_util` to get the `pin_mut!`
+//! macro and the `stream.try_next()` method.
+//!
 //! Asynchronous iteration is a bit uglier, since there's currently no
 //! syntactic sugar for `for` loops. See this article for more information:
 //!


### PR DESCRIPTION
This is a no-code commit. The `pagination_async` example doesn't explicitly say that the `futures` and `futures_util` crates are required, so I had to do a lil' hunting to figure out what crates I was missing when I tried to copy-paste the code.

This commit just adds a comment explaining how to add the required dependencies.