### PR TITLE
Upgrade RSpotify to 0.13.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,5 @@
 on:
-  create:
+  push:
     tags:
       - 'v*'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.1 (Unreleased)
+## 0.13.1 (2024.04.01)
 
 **Bugfixes**
 - ([#471](https://github.com/ramsayleung/rspotify/pull/471)) Fix `ureq-native-tls` feature to actually use native-tls
@@ -12,7 +12,7 @@
 - ([#440](https://github.com/ramsayleung/rspotify/issues/440)) Add Smartwatch device type, fix for json parse error: unknown variant Smartwatch.
 - ([#447](https://github.com/ramsayleung/rspotify/pull/447)) Replace the deprecated `dotenv` crate with `dotenvy`
 
-## 0.13.0 (2023.08.26)
+## 0.12.0 (2023.08.26)
 **New features**
 - ([#390](https://github.com/ramsayleung/rspotify/pull/390)) The `scopes!` macro supports to split the scope by whitespace.
 - ([#418](https://github.com/ramsayleung/rspotify/pull/418)) Add a user-settable callback function whenever token is updated.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify"
-version = "0.13.0"
+version = "0.13.1"
 license = "MIT"
 readme = "README.md"
 description = "Spotify API wrapper"
@@ -26,9 +26,9 @@ exclude = [
 ]
 
 [dependencies]
-rspotify-macros = { path = "rspotify-macros", version = "0.13.0" }
-rspotify-model = { path = "rspotify-model", version = "0.13.0" }
-rspotify-http = { path = "rspotify-http", version = "0.13.0", default-features = false }
+rspotify-macros = { path = "rspotify-macros", version = "0.13.1" }
+rspotify-model = { path = "rspotify-model", version = "0.13.1" }
+rspotify-http = { path = "rspotify-http", version = "0.13.1", default-features = false }
 
 async-stream = { version = "0.3.2", optional = true }
 async-trait = { version = "0.1.51", optional = true }

--- a/rspotify-http/Cargo.toml
+++ b/rspotify-http/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
 name = "rspotify-http"
-version = "0.13.0"
+version = "0.13.1"
 license = "MIT"
 description = "HTTP compatibility layer for RSpotify"
 homepage = "https://github.com/ramsayleung/rspotify"
@@ -30,7 +30,7 @@ native-tls = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
-rspotify-model = { path = "../rspotify-model", version = "0.13.0" }
+rspotify-model = { path = "../rspotify-model", version = "0.13.1" }
 
 [features]
 default = ["client-reqwest", "reqwest-default-tls"]

--- a/rspotify-macros/Cargo.toml
+++ b/rspotify-macros/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"
 ]
-version = "0.13.0"
+version = "0.13.1"
 license = "MIT"
 description = "Macros for RSpotify"
 homepage = "https://github.com/ramsayleung/rspotify"

--- a/rspotify-model/Cargo.toml
+++ b/rspotify-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspotify-model"
-version = "0.13.0"
+version = "0.13.1"
 authors = [
     "Ramsay Leung <ramsayleung@gmail.com>",
     "Mario Ortiz Manero <marioortizmanero@gmail.com>"


### PR DESCRIPTION
## Description

1. Upgrade RSpotify to 0.13.1
2. Fix the GitHub workflow to trigger GitHub Action only on new tags

## Motivation and Context

#471 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?

1. All CI jobs pass
2. The `Publish Crate` GitHub Action will be only triggered on pushing new tags.

## Is this change properly documented?

Yes
