### PR TITLE
Fix JSON deserialize error that TrackLink::id could be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0 (unreleased)
+**Breaking changes**
+- ([]()) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
+
 ## 0.13.2 (2024.06.03)
 - ([#480](https://github.com/ramsayleung/rspotify/pull/480)) Fix deserialize empty images from null.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.14.0 (unreleased)
 **Breaking changes**
-- ([]()) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
+- ([#487](https://github.com/ramsayleung/rspotify/pull/487)) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
 
 ## 0.13.2 (2024.06.03)
 - ([#480](https://github.com/ramsayleung/rspotify/pull/480)) Fix deserialize empty images from null.

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -41,7 +41,7 @@ pub struct FullTrack {
 }
 
 /// Track link object
-/// https://developer.spotify.com/documentation/web-api/concepts/track-relinking
+/// [track-relinking](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrackLink {
     pub external_urls: HashMap<String, String>,

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{
-    custom_serde::duration_ms, PlayableId, Restriction, SimplifiedAlbum, SimplifiedArtist, TrackId, Type
+    custom_serde::duration_ms, PlayableId, Restriction, SimplifiedAlbum, SimplifiedArtist, TrackId,
+    Type,
 };
 
 /// Full track object
@@ -47,7 +48,7 @@ pub struct TrackLink {
     pub href: String,
     pub id: Option<TrackId<'static>>,
     pub r#type: Type,
-    pub uri: String
+    pub uri: String,
 }
 
 /// Intermediate full track wrapped by `Vec`

--- a/rspotify-model/src/track.rs
+++ b/rspotify-model/src/track.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{
-    custom_serde::duration_ms, PlayableId, Restriction, SimplifiedAlbum, SimplifiedArtist, TrackId,
+    custom_serde::duration_ms, PlayableId, Restriction, SimplifiedAlbum, SimplifiedArtist, TrackId, Type
 };
 
 /// Full track object
@@ -40,11 +40,14 @@ pub struct FullTrack {
 }
 
 /// Track link object
+/// https://developer.spotify.com/documentation/web-api/concepts/track-relinking
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrackLink {
     pub external_urls: HashMap<String, String>,
     pub href: String,
-    pub id: TrackId<'static>,
+    pub id: Option<TrackId<'static>>,
+    pub r#type: Type,
+    pub uri: String
 }
 
 /// Intermediate full track wrapped by `Vec`

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1204,3 +1204,22 @@ fn test_collectionyourepisodes_type() {
     let context: Context = deserialize(json);
     assert_eq!(context._type, Type::Collectionyourepisodes);
 }
+
+#[test]
+#[wasm_bindgen_test]
+fn test_null_id_in_tracklink() {
+    let json = r#"
+{
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/0tSkMuKKrLXEfxc58cEhFX"
+          },
+          "href": "https://api.spotify.com/v1/tracks/0tSkMuKKrLXEfxc58cEhFX",
+          "id": null,
+          "type": "track",
+          "uri": "spotify:track:0tSkMuKKrLXEfxc58cEhFX"
+        }
+"#;
+    let linked_from: TrackLink = deserialize(json);
+    assert!(linked_from.id.is_none());
+    assert_eq!(linked_from.r#type, Type::Track);
+}


### PR DESCRIPTION
## Description

Fix JSON deserialize error that TrackLink::id could be null, and add the missing `type` and `uri` field for TrackLink based on the updated Spotify document: https://developer.spotify.com/documentation/web-api/concepts/track-relinking

## Motivation and Context

- https://github.com/ramsayleung/rspotify/issues/486

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

- All CI jobs pass
- newly added unit test: test_null_id_in_track_link pass

## Is this change properly documented?

Yes.
