### PR TITLE
security: Disable TLS1.0/1.1 for ureq-native-tls

### DIFF
--- a/rspotify-http/src/ureq.rs
+++ b/rspotify-http/src/ureq.rs
@@ -63,7 +63,11 @@ impl Default for UreqClient {
 
         #[cfg(feature = "ureq-native-tls")]
         let agent = agent.tls_connector(std::sync::Arc::new(
-            native_tls::TlsConnector::new().expect("Failed to initialize TLS connector"),
+            native_tls::TlsConnector::builder()
+                // rust-native-tls defaults to a minimum of TLS 1.0, which is insecure
+                .min_protocol_version(Some(native_tls::Protocol::Tlsv12))
+                .build()
+                .expect("Failed to initialize TLS connector"),
         ));
 
         Self {


### PR DESCRIPTION
## Description

Explicity opt-out of old TLS versions when using the ureq-native-tls feature. Rust-native-tls enables these outdated TLS versions by default

## Motivation and Context

TLS 1.0 and 1.1 have been deprecated since 2021. Enabling TLS 1.0/1.1 has possibility (albeit a low one) of introducing a security vulnerability. All modern clients and servers have supported 1.2 for years, so this should be an issue

## Dependencies 

None

## Type of change

- [ *] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Locally only, through cargo-test and cargo-clippy

## Is this change properly documented?

Added a short comment explaining reasoning