### PR TITLE
Fix ureq-native-tls feature to actually use native-tls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         features:
           - rspotify/cli,rspotify/env-file,rspotify/client-ureq,rspotify/ureq-rustls-tls,rspotify-http/client-ureq,rspotify-http/ureq-rustls-tls
           - rspotify/cli,rspotify/env-file,rspotify/client-reqwest,rspotify/reqwest-rustls-tls,rspotify-http/client-reqwest,rspotify-http/reqwest-rustls-tls
+          - rspotify/cli,rspotify/env-file,rspotify/client-ureq,rspotify/ureq-native-tls,rspotify-http/client-ureq,rspotify-http/ureq-native-tls
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -79,6 +80,10 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+
+      - name: Install libssl-dev
+        if: ${{ contains(matrix.features, 'ureq-native-tls') }}
+        run: sudo apt-get install libssl-dev
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.1 (Unreleased)
+
+**Bugfixes**
+- ([#471](https://github.com/ramsayleung/rspotify/pull/471)) Fix `ureq-native-tls` feature to actually use native-tls
+
 ## 0.13.0 (2024.03.08)
 
 **New features**

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0.29"
 # Supported clients
 reqwest = { version = "0.12.1", default-features = false, features = ["json", "socks"], optional = true }
 ureq = { version = "2.2.0", default-features = false, features = ["json", "cookies", "socks-proxy"], optional = true }
+native-tls = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
@@ -47,7 +48,7 @@ reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
 # Same for ureq.
 ureq-rustls-tls = ["ureq/tls"]
 ureq-rustls-tls-native-certs = ["ureq/tls", "ureq/native-certs"]
-ureq-native-tls = ["ureq/native-tls"]
+ureq-native-tls = ["ureq/native-tls", "dep:native-tls"]
 
 # Internal features for checking async or sync compilation
 __async = ["async-trait"]

--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -59,9 +59,16 @@ impl Default for UreqClient {
     fn default() -> Self {
         let agent = ureq::AgentBuilder::new()
             .try_proxy_from_env(true)
-            .timeout(Duration::from_secs(10))
-            .build();
-        Self { agent }
+            .timeout(Duration::from_secs(10));
+
+        #[cfg(feature = "ureq-native-tls")]
+        let agent = agent.tls_connector(std::sync::Arc::new(
+            native_tls::TlsConnector::new().expect("Failed to initialize TLS connector"),
+        ));
+
+        Self {
+            agent: agent.build(),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Feature `ureq-native-tls` currently doesn't work because ureq requires the TLS
connector to be specified explicitly for native-tls:

> `native-tls` enables an adapter so you can pass a
> `native_tls::TlsConnector` instance to `AgentBuilder::tls_connector`.
> Due to the risk of diamond dependencies accidentally switching on an
> unwanted TLS implementation, `native-tls` is never picked up as a
> default or used by the crate level convenience calls (`ureq::get`
> etc) – it must be configured on the agent.
> -- https://github.com/algesten/ureq#features

When ncspot is built with rspotify with ureq-native-tls, it's unable to
create an HTTPS connection:

	[ncspot::spotify_api] [DEBUG] http error: Transport(Transport { kind: UnknownScheme, message: Some("cannot make HTTPS request because no TLS backend is configured"), url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.spotify.com")), port: None, path: "/v1/me/", query: None, fragment: None }), source: None })


## Motivation and Context

rspotify currently doesn’t work when built with `ureq-native-tls`.

## Dependencies 

`tls-native` (optional)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

CI

## Is this change properly documented?

Yes

* * *
Related to #402

Fixes hrkfdn/ncspot#1159