### PR TITLE
[fix] the suspicious use of OpenOptions::create() without an explicit OpenOptions::truncate().

### DIFF
--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -69,7 +69,11 @@ impl Token {
     pub fn write_cache<T: AsRef<Path>>(&self, path: T) -> ModelResult<()> {
         let token_info = serde_json::to_string(&self)?;
 
-        let mut file = fs::OpenOptions::new().write(true).create(true).truncate(true).open(path)?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
         file.set_len(0)?;
         file.write_all(token_info.as_bytes())?;
 

--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -69,7 +69,7 @@ impl Token {
     pub fn write_cache<T: AsRef<Path>>(&self, path: T) -> ModelResult<()> {
         let token_info = serde_json::to_string(&self)?;
 
-        let mut file = fs::OpenOptions::new().write(true).create(true).open(path)?;
+        let mut file = fs::OpenOptions::new().write(true).create(true).truncate(true).open(path)?;
         file.set_len(0)?;
         file.write_all(token_info.as_bytes())?;
 


### PR DESCRIPTION
## Description

Rust 1.77 introduces a new cargo clippy lint rule for the suspicious use of `OpenOptions::create()` without an explicit `OpenOptions::truncate()`, which failed the `cargo clipy` CI task

## Motivation and Context

- https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options
- https://github.com/ramsayleung/rspotify/actions/runs/8396555462/job/22998169454?pr=467

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

- `cargo clippy -p rspotify -p rspotify-http -p rspotify-model -p rspotify-macros --no-default-features --features=rspotify/cli,rspotify/env-file,rspotify/client-ureq,rspotify/ureq-rustls-tls,rspotify-http/client-ureq,rspotify-http/ureq-rustls-tls --all-targets -- -D warnings`: passed
- All CI tasks passed

## Is this change properly documented?

It's unnecessary.