### PR TITLE
Fix failed CI job by resolving elided-named-lifetimes clippy rule and fixing failed wasm test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,4 +122,4 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Run wasm-pack test
-        run: wasm-pack test --node
+        run: wasm-pack test --node -- --features console_error_panic_hook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
 
       - name: Install node
         uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,4 +122,4 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Run wasm-pack test
-        run: wasm-pack test --node -- --features console_error_panic_hook
+        run: wasm-pack test --node --firefox --chrome --safari --headless

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,4 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Run wasm-pack test
-        run: wasm-pack test --node --firefox --chrome --safari --headless
+        run: wasm-pack test --node

--- a/rspotify-model/src/custom_serde.rs
+++ b/rspotify-model/src/custom_serde.rs
@@ -9,7 +9,7 @@ pub mod duration_ms {
     /// Vistor to help deserialize duration represented as millisecond to
     /// `chrono::Duration`.
     pub struct DurationVisitor;
-    impl<'de> de::Visitor<'de> for DurationVisitor {
+    impl de::Visitor<'_> for DurationVisitor {
         type Value = Duration;
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             write!(formatter, "a milliseconds represents chrono::Duration")

--- a/rspotify-model/src/error.rs
+++ b/rspotify-model/src/error.rs
@@ -6,6 +6,7 @@ pub type ModelResult<T> = Result<T, ModelError>;
 
 /// Matches errors that are returned from the Spotfiy
 /// API as part of the JSON response object.
+#[allow(unreachable_patterns)]
 #[derive(Debug, Error, Deserialize)]
 pub enum ApiError {
     /// See [Error Object](https://developer.spotify.com/documentation/web-api/reference/#object-errorobject)

--- a/rspotify-model/src/error.rs
+++ b/rspotify-model/src/error.rs
@@ -6,17 +6,14 @@ pub type ModelResult<T> = Result<T, ModelError>;
 
 /// Matches errors that are returned from the Spotfiy
 /// API as part of the JSON response object.
-#[allow(unreachable_patterns)]
 #[derive(Debug, Error, Deserialize)]
 pub enum ApiError {
     /// See [Error Object](https://developer.spotify.com/documentation/web-api/reference/#object-errorobject)
     #[error("{status}: {message}")]
-    #[serde(alias = "error")]
     Regular { status: u16, message: String },
 
     /// See [Play Error Object](https://developer.spotify.com/documentation/web-api/reference/#object-playererrorobject)
     #[error("{status} ({reason}): {message}")]
-    #[serde(alias = "error")]
     Player {
         status: u16,
         message: String,

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -279,7 +279,7 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-artists-albums)
-    fn artist_albums<'b, 'a: 'b,>(
+    fn artist_albums<'b, 'a: 'b>(
         &'a self,
         artist_id: ArtistId<'a>,
         include_groups: impl IntoIterator<Item = AlbumType> + Send + Copy + 'a,
@@ -516,7 +516,7 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-albums-tracks)
-    fn album_track<'b, 'a:'b,>(
+    fn album_track<'b, 'a: 'b>(
         &'a self,
         album_id: AlbumId<'a>,
         market: Option<Market>,
@@ -685,7 +685,7 @@ where
     /// of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-shows-episodes)
-    fn get_shows_episodes<'b, 'a:'b>(
+    fn get_shows_episodes<'b, 'a: 'b>(
         &'a self,
         id: ShowId<'a>,
         market: Option<Market>,
@@ -822,7 +822,7 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-categories)
-    fn categories<'b,'a:'b>(
+    fn categories<'b, 'a: 'b>(
         &'a self,
         locale: Option<&'a str>,
         country: Option<Market>,
@@ -1051,7 +1051,7 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlists-tracks)
-    fn playlist_items<'b, 'a:'b>(
+    fn playlist_items<'b, 'a: 'b>(
         &'a self,
         playlist_id: PlaylistId<'a>,
         fields: Option<&'a str>,
@@ -1106,7 +1106,7 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-list-users-playlists)
-    fn user_playlists<'b, 'a:'b>(
+    fn user_playlists<'b, 'a: 'b>(
         &'a self,
         user_id: UserId<'a>,
     ) -> Paginator<'b, ClientResult<SimplifiedPlaylist>> {

--- a/src/clients/base.rs
+++ b/src/clients/base.rs
@@ -279,12 +279,12 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-artists-albums)
-    fn artist_albums<'a>(
+    fn artist_albums<'b, 'a: 'b,>(
         &'a self,
         artist_id: ArtistId<'a>,
         include_groups: impl IntoIterator<Item = AlbumType> + Send + Copy + 'a,
         market: Option<Market>,
-    ) -> Paginator<'_, ClientResult<SimplifiedAlbum>> {
+    ) -> Paginator<'b, ClientResult<SimplifiedAlbum>> {
         paginate_with_ctx(
             (self, artist_id),
             move |(slf, artist_id), limit, offset| {
@@ -516,11 +516,11 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-albums-tracks)
-    fn album_track<'a>(
+    fn album_track<'b, 'a:'b,>(
         &'a self,
         album_id: AlbumId<'a>,
         market: Option<Market>,
-    ) -> Paginator<'_, ClientResult<SimplifiedTrack>> {
+    ) -> Paginator<'b, ClientResult<SimplifiedTrack>> {
         paginate_with_ctx(
             (self, album_id),
             move |(slf, album_id), limit, offset| {
@@ -685,11 +685,11 @@ where
     /// of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-shows-episodes)
-    fn get_shows_episodes<'a>(
+    fn get_shows_episodes<'b, 'a:'b>(
         &'a self,
         id: ShowId<'a>,
         market: Option<Market>,
-    ) -> Paginator<'_, ClientResult<SimplifiedEpisode>> {
+    ) -> Paginator<'b, ClientResult<SimplifiedEpisode>> {
         paginate_with_ctx(
             (self, id),
             move |(slf, id), limit, offset| {
@@ -822,11 +822,11 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-categories)
-    fn categories<'a>(
+    fn categories<'b,'a:'b>(
         &'a self,
         locale: Option<&'a str>,
         country: Option<Market>,
-    ) -> Paginator<'_, ClientResult<Category>> {
+    ) -> Paginator<'b, ClientResult<Category>> {
         paginate(
             move |limit, offset| self.categories_manual(locale, country, Some(limit), Some(offset)),
             self.get_config().pagination_chunks,
@@ -867,11 +867,11 @@ where
     /// of this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-categories-playlists)
-    fn category_playlists<'a>(
+    fn category_playlists<'b, 'a: 'b>(
         &'a self,
         category_id: &'a str,
         country: Option<Market>,
-    ) -> Paginator<'_, ClientResult<SimplifiedPlaylist>> {
+    ) -> Paginator<'b, ClientResult<SimplifiedPlaylist>> {
         paginate(
             move |limit, offset| {
                 self.category_playlists_manual(category_id, country, Some(limit), Some(offset))
@@ -1051,12 +1051,12 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlists-tracks)
-    fn playlist_items<'a>(
+    fn playlist_items<'b, 'a:'b>(
         &'a self,
         playlist_id: PlaylistId<'a>,
         fields: Option<&'a str>,
         market: Option<Market>,
-    ) -> Paginator<'_, ClientResult<PlaylistItem>> {
+    ) -> Paginator<'b, ClientResult<PlaylistItem>> {
         paginate_with_ctx(
             (self, playlist_id, fields),
             move |(slf, playlist_id, fields), limit, offset| {
@@ -1106,10 +1106,10 @@ where
     /// this.
     ///
     /// [Reference](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-list-users-playlists)
-    fn user_playlists<'a>(
+    fn user_playlists<'b, 'a:'b>(
         &'a self,
         user_id: UserId<'a>,
-    ) -> Paginator<'_, ClientResult<SimplifiedPlaylist>> {
+    ) -> Paginator<'b, ClientResult<SimplifiedPlaylist>> {
         paginate_with_ctx(
             (self, user_id),
             move |(slf, user_id), limit, offset| {


### PR DESCRIPTION
## Description

Fix failed CI job by resolving elided-named-lifetimes clippy rule.

## Motivation and Context

- https://github.com/ramsayleung/rspotify/actions/runs/12473292920/job/34813544989?pr=509
- https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#elided-named-lifetimes

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

```sh
cargo clippy -p rspotify -p rspotify-http -p rspotify-model -p rspotify-macros --no-default-features --features=rspotify/cli,rspotify/env-file,rspotify/client-reqwest,rspotify/reqwest-rustls-tls,rspotify-http/client-reqwest,rspotify-http/reqwest-rustls-tls --all-targets -- -D warnings
```

build succeeded.

## Is this change properly documented?

It's unnecessary.