### PR TITLE
Replace `dotenv` (unmaintained since 2020) with `dotenvy` (RUSTSEC-2021-0141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.1 (Unreleased)
 **Bugfixes**
 - ([#440](https://github.com/ramsayleung/rspotify/issues/440)) Add Smartwatch device type, fix for json parse error: unknown variant Smartwatch.
+- ([#447](https://github.com/ramsayleung/rspotify/pull/447)) Replace the deprecated `dotenv` crate with `dotenvy`
 
 ## 0.12.0 (2023.08.26)
 **New features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }
 base64 = "0.21.2"
 chrono = { version = "0.4.19", features = ["serde"] }
-dotenv = { version = "0.15.0", optional = true }
+dotenvy = { version = "0.15.0", optional = true }
 futures = { version = "0.3.17", optional = true }
 getrandom = "0.2.3"
 log = "0.4.14"
@@ -56,7 +56,7 @@ default = ["client-reqwest", "reqwest-default-tls"]
 
 ### Client ###
 cli = ["webbrowser"]
-env-file = ["dotenv"]
+env-file = ["dotenvy"]
 
 ### HTTP ###
 # Available clients. By default they don't include a TLS so that it can be
@@ -80,7 +80,7 @@ __sync = ["maybe-async/is_sync"]
 
 [package.metadata.docs.rs]
 # When generating the docs, we also want to include the CLI methods, and working
-# links for `dotenv`. We generate them for ureq so that the function signatures
+# links for `dotenvy`. We generate them for ureq so that the function signatures
 # of the endpoints don't look gnarly (because of `async-trait`).
 features = ["cli", "env-file", "client-ureq"]
 no-default-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! ### Environmental variables
 //!
-//! RSpotify supports the `dotenv` crate, which allows you to save credentials
+//! RSpotify supports the `dotenvy` crate, which allows you to save credentials
 //! in a `.env` file. These will then be automatically available as
 //! environmental values when using methods like [`Credentials::from_env`].
 //!
@@ -367,7 +367,7 @@ impl Credentials {
     pub fn from_env() -> Option<Self> {
         #[cfg(feature = "env-file")]
         {
-            dotenv::dotenv().ok();
+            dotenvy::dotenv().ok();
         }
 
         Some(Self {
@@ -422,7 +422,7 @@ impl OAuth {
     pub fn from_env(scopes: HashSet<String>) -> Option<Self> {
         #[cfg(feature = "env-file")]
         {
-            dotenv::dotenv().ok();
+            dotenvy::dotenv().ok();
         }
 
         Some(Self {


### PR DESCRIPTION
## Description
Replace the [dotenv](https://github.com/dotenv-rs/dotenv) crate with [dotenvy](https://github.com/allan2/dotenvy). `dotenvy` is a maintained fork recommended by RUSTSEC.

## Motivation and Context

`dotenv` is unmaintained and has not received an update since 2020. `dotenvy` is the recommended, drop in fork.

Sources:
1. https://github.com/dotenv-rs/dotenv
2. https://rustsec.org/advisories/RUSTSEC-2021-0141.html

## Dependencies 

* [dotenvy](https://github.com/allan2/dotenvy)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
I ran the test suite with `--features env-file` before and after the change. The fork doesn't change the original crate's API beyond replacing `dotenv` with `dotenvy`.

## Is this change properly documented?

No, but I'll edit the `CHANGELOG.md` and squash the commits now.
