### PR TITLE
[fix] Fix endless sequential pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 **Breaking changes**
 - ([#487](https://github.com/ramsayleung/rspotify/pull/487)) Change the type of `TrackLink.id` from `TrackId<'static>` to `Option<TrackId<'static>>`
 
+**Bugfixes**
+- ([#494](https://github.com/ramsayleung/rspotify/pull/494)) Fix endless sequential pagination problem.
+
 ## 0.13.3 (2024.08.24)
 **New features**
 - ([#490](https://github.com/ramsayleung/rspotify/pull/490)) Add impls for `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize` and `Hash` for `PlayContextId` and `PlayableId`

--- a/src/clients/pagination/stream.rs
+++ b/src/clients/pagination/stream.rs
@@ -34,11 +34,11 @@ where
             if page.items.is_empty() {
                 break;
             }
-            if page.next.is_none() {
-                break;
-            }
             for item in page.items {
                 yield Ok(item);
+            }
+            if page.next.is_none() {
+                break;
             }
         }
     })

--- a/src/clients/pagination/stream.rs
+++ b/src/clients/pagination/stream.rs
@@ -28,11 +28,17 @@ where
             let request = req(&ctx, page_size, offset);
             let page = request.await?;
             offset += page.items.len() as u32;
-            for item in page.items {
-                yield Ok(item);
+            // Occasionally, the Spotify will return an empty items with non-none next page
+            // So we have to check both conditions
+            // https://github.com/ramsayleung/rspotify/issues/492
+            if page.items.is_empty() {
+                break;
             }
             if page.next.is_none() {
                 break;
+            }
+            for item in page.items {
+                yield Ok(item);
             }
         }
     })


### PR DESCRIPTION
## Description

Fix endless sequential pagination issue caused by invalid data return from the Spotify server side.

## Motivation and Context

The log dive and conclusion are posted in #492, check that issue for detail.

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

1. All existing tests passed
2. Test with the example code posted in #492, the output becomes:
```
Items (blocking):
* Anomaly
* Not All The Beautiful Things
* Divide & Conquer (Remixes)
* Divide & Conquer
```

The pagination ends as expected.

## Is this change properly documented?

Yes

Don't forget to add an entry to the CHANGELOG if necessary (new features, breaking changes, relevant internal improvements).
