### PR TITLE
Enable proxy detection when using `ureq` as HTTP client

### DIFF
--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.29"
 
 # Supported clients
 reqwest = { version = "0.11.4", default-features = false, features = ["json", "socks"], optional = true }
-ureq = { version = "2.2.0", default-features = false, features = ["json", "cookies"], optional = true }
+ureq = { version = "2.2.0", default-features = false, features = ["json", "cookies", "socks-proxy"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -58,6 +58,7 @@ pub struct UreqClient {
 impl Default for UreqClient {
     fn default() -> Self {
         let agent = ureq::AgentBuilder::new()
+            .try_proxy_from_env(true)
             .timeout(Duration::from_secs(10))
             .build();
         Self { agent }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,14 @@
 //!
 //! ### Proxies
 //!
-//! [reqwest supports system proxies by default][reqwest-proxies]. It reads the
-//! environment variables `HTTP_PROXY` and `HTTPS_PROXY` environmental variables
-//! to set HTTP and HTTPS proxies, respectively.
+//! Both [reqwest][reqwest-proxies] and [ureq][ureq-proxying] support system
+//! proxies by default. They both read `http_proxy`, `https_proxy`, `all_proxy`
+//! and their uppercase variants `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`,
+//! although the specific logic implementations are a little different.
+//!
+//! See also:
+//! - [reqwest](https://docs.rs/reqwest/latest/src/reqwest/proxy.rs.html#897-920)
+//! - [ureq](https://docs.rs/ureq/latest/src/ureq/proxy.rs.html#73-95)
 //!
 //! ### Environmental variables
 //!


### PR DESCRIPTION
## Description

Enable proxy detection when using `ureq` as HTTP client, making it consistent with using `reqwest`.

## Motivation and Context

I found a proxy leak in hrkfdn/ncspot#1384 and traced it back to this crate.

## Dependencies 

None.

## Type of change

Should this count as a bug fix or a new feature? I'm not sure.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested?

This is a very minor change that simply calls a function of a dependency. I think it's okay to forgo tests.

## Is this change properly documented?

- [x] `lib.rs` documentation updated
- [ ] Changelog entry pending on determining change type