### PR TITLE
auth_code_pkce: add from_token_with_config() constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  
 **New features**
 - ([#496](https://github.com/ramsayleung/rspotify/pull/497)) Add support for searching multiple types
+- ([#512](https://github.com/ramsayleung/rspotify/pull/512)) Add `AuthCodePkceSpotify::from_token_with_config()`
 
 
 ## 0.13.3 (2024.08.24)

--- a/src/auth_code_pkce.rs
+++ b/src/auth_code_pkce.rs
@@ -162,6 +162,24 @@ impl AuthCodePkceSpotify {
         }
     }
 
+    /// Build a new [`AuthCodePkceSpotify`] from an already generated token and
+    /// config. Use this to be able to refresh a token.
+    #[must_use]
+    pub fn from_token_with_config(
+        token: Token,
+        creds: Credentials,
+        oauth: OAuth,
+        config: Config,
+    ) -> Self {
+        Self {
+            token: Arc::new(Mutex::new(Some(token))),
+            creds,
+            oauth,
+            config,
+            ..Default::default()
+        }
+    }
+
     /// Generate the verifier code and the challenge code.
     fn generate_codes(verifier_bytes: usize) -> (String, String) {
         log::info!("Generating PKCE codes");


### PR DESCRIPTION
## Description

Add `AuthCodePkceSpotify::from_token_with_config()`

## Motivation and Context

This is required to be able to refresh an expired token from the cache as we need the client ID to refresh the token.

Fix #511

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Call a `AuthCodePkceSpotify` using `with_config()` and

```rust
Config {
        token_cached: true,
        token_refreshing: true,
        ..Default::default()
    };
```

- Authenticate using the normal flow.
- Terminate the app and wait for one hour for the token to expired.
- Restore the token using `Token::from_cache()` and check that `token.is_expired()` returns `true`.
- Create a client with `AuthCodePkceSpotify::from_token()` and then call  `client.refresh_token()`. The client won't work as the token has not been refresh. You can also check by calling `client.refetch_token()` as it returns `None`.
- Now create a client using `AuthCodePkceSpotify::from_token_with_config()` passing the proper  `Credentials`. `client.refresh_token()` and `client.refetch_token()` are now working.

## Is this change properly documented?

Yes.