### PR TITLE
Fix incorrect reference link.

### DIFF
--- a/src/clients/oauth.rs
+++ b/src/clients/oauth.rs
@@ -957,7 +957,7 @@ pub trait OAuthClient: BaseClient {
     ///   your client supports besides the default track type. Valid types are:
     ///   `track` and `episode`.
     ///
-    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recently-played)
+    /// [Reference](https://developer.spotify.com/documentation/web-api/reference/get-the-users-currently-playing-track)
     async fn current_playing<'a>(
         &'a self,
         market: Option<Market>,


### PR DESCRIPTION
## Description

Fix the incorrect reference link pointing to the [Get Recently Played Tracks](https://developer.spotify.com/documentation/web-api/reference/get-recently-played) endpoint instead of the correct one, [Get Currently Playing Track](https://developer.spotify.com/documentation/web-api/reference/get-the-users-currently-playing-track)

## Motivation and Context

#450 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

All CI tasks passed

## Is this change properly documented?

Please make sure you've properly documented the changes you're making.

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
