### PR TITLE
Move item in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.14.0 (unreleased)
-**New features**
-- ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`
-- 
 **Breaking changes**
 - ([#487](https://github.com/ramsayleung/rspotify/pull/487)) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
+
+## 0.13.3 (2024.08.24)
+**New features**
+- ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`
 
 ## 0.13.2 (2024.06.03)
 - ([#480](https://github.com/ramsayleung/rspotify/pull/480)) Fix deserialize empty images from null.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.14.0 (unreleased)
+**New features**
+- ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`
+- 
 **Breaking changes**
 - ([#487](https://github.com/ramsayleung/rspotify/pull/487)) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
 
@@ -13,7 +16,6 @@
 ## 0.13.0 (2024.03.08)
 
 **New features**
-- ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`
 - ([#458](https://github.com/ramsayleung/rspotify/pull/458)) Support for the `wasm32-unknown-unknown` build target
 
 **Bugfixes**


### PR DESCRIPTION
@ramsayleung , thank you for merging https://github.com/ramsayleung/rspotify/pull/490

After you merged, I noticed that my CHANGELOG entry was under the wrong release. I moved the note to the unreleased portion.

Sidenote, but are you able to release these changes as a patch version update instead of waiting for v0.14 to land? Thank you!