### PR TITLE
[feat] Add fallback variant to capture unknown variant

### DIFF
--- a/rspotify-model/src/custom_serde.rs
+++ b/rspotify-model/src/custom_serde.rs
@@ -40,9 +40,7 @@ pub mod duration_ms {
                     )
                 }),
                 Err(_) => Err(E::custom(format!(
-                    "Conversion error: u64 to i64 conversion failed for value {}",
-                    v
-                ))),
+                    "Conversion error: u64 to i64 conversion failed for value {v}"))),
             }
         }
     }

--- a/rspotify-model/src/enums/types.rs
+++ b/rspotify-model/src/enums/types.rs
@@ -26,7 +26,7 @@ pub enum AlbumType {
 
 /// Type: `artist`, `album`, `track`, `playlist`, `show` or `episode`
 #[derive(
-    Clone, Serialize, Deserialize, Copy, PartialEq, Eq, Debug, Display, EnumString, IntoStaticStr,
+    Clone, Serialize, Deserialize, PartialEq, Eq, Debug, Display, EnumString, IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -40,6 +40,10 @@ pub enum Type {
     Episode,
     Collection,
     Collectionyourepisodes, // rename to collectionyourepisodes
+    // Fallback variant to capture unknown variants introduced by
+    // Spotify rather than raise a deserialization error.
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 /// Additional typs: `track`, `episode`

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -1207,6 +1207,23 @@ fn test_collectionyourepisodes_type() {
 
 #[test]
 #[wasm_bindgen_test]
+fn test_fallback_variant_type_to_capture_new_type() {
+    let json = r#"
+{
+	"external_urls": {
+		"spotify": "https://open.spotify.com/collection/episodes"
+	},
+	"href": "https://api.spotify.com/v1/me/episodes",
+	"type": "onlygodknow",
+	"uri": "spotify:user:<username>:collection:your-episodes"
+}
+"#;
+    let context: Context = deserialize(json);
+    assert_eq!(context._type, Type::Unknown("onlygodknow".to_string()));
+}
+
+#[test]
+#[wasm_bindgen_test]
 fn test_null_id_in_tracklink() {
     let json = r#"
 {


### PR DESCRIPTION
To prevent `RSpotify` from raising a deserialization error whenever Spotify adds new variant type

## Description

Whenever Spotify introduces a new type, this library will fail to deserialize the JSON, as it couldn't find the matched variant for the newly added type.

Add a fallback variant to capture this new type to prevent us from raising JSON parse error

## Motivation and Context

#525 

## Dependencies 

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- [ ] `test_fallback_variant_type_to_capture_new_type`: passed

## Is this change properly documented?

It's unnecessary