### PR TITLE
Fix: deserialization of pagination with null items

### DIFF
--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -84,7 +84,7 @@ impl Token {
     /// is how much a request would take in the worst case scenario).
     #[must_use]
     pub fn is_expired(&self) -> bool {
-        self.expires_at.map_or(true, |expiration| {
+        self.expires_at.is_none_or(|expiration| {
             Utc::now() + TimeDelta::try_seconds(10).unwrap() >= expiration
         })
     }

--- a/rspotify-model/src/auth.rs
+++ b/rspotify-model/src/auth.rs
@@ -84,9 +84,8 @@ impl Token {
     /// is how much a request would take in the worst case scenario).
     #[must_use]
     pub fn is_expired(&self) -> bool {
-        self.expires_at.is_none_or(|expiration| {
-            Utc::now() + TimeDelta::try_seconds(10).unwrap() >= expiration
-        })
+        self.expires_at
+            .is_none_or(|expiration| Utc::now() + TimeDelta::try_seconds(10).unwrap() >= expiration)
     }
 
     /// Generates an HTTP token authorization header with proper formatting

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -22,6 +22,8 @@ pub struct Page<T: DeserializeOwned> {
     pub next: Option<String>,
     pub offset: u32,
     pub previous: Option<String>,
+    /// This field could mismatch the actual number of items in `items` field 
+    /// because sometimes the API returns `null` items that are not included in the `items` field.
     pub total: u32,
 }
 

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -22,7 +22,7 @@ pub struct Page<T: DeserializeOwned> {
     pub next: Option<String>,
     pub offset: u32,
     pub previous: Option<String>,
-    /// This field could mismatch the actual number of items in `items` field 
+    /// This field could mismatch the actual number of items in `items` field
     /// because sometimes the API returns `null` items that are not included in the `items` field.
     pub total: u32,
 }

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -1,11 +1,20 @@
 //! All kinds of page object
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use serde::{Deserialize, Serialize};
+fn vec_without_nulls<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    let v = Vec::<Option<T>>::deserialize(deserializer)?;
+    Ok(v.into_iter().filter_map(|x| x).collect())
+}
 
 /// Paging object
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct Page<T> {
+pub struct Page<T: DeserializeOwned> {
     pub href: String,
+    #[serde(deserialize_with = "vec_without_nulls")]
     pub items: Vec<T>,
     pub limit: u32,
     pub next: Option<String>,

--- a/rspotify-model/src/page.rs
+++ b/rspotify-model/src/page.rs
@@ -1,13 +1,15 @@
 //! All kinds of page object
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+/// Custom deserializer to handle `Vec<Option<T>>` and filter out `None` values
+/// This is useful for deserializing lists that may contain null values that are not relevants
 fn vec_without_nulls<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     T: serde::Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
     let v = Vec::<Option<T>>::deserialize(deserializer)?;
-    Ok(v.into_iter().filter_map(|x| x).collect())
+    Ok(v.into_iter().flatten().collect())
 }
 
 /// Paging object

--- a/src/clients/pagination/iter.rs
+++ b/src/clients/pagination/iter.rs
@@ -18,7 +18,10 @@ where
 }
 
 /// This is used to handle paginated requests automatically.
-pub fn paginate<'a, T: DeserializeOwned + 'a, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
+pub fn paginate<'a, T: DeserializeOwned + 'a, Request>(
+    req: Request,
+    page_size: u32,
+) -> Paginator<'a, ClientResult<T>>
 where
     Request: 'a + Fn(u32, u32) -> ClientResult<Page<T>>,
 {

--- a/src/clients/pagination/iter.rs
+++ b/src/clients/pagination/iter.rs
@@ -1,11 +1,12 @@
 //! Synchronous implementation of automatic pagination requests.
 
 use crate::{model::Page, ClientError, ClientResult};
+use serde::de::DeserializeOwned;
 
 /// Alias for `Iterator<Item = T>`, since sync mode is enabled.
 pub type Paginator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
 
-pub fn paginate_with_ctx<'a, Ctx: 'a, T: 'a, Request>(
+pub fn paginate_with_ctx<'a, Ctx: 'a, T: DeserializeOwned + 'a, Request>(
     ctx: Ctx,
     req: Request,
     page_size: u32,
@@ -17,7 +18,7 @@ where
 }
 
 /// This is used to handle paginated requests automatically.
-pub fn paginate<'a, T: 'a, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
+pub fn paginate<'a, T: DeserializeOwned + 'a, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
 where
     Request: 'a + Fn(u32, u32) -> ClientResult<Page<T>>,
 {
@@ -40,7 +41,7 @@ struct PageIterator<Request> {
     page_size: u32,
 }
 
-impl<T, Request> Iterator for PageIterator<Request>
+impl<T: DeserializeOwned, Request> Iterator for PageIterator<Request>
 where
     Request: Fn(u32, u32) -> ClientResult<Page<T>>,
 {

--- a/src/clients/pagination/stream.rs
+++ b/src/clients/pagination/stream.rs
@@ -5,6 +5,7 @@ use crate::{model::Page, ClientResult};
 use std::pin::Pin;
 
 use futures::{future::Future, stream::Stream};
+use serde::de::DeserializeOwned;
 
 /// Alias for `futures::stream::Stream<Item = T>`, since async mode is enabled.
 pub type Paginator<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a + Send>>;
@@ -18,7 +19,7 @@ pub fn paginate_with_ctx<'a, Ctx: 'a + Send, T, Request>(
     page_size: u32,
 ) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin + Send,
+    T: 'a + Unpin + Send + DeserializeOwned,
     Request: 'a + for<'ctx> Fn(&'ctx Ctx, u32, u32) -> RequestFuture<'ctx, T> + Send,
 {
     use async_stream::stream;
@@ -46,7 +47,7 @@ where
 
 pub fn paginate<'a, T, Fut, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin + Send,
+    T: 'a + Unpin + Send + DeserializeOwned,
     Fut: Future<Output = ClientResult<Page<T>>> + Send,
     Request: 'a + Fn(u32, u32) -> Fut + Send,
 {

--- a/src/clients/pagination/wasm_stream.rs
+++ b/src/clients/pagination/wasm_stream.rs
@@ -5,6 +5,7 @@ use crate::{model::Page, ClientResult};
 use std::pin::Pin;
 
 use futures::{future::Future, stream::Stream};
+use serde::de::DeserializeOwned;
 
 /// Alias for `futures::stream::Stream<Item = T>`, since async mode is enabled.
 pub type Paginator<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
@@ -18,7 +19,7 @@ pub fn paginate_with_ctx<'a, Ctx: 'a, T, Request>(
     page_size: u32,
 ) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin,
+    T: DeserializeOwned + 'a + Unpin,
     Request: 'a + for<'ctx> Fn(&'ctx Ctx, u32, u32) -> RequestFuture<'ctx, T>,
 {
     use async_stream::stream;
@@ -40,7 +41,7 @@ where
 
 pub fn paginate<'a, T, Fut, Request>(req: Request, page_size: u32) -> Paginator<'a, ClientResult<T>>
 where
-    T: 'a + Unpin,
+    T: DeserializeOwned + 'a + Unpin,
     Fut: Future<Output = ClientResult<Page<T>>>,
     Request: 'a + Fn(u32, u32) -> Fut,
 {

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1223,3 +1223,26 @@ fn test_null_id_in_tracklink() {
     assert!(linked_from.id.is_none());
     assert_eq!(linked_from.r#type, Type::Track);
 }
+
+#[test]
+#[wasm_bindgen_test]
+fn test_null_item_in_page() {
+    let json = r#"
+{
+  "href": "https://api.spotify.com/v1/me/top/artists?limit=20&offset=0",
+  "items": [
+    null
+  ],
+  "limit": 20,
+  "next": null,
+  "offset": 0,
+  "previous": null,
+  "total": 1
+}"#;
+    let page: Page<SimplifiedArtist> = deserialize(json);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total, 1);
+    assert_eq!(page.limit, 20);
+    assert!(page.next.is_none());
+    assert!(page.previous.is_none());
+}

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1241,7 +1241,7 @@ fn test_null_item_in_page() {
 }"#;
     let page: Page<SimplifiedPlaylist> = deserialize(json);
     assert_eq!(page.items.len(), 0);
-    assert_eq!(page.total-1, 0); // Because one element is null so ignore at deserialization but counted in total
+    assert_eq!(page.total, 1); // Because one element is null so ignored at deserialization but counted in total
     assert_eq!(page.limit, 20);
     assert!(page.next.is_none());
     assert!(page.previous.is_none());

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1229,7 +1229,7 @@ fn test_null_id_in_tracklink() {
 fn test_null_item_in_page() {
     let json = r#"
 {
-  "href": "https://api.spotify.com/v1/me/top/artists?limit=20&offset=0",
+  "href": "https://api.spotify.com/v1/search?offset=17&limit=2&query=My%20Playlist&type=playlist&market=FR",
   "items": [
     null
   ],
@@ -1239,9 +1239,9 @@ fn test_null_item_in_page() {
   "previous": null,
   "total": 1
 }"#;
-    let page: Page<SimplifiedArtist> = deserialize(json);
+    let page: Page<SimplifiedPlaylist> = deserialize(json);
     assert_eq!(page.items.len(), 1);
-    assert_eq!(page.total, 1);
+    assert_eq!(page.total-1, 1); // Because one element is null so ignore at deserialization but counted in total
     assert_eq!(page.limit, 20);
     assert!(page.next.is_none());
     assert!(page.previous.is_none());

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1240,8 +1240,8 @@ fn test_null_item_in_page() {
   "total": 1
 }"#;
     let page: Page<SimplifiedPlaylist> = deserialize(json);
-    assert_eq!(page.items.len(), 1);
-    assert_eq!(page.total-1, 1); // Because one element is null so ignore at deserialization but counted in total
+    assert_eq!(page.items.len(), 0);
+    assert_eq!(page.total-1, 0); // Because one element is null so ignore at deserialization but counted in total
     assert_eq!(page.limit, 20);
     assert!(page.next.is_none());
     assert!(page.previous.is_none());


### PR DESCRIPTION
## Description

Fix deserialization panic on the search endpoint when the API returns a list of elements containing one or more null values. Also fix CI (clippy warnings).

## Motivation and Context
When the Spotify API returns results for a search query, sometimes items are null, which causes a panic during deserialization.
Here is an example of a case that causes a panic:
```json
{
    "playlists": {
        "href": "https://api.spotify.com/v1/search?offset=17&limit=2&query=My%20Playlist&type=playlist&market=FR",
        "limit": 2,
        "next": "https://api.spotify.com/v1/search?offset=19&limit=2&query=My%20Playlist&type=playlist&market=FR",
        "offset": 17,
        "previous": "https://api.spotify.com/v1/search?offset=15&limit=2&query=My%20Playlist&type=playlist&market=FR",
        "total": 901,
        "items": [
            {
                ...
            },
            null // <--
        ]
    }
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I performed a search query on the FR market for playlists with the query "My Playlist". The response contained a null item. After applying the fix, I checked the same query again and confirmed that the panic no longer occurs (the "null" is still present in the response, but does not cause any error).

