### PR TITLE
Add SimplifiedAlbum to SimplifiedTrack.

### DIFF
--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -59,6 +59,7 @@ pub struct FullTracks {
 /// relinking is applied.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedTrack {
+    pub album: SimplifiedAlbum,
     pub artists: Vec<SimplifiedArtist>,
     pub available_markets: Option<Vec<String>>,
     pub disc_number: i32,

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -59,7 +59,8 @@ pub struct FullTracks {
 /// relinking is applied.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedTrack {
-    pub album: SimplifiedAlbum,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album: Option<SimplifiedAlbum>,
     pub artists: Vec<SimplifiedArtist>,
     pub available_markets: Option<Vec<String>>,
     pub disc_number: i32,

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -22,7 +22,51 @@ where
 #[wasm_bindgen_test]
 fn test_simplified_track() {
     let json_str = r#"
-{
+    {
+      "album": {
+        "album_type": "album",
+        "total_tracks": 11,
+        "available_markets": ["AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK"],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/6akEvsycLGftJxYudPjmqK"
+        },
+        "href": "https://api.spotify.com/v1/albums/6akEvsycLGftJxYudPjmqK",
+        "id": "6akEvsycLGftJxYudPjmqK",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d0000b2731ae2bdc1378da1b440e1f610",
+            "height": 640,
+            "width": 640
+          },
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e021ae2bdc1378da1b440e1f610",
+            "height": 300,
+            "width": 300
+          },
+          {
+            "url": "https://i.scdn.co/image/ab67616d000048511ae2bdc1378da1b440e1f610",
+            "height": 64,
+            "width": 64
+          }
+        ],
+        "name": "Place In The Sun",
+        "release_date": "2004-02-02",
+        "release_date_precision": "day",
+        "type": "album",
+        "uri": "spotify:album:6akEvsycLGftJxYudPjmqK",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/08td7MxkoHQkXnWAYD8d6Q"
+            },
+            "href": "https://api.spotify.com/v1/artists/08td7MxkoHQkXnWAYD8d6Q",
+            "id": "08td7MxkoHQkXnWAYD8d6Q",
+            "name": "Tania Bowra",
+            "type": "artist",
+            "uri": "spotify:artist:08td7MxkoHQkXnWAYD8d6Q"
+          }
+        ]
+      },
     "artists": [ {
       "external_urls": {
         "spotify": "https://open.spotify.com/artist/08td7MxkoHQkXnWAYD8d6Q"


### PR DESCRIPTION
## Description

This adds SimplifiedAlbum member to the SimplifiedTrack struct.

## Motivation and Context

Found this issue through the recommendations API.
Fixes: https://github.com/ramsayleung/rspotify/issues/464#issue-2176647918

## Type of change

Please delete options that are not relevant.

**- [X] Bug fix (non-breaking change which fixes an issue)**

## How has this been tested?
Using this function:

    pub async fn get_user_suggestions(spotify_session: AuthCodeSpotify) -> Recommendations {
        let seed_artists = [ArtistId::from_id("4NHQUGzhtTLFvgF5SZesLK").unwrap()];

        let attributes = [RecommendationsAttribute::MinEnergy(0.4)];

        let recommendations: Recommendations = spotify_session.recommendations(
            attributes,
            Some(seed_artists),
            None::<Vec<&str>>,
            Some(None),
            Some(Market::Country(Country::UnitedStates)),
            Some(100)
        )
            .await
            .unwrap();

        recommendations
    }
    
You were not able to see Album information prior to the member addition.
