### PR TITLE
add derivable traits to PlayableId and PlayContextId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## 0.13.0 (2024.03.08)
 
 **New features**
+- ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`
 - ([#458](https://github.com/ramsayleung/rspotify/pull/458)) Support for the `wasm32-unknown-unknown` build target
 
 **Bugfixes**

--- a/rspotify-model/src/idtypes.rs
+++ b/rspotify-model/src/idtypes.rs
@@ -479,6 +479,7 @@ define_idtypes!(
 /// Grouping up multiple kinds of IDs to treat them generically. This also
 /// implements [`Id`], and [`From`] to instantiate it.
 #[enum_dispatch(Id)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Hash)]
 pub enum PlayContextId<'a> {
     Artist(ArtistId<'a>),
     Album(AlbumId<'a>),
@@ -521,6 +522,7 @@ impl<'a> PlayContextId<'a> {
 /// Grouping up multiple kinds of IDs to treat them generically. This also
 /// implements [`Id`] and [`From`] to instantiate it.
 #[enum_dispatch(Id)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Hash)]
 pub enum PlayableId<'a> {
     Track(TrackId<'a>),
     Episode(EpisodeId<'a>),


### PR DESCRIPTION
## Description

This PR derives the traits `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`. These two types are enums around other ID types that already derive the same traits.

## Motivation and Context

I'm currently working on [a feature in a downstream crate](https://github.com/aome510/spotify-player/pull/552) and there are a few places where we could simplify the code a lot by having these traits be implemented for `PlayableId`. I have less need of the same for `PlayContextId`, but figured I might as well add that to the PR so that all IDs are covered.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Not tested

## Is this change properly documented?

Changelog updated
