### PR TITLE
Return new error `InvalidToken` if user is not yet authenticated

### DIFF
--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -94,10 +94,10 @@ where
     /// automatic reauthentication takes place, if enabled.
     #[doc(hidden)]
     async fn auth_headers(&self) -> ClientResult<Headers> {
-        self.auto_reauth()
-            .await?;
+        self.auto_reauth().await?;
 
-        Ok(self.get_token()
+        Ok(self
+            .get_token()
             .lock()
             .await
             .unwrap()

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -9,7 +9,7 @@ use crate::{
     model::*,
     sync::Mutex,
     util::build_map,
-    ClientResult, Config, Credentials, Token,
+    ClientError, ClientResult, Config, Credentials, Token,
 };
 
 use std::{collections::HashMap, fmt, ops::Not, sync::Arc};
@@ -93,18 +93,17 @@ where
     /// Since this is accessed by authenticated requests always, it's where the
     /// automatic reauthentication takes place, if enabled.
     #[doc(hidden)]
-    async fn auth_headers(&self) -> Headers {
+    async fn auth_headers(&self) -> ClientResult<Headers> {
         self.auto_reauth()
-            .await
-            .expect("Failed to re-authenticate automatically, please authenticate");
+            .await?;
 
-        self.get_token()
+        Ok(self.get_token()
             .lock()
             .await
-            .expect("Failed to acquire lock")
+            .unwrap()
             .as_ref()
-            .expect("RSpotify not authenticated")
-            .auth_headers()
+            .ok_or(ClientError::InvalidToken)?
+            .auth_headers())
     }
 
     // HTTP-related methods for the Spotify client. They wrap up the basic HTTP
@@ -116,7 +115,7 @@ where
     #[inline]
     async fn api_get(&self, url: &str, payload: &Query<'_>) -> ClientResult<String> {
         let url = self.api_url(url);
-        let headers = self.auth_headers().await;
+        let headers = self.auth_headers().await?;
         Ok(self.get_http().get(&url, Some(&headers), payload).await?)
     }
 
@@ -126,7 +125,7 @@ where
     #[inline]
     async fn api_post(&self, url: &str, payload: &Value) -> ClientResult<String> {
         let url = self.api_url(url);
-        let headers = self.auth_headers().await;
+        let headers = self.auth_headers().await?;
         Ok(self.get_http().post(&url, Some(&headers), payload).await?)
     }
 
@@ -136,7 +135,7 @@ where
     #[inline]
     async fn api_put(&self, url: &str, payload: &Value) -> ClientResult<String> {
         let url = self.api_url(url);
-        let headers = self.auth_headers().await;
+        let headers = self.auth_headers().await?;
         Ok(self.get_http().put(&url, Some(&headers), payload).await?)
     }
 
@@ -146,7 +145,7 @@ where
     #[inline]
     async fn api_delete(&self, url: &str, payload: &Value) -> ClientResult<String> {
         let url = self.api_url(url);
-        let headers = self.auth_headers().await;
+        let headers = self.auth_headers().await?;
         Ok(self
             .get_http()
             .delete(&url, Some(&headers), payload)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,9 @@ pub enum ClientError {
 
     #[error("model error: {0}")]
     Model(#[from] model::ModelError),
+
+    #[error("Token is not valid")]
+    InvalidToken,
 }
 
 // The conversion has to be done manually because it's in a `Box<T>`


### PR DESCRIPTION
## Description

Return new error `InvalidToken` if user is not yet authenticated. The library should never panic when the user forgets to authenticate, but return a valid error to the user.

## Motivation and Context

Resolves https://github.com/ramsayleung/rspotify/issues/333

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
