### PR TITLE
Add option to create AuthCodeSpotify with token and refresh

### DIFF
--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -198,6 +198,24 @@ impl AuthCodeSpotify {
         }
     }
 
+    /// Build a new [`AuthCodeSpotify`] from an already generated token and
+    /// config. Use this to be able to refresh a token.
+    #[must_use]
+    pub fn from_token_with_config(
+        token: Token,
+        creds: Credentials,
+        oauth: OAuth,
+        config: Config,
+    ) -> Self {
+        Self {
+            token: Arc::new(Mutex::new(Some(token))),
+            creds,
+            oauth,
+            config,
+            ..Default::default()
+        }
+    }
+
     /// Returns the URL needed to authorize the current client as the first step
     /// in the authorization flow.
     pub fn get_authorize_url(&self, show_dialog: bool) -> ClientResult<String> {

--- a/src/auth_code.rs
+++ b/src/auth_code.rs
@@ -4,7 +4,7 @@ use crate::{
     http::{Form, HttpClient},
     join_scopes, params,
     sync::Mutex,
-    ClientResult, Config, Credentials, OAuth, Token,
+    ClientError, ClientResult, Config, Credentials, OAuth, Token,
 };
 
 use std::collections::HashMap;
@@ -116,7 +116,10 @@ impl BaseClient for AuthCodeSpotify {
 
                 Ok(Some(token))
             }
-            _ => Ok(None),
+            _ => {
+                log::warn!("Can not refresh token! Token missing!");
+                Err(ClientError::InvalidToken)
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes: https://github.com/ramsayleung/rspotify/issues/446

## Motivation and Context

Being able to restore a token from cache and also refreshing it.

## Dependencies 


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Use token from cache and refresh it successfully.

## Is this change properly documented?

Example code was not changed.