### PR TITLE
fix(model): handle null images on `FullPlaylist` model

### DIFF
--- a/rspotify-model/src/playlist.rs
+++ b/rspotify-model/src/playlist.rs
@@ -53,6 +53,7 @@ pub struct FullPlaylist {
     pub followers: Followers,
     pub href: String,
     pub id: PlaylistId<'static>,
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub images: Vec<Image>,
     pub name: String,
     pub owner: PublicUser,


### PR DESCRIPTION
## Description

Fixes a deserialization error that occurs when spotify returns a playlist with `"images": null` when deserializing into `FullPlaylist`.

This was fixed for `SimplifiedPlaylist`, but we need the fix for `FullPlaylist` as well:
- https://github.com/ramsayleung/rspotify/pull/480
- https://github.com/ramsayleung/rspotify/issues/459

```
json parse error: invalid type: null, expected a sequence at line 1 column 275
```

## Motivation and Context

I am using `playlist()` to fetch a playlist by its ID, and my playlist has no tracks (and therefor no images), and I'm encountering this deserialization error that I'd like to fix.

## Dependencies 

None.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I've pointed my project at my fork (on this branch) and verified that this resolves the deserialization failure.

## Is this change properly documented?

Not documented.