### PR TITLE
[Fix] Fix the filter of GitHub Action on event

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 on:
   create:
     tags:
-      - v*
+      - 'v*'
 
 name: Publish Crate
 


### PR DESCRIPTION
## Description

Fix the filter of GitHub Action on event

## Motivation and Context

The `on` section specifies the events that trigger workflow, what I expect is the workflow only get triggered when new tag name `v*` is created(e.g. new version is published).

However, the current configuration will trigger the workflow not only when a new tag is created but also when any other type of creation event occurs(such as creating a new branch)

Fixing it by enclosing the tag pattern `'v*'` in single quotes, it should explicitly specfy that the workflow should trigger only when a new tg matching that pattern is created.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

This PR shoudn't trigger the `Publish Create` workflow

## Is this change properly documented?

It's unnecessary.