### PR TITLE
Workaround for Spotify API bug

### DIFF
--- a/rspotify-model/src/artist.rs
+++ b/rspotify-model/src/artist.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 
-use crate::{ArtistId, CursorBasedPage, Followers, Image};
+use crate::{data_type_patcher::as_u32, ArtistId, CursorBasedPage, Followers, Image};
 
 /// Simplified Artist Object
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -25,6 +25,8 @@ pub struct FullArtist {
     pub id: ArtistId<'static>,
     pub images: Vec<Image>,
     pub name: String,
+    // TODO: remove this statement after Spotify fix the [issue](https://github.com/ramsayleung/rspotify/issues/452)
+    #[serde(deserialize_with = "as_u32")]
     pub popularity: u32,
 }
 

--- a/rspotify-model/src/data_type_patcher.rs
+++ b/rspotify-model/src/data_type_patcher.rs
@@ -1,0 +1,28 @@
+// Workaround for Spotify API bug which causes dome uint fields
+// being return as floats
+// TODO: remove this workaround after Spotify fix the [issue](https://github.com/ramsayleung/rspotify/issues/452)
+
+use serde::{Deserialize, Deserializer};
+
+pub fn as_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let float_data: f64 = Deserialize::deserialize(deserializer)?;
+
+    let u32_data = float_data as u32;
+
+    Ok(u32_data)
+}
+
+pub fn as_some_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let float_data: Option<f64> = Deserialize::deserialize(deserializer)?;
+
+    match float_data {
+        Some(f) => Ok(Some(f as u32)),
+        None => Ok(None),
+    }
+}

--- a/rspotify-model/src/image.rs
+++ b/rspotify-model/src/image.rs
@@ -1,11 +1,17 @@
 //! Image object
 
+pub use crate::data_type_patcher::as_some_u32;
+
 use serde::{Deserialize, Serialize};
 
 /// Image object
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Image {
+    // TODO: remove this statement after Spotify fix the [issue](https://github.com/ramsayleung/rspotify/issues/452)
+    #[serde(deserialize_with = "as_some_u32")]
     pub height: Option<u32>,
     pub url: String,
+    // TODO: remove this statement after Spotify fix the [issue](https://github.com/ramsayleung/rspotify/issues/452)
+    #[serde(deserialize_with = "as_some_u32")]
     pub width: Option<u32>,
 }

--- a/rspotify-model/src/lib.rs
+++ b/rspotify-model/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod category;
 pub mod context;
 pub(crate) mod custom_serde;
+pub mod data_type_patcher;
 pub mod device;
 pub mod enums;
 pub mod error;
@@ -24,9 +25,9 @@ pub mod track;
 pub mod user;
 
 pub use {
-    album::*, artist::*, audio::*, auth::*, category::*, context::*, device::*, enums::*, error::*,
-    idtypes::*, image::*, offset::*, page::*, playing::*, playlist::*, recommend::*, search::*,
-    show::*, track::*, user::*,
+    album::*, artist::*, audio::*, auth::*, category::*, context::*, data_type_patcher::as_u32,
+    device::*, enums::*, error::*, idtypes::*, image::*, offset::*, page::*, playing::*,
+    playlist::*, recommend::*, search::*, show::*, track::*, user::*,
 };
 
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,8 @@ use serde::{Deserialize, Serialize};
 pub struct Followers {
     // This field will always set to null, as the Web API does not support it at the moment.
     // pub href: Option<String>,
+    // TODO: remove this statement after Spotify fix the [issue](https://github.com/ramsayleung/rspotify/issues/452)
+    #[serde(deserialize_with = "as_u32")]
     pub total: u32,
 }
 


### PR DESCRIPTION
## Description

https://github.com/ramsayleung/rspotify/issues/452 Due to Spotify API returning floats instead of uints for some fields of the Artist it cannot be parsed. This commit adds deserializing float values into u32 as a workaround.

## Motivation and Context

Please also include relevant motivation and context. 

## Dependencies

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Tested using https://github.com/aome510/spotify-player, after this fix the artist's page loaded successfully.

## Is this change properly documented?

Yes