### PR TITLE
fix: deserialize empty images from null

### DIFF
--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -20,6 +20,14 @@ pub struct PlaylistTracksRef {
     pub total: u32,
 }
 
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::deserialize(deserializer)?.unwrap_or_default())
+}
+
 /// Simplified playlist object
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimplifiedPlaylist {
@@ -27,6 +35,7 @@ pub struct SimplifiedPlaylist {
     pub external_urls: HashMap<String, String>,
     pub href: String,
     pub id: PlaylistId<'static>,
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub images: Vec<Image>,
     pub name: String,
     pub owner: PublicUser,


### PR DESCRIPTION
## Description

Adjust the derived implementation of `Deserialize` for `SimplifiedPlaylist`. Instead of returning an error when deserializing the value `null` for the field `images`, this value is deserialized to an empty `Vec`.
This is necessary, because the Spotify-API is returning `null` instead of an empty array for this field in some instances.

## Motivation and Context

This fixes the problem described in https://github.com/ramsayleung/rspotify/issues/459. The Spotify-API is returning `null` instead of an empty array for the `images`-field in some instances.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

The change was tested by using the patched version of rspotify in [this](https://gitea.tecks.eu/plustik/plservice) project.

## Is this change properly documented?
I don't think this needs to be documented. The change won't affect the behavior of rspotify when the Spotify-API returns `images: []`. When the Spotify-API returns `images: null` `current_user_playlists` wasn't usable prior to this change. In this case the PR implements the expected behavior.
